### PR TITLE
XRDDEV-51 Update OCSP response recovery schedule

### DIFF
--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.31  
+Version: 2.32  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -250,7 +250,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | port                                             | 5556                                       |   |   | TCP port on which the signer process listens. |
 | key-length                                       | 2048                                       |   |   | Key length for generating authentication and signing keys (since version 6.7) |
 | csr-signature-digest-algorithm                   | SHA-256                                    |   |   | Certificate Signing Request signature digest algorithm.<br/>Possible values are<br/>-   SHA-256,<br/>-   SHA-384,<br/>-   SHA-512. |
-| ocsp-retry-delay                                 | 60                                         |   |   | Interval (in seconds) for fetching OCSP responses during a failure of OCSP service. Signer switches to `ocsp-retry-delay` interval after a failure to fetch an OCSP response, and returns back to the normal schedule after receiving a successful OCSP response. |
+| ocsp-retry-delay                                 | 60                                         |   |   | OCSP retry delay for signer when fetching OCSP responses fail. After failing to fetch OCSP responses signer waits for the time period defined by "ocsp-retry-delay" before trying again. This is repeated until fetching OCSP responses succeeds. After successfully fetching OCSP responses signer returns to normal OCSP refresh schedule defined by "ocspFetchInterval". If the value of "ocsp-retry-delay" is higher than "ocspFetchInterval", the value of "ocspFetchInterval" is used as OCSP retry delay. |
 
 ### 3.5 Anti-DOS parameters: `[anti-dos]`
 

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -41,6 +41,7 @@ Doc. ID: UG-SYSPAR
 | 29.01.2018 | 2.29     | Removed proxy parameter client-fastest-connecting-ssl-use-uri-cache. Added proxy parameter client-fastest-connecting-ssl-uri-cache-period. | Ilkka Seppälä |
 | 05.03.2018 | 2.30     | Added reference to terms and abbreviations, modified reference handling, added numbering. | Tatu Repo |
 | 06.04.2018 | 2.31     | Removed TLSv1.1 support (client-side interfaces for incoming request) and TLS SHA-1 ciphers from default ciphers list. | Kristo Heero |
+| 18.08.2018 | 2.32     | Added new parameter *ocsp-retry-delay* | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -249,6 +250,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | port                                             | 5556                                       |   |   | TCP port on which the signer process listens. |
 | key-length                                       | 2048                                       |   |   | Key length for generating authentication and signing keys (since version 6.7) |
 | csr-signature-digest-algorithm                   | SHA-256                                    |   |   | Certificate Signing Request signature digest algorithm.<br/>Possible values are<br/>-   SHA-256,<br/>-   SHA-384,<br/>-   SHA-512. |
+| ocsp-retry-delay                                 | 60                                         |   |   | Interval (in seconds) for fetching OCSP responses during a failure of OCSP service. Signer switches to `ocsp-retry-delay` interval after a failure to fetch an OCSP response, and returns back to the normal schedule after receiving a successful OCSP response. |
 
 ### 3.5 Anti-DOS parameters: `[anti-dos]`
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -304,6 +304,11 @@ public final class SystemProperties {
     public static final String OCSP_RESPONSE_RETRIEVAL_ACTIVE =
             PREFIX + "signer.ocsp-response-retrieval-active";
 
+    public static final String SIGNER_OCSP_RETRY_DELAY =
+            PREFIX + "signer.ocsp-retry-delay";
+
+    private static final String DEFAULT_SIGNER_OCSP_RETRY_DELAY = "60";
+
     // AntiDos ----------------------------------------------------------------
 
     /** Property name of the AntiDos on/off switch */
@@ -780,6 +785,15 @@ public final class SystemProperties {
      */
     public static boolean isOcspResponseRetrievalActive() {
         return "true".equalsIgnoreCase(System.getProperty(OCSP_RESPONSE_RETRIEVAL_ACTIVE, "true"));
+    }
+
+    /**
+     * @return the OCSP-response retry delay in seconds that should be set for signer, 60 by default
+     *
+     */
+    public static int getOcspResponseRetryDelay() {
+        return Integer.parseInt(System.getProperty(SIGNER_OCSP_RETRY_DELAY,
+                DEFAULT_SIGNER_OCSP_RETRY_DELAY));
     }
 
     /**

--- a/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
@@ -22,6 +22,7 @@
  */
 package ee.ria.xroad.signer;
 
+import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.signer.certmanager.OcspClientWorker;
 
 import lombok.extern.slf4j.Slf4j;
@@ -48,11 +49,8 @@ public class OcspClientJob extends OcspRetrievalJob {
     private static final FiniteDuration INITIAL_DELAY =
             FiniteDuration.create(5, TimeUnit.SECONDS);
 
-    private static final int BASIC_DELAY = 10;
     private static final int RECOVER_FROM_INVALID_GLOBALCONF_DELAY = 60;
-    private int nextDelay = 0;
-    private int currentDelay = 0;
-    private int prevDelay = 0;
+    private static final int RETRY_DELAY = SystemProperties.getOcspResponseRetryDelay();
 
     //flag for indicating backoff retry state
     private boolean failed = false;
@@ -68,20 +66,9 @@ public class OcspClientJob extends OcspRetrievalJob {
 
     @Override
     protected FiniteDuration getNextDelay() {
-        // Init first round
-        if (currentDelay == 0) {
-            prevDelay = 0;
-            currentDelay = BASIC_DELAY;
-        }
-        // Use fibonacci number series for modeling backoff delay
-        nextDelay = currentDelay + prevDelay;
-
-
-        if (failed && nextDelay < OcspClientWorker.getNextOcspFetchIntervalSeconds()) {
-            prevDelay = currentDelay;
-            currentDelay = nextDelay;
-            log.info("Next OCSP refresh retry scheduled in {} seconds", nextDelay);
-            return FiniteDuration.create(nextDelay, TimeUnit.SECONDS);
+        if (failed && RETRY_DELAY < OcspClientWorker.getNextOcspFetchIntervalSeconds()) {
+            log.info("Next OCSP refresh retry scheduled in {} seconds", RETRY_DELAY);
+            return FiniteDuration.create(RETRY_DELAY, TimeUnit.SECONDS);
         } else {
             log.info("Next OCSP refresh scheduled in {} seconds", OcspClientWorker.getNextOcspFetchIntervalSeconds());
             return FiniteDuration.create(
@@ -107,13 +94,12 @@ public class OcspClientJob extends OcspRetrievalJob {
             log.debug("received message OcspClientJob.SUCCESS");
             log.info("OCSP-response refresh cycle successfully completed, continuing with normal scheduling");
             failed = false;
-            currentDelay = 0;
         } else if (FAILED.equals(incoming)) {
             log.debug("received message OcspClientJob.FAILED");
             if (!failed) {
                 log.info("OCSP-response refresh cycle failed, switching to retry backoff schedule");
                 // move into recover-from-failed state
-                // cancel next send and start fibonacci-recovering
+                // cancel next send and start backoff schedule
                 cancelNextSend();
                 failed = true;
                 scheduleNextSend(getNextDelay());
@@ -132,7 +118,6 @@ public class OcspClientJob extends OcspRetrievalJob {
             cancelNextSend();
             scheduleNextSend(getNextDelayForInvalidGlobalConf());
             failed = false;
-            currentDelay = 0;
 
         } else {
             // received either EXECUTE (VariableIntervalPeriodicJob


### PR DESCRIPTION
- Change Fibonacci based recovery schedule to fixed schedule.
- Add new signer system property `ocsp-retry-delay` that defines a fixed delay that `signer` waits after failing to fetch OCSP responses before trying again.
- Set `ocsp-retry-delay` default value to 60 seconds.
- Add `ocsp-retry-delay` parameter description to System Parameters User Guide.