### PR TITLE
XRDDEV-162

### DIFF
--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server Installation Guide
 
-Version: 2.7  
+Version: 2.8  
 Doc. ID: IG-CS
 
 
@@ -23,7 +23,8 @@ Doc. ID: IG-CS
 | 25.08.2017 | 2.5     | Update installation instructions concerning the support for environmental monitoring  | Ilkka Seppälä |
 | 05.03.2018 | 2.6     | Added terms and abbreviations reference, links to references and actual documents | Tatu Repo | 
 | 10.04.2018 | 2.7     | Updated chapter "[Installing the Support for Hardware Tokens](#26-installing-the-support-for-hardware-tokens)" with configurable parameters described in the configuration file 'devices.ini' | Cybernetica AS |
-
+| 14.10.2018 | 2.8    | Update package repository address | Petteri Kivimäki |
+ 
 ## Table of Contents
 
 <!-- toc -->
@@ -101,8 +102,8 @@ Caution: Data necessary for the functioning of the operating system is not inclu
 | **Ref**              |                                                  | **Explanation**                                    |
 |----------------------|--------------------------------------------------|----------------------------------------------------|
 | 1.0 | Ubuntu 14.04, 64-bit, 2 GB RAM, 3 GB free disk space | Minimum requirements |
-| 1.1 | http://x-road.eu/packages | X-Road package repository |
-| 1.2 | http://x-road.eu/packages/xroad_repo.gpg | The repository key |
+| 1.1 | https://artifactory.niis.org/xroad-release-deb | X-Road package repository |
+| 1.2 | https://artifactory.niis.org/api/gpg/key/public | The repository key |
 | 1.3 |  | Account name in the user interface |
 | 1.4 | TCP 4001 service for authentication certificate registration<br>TCP 80 distribution of the global configuration | Ports for inbound connections (from the external network to the central server) |
 | 1.5 | TCP 80 software updates | Ports for outbound connections (from the central server to the external network) |
@@ -135,22 +136,20 @@ Requirements for software and settings:
 
 ## 2.5 Installation
 
-Add the addresses of the X-Road package repository (reference data: 1.1), and the nginx and opendjdk repositories to the file /etc/apt/sources.list.d/xroad.list
+Add the X-Road package repository (reference data: 1.1), and the nginx and opendjdk repositories:
 
-`deb http://x-road.eu/packages trusty main`<br>
-`deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main`<br>
-`deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main`
+        sudo apt-add-repository -y ppa:openjdk-r/ppa
+        sudo apt-add-repository -y ppa:nginx/stable
+        sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb trusty-current main"
+        
+Add the X-Road repository’s signing key to the list of trusted keys (reference data: 1.2):
 
-Add the signing keys of the X-Road and external repositories to the list of trusted keys (reference data: 1.2):
-
-`curl http://x-road.eu/packages/xroad_repo.gpg | sudo apt-key add –`<br>
-`sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \ 00A6F0A3C300EE8C`<br>
-`sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \ EB9B1D8886F44E2A`
+        curl https://artifactory.niis.org/api/gpg/key/public | sudo apt-key add -
 
 Issue the following commands to install the central server packages:
 
-`sudo apt-get update`<br>
-`sudo apt-get install xroad-centralserver`
+        sudo apt-get update
+        sudo apt-get install xroad-centralserver
 
 Upon the first installation of the central server software, the system asks for the following information.
 

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 6**
 
-Version: 2.12  
+Version: 2.13  
 Doc. ID: IG-SS
 
 ---
@@ -37,7 +37,8 @@ Doc. ID: IG-SS
  15.09.2017 | 2.10    | Added package with configuration specific to Estonia xroad-securityserver-ee | Cybernetica AS
  05.03.2018 | 2.11    | Added terms and abbreviations reference and document links | Tatu Repo
  10.04.2018 | 2.12    | Updated chapter "[Installing the Support for Hardware Tokens](#27-installing-the-support-for-hardware-tokens)" with configurable parameters described in the configuration file 'devices.ini' | Cybernetica AS
-
+ 14.10.2018 | 2.13    | Update package repository address | Petteri Kivimäki
+ 
 ## Table of Contents
 
 <!-- toc -->
@@ -97,7 +98,10 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 ### 2.1 Supported Platforms
 
-The security server runs on the *Ubuntu Server 14.04 Long-Term Support (LTS)* operating system on a 64-bit platform. The security server software is distributed as .deb packages through the official X-Road repository at http://x-road.eu/packages/
+The security server runs on the following platforms:
+
+* Ubuntu Server 14.04 Long-Term Support (LTS) operating system on a 64-bit platform. The security server software is distributed as .deb packages through the official X-Road repository at https://artifactory.niis.org/xroad-release-deb/
+* Red Hat Enterprise Linux 7 (RHEL7) operating system on a 64-bit platform. The security server software is distributed as .rpm packages through the official X-Road repository at https://artifactory.niis.org/xroad-release-rpm/
 
 The software can be installed both on physical and virtualized hardware (of the latter, Xen and Oracle VirtualBox have been tested).
 
@@ -112,8 +116,8 @@ The software can be installed both on physical and virtualized hardware (of the 
  **Ref** |                                        | **Explanation**
  ------ | --------------------------------------- | ----------------------------------------------------------
  1.0    | Ubuntu 14.04, 64-bit<br>3 GB RAM, 3 GB free disk space | Minimum requirements
- 1.1    | http://x-road.eu/packages               | X-Road package repository
- 1.2    | http://x-road.eu/packages/xroad_repo.gpg | The repository key
+ 1.1    | https://artifactory.niis.org/xroad-release-deb               | X-Road package repository
+ 1.2    | https://artifactory.niis.org/api/gpg/key/public | The repository key
  1.3    |                                         | Account name in the user interface
  1.4    | TCP 5500                                | Port for inbound connections (from the external network to the security server)<br> Message exchange between security servers
  &nbsp; | TCP 5577                                | Port for inbound connections (from the external network to the security server)<br> Querying of OCSP responses between security servers
@@ -172,21 +176,19 @@ Requirements to software and settings:
 
 ### 2.5 Installation
 
-To install the X-Road security server software, follow these steps.
+To install the X-Road security server software on *Ubuntu 14.04 LTS* operating system, follow these steps.
 
-1.  Add to `/etc/apt/sources.list.d/xroad.list` the address of X-Road package repository (**reference data: 1.1**) and the nginx repository:
+1.  Add X-Road package repository (**reference data: 1.1**), openjdk repository and nginx repository:
 
-        deb http://x-road.eu/packages trusty main
-        deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main
-        deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main
+        sudo apt-add-repository -y ppa:openjdk-r/ppa
+        sudo apt-add-repository -y ppa:nginx/stable
+        sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb trusty-current main"
 
 2.  Add the X-Road repository’s signing key to the list of trusted keys (**reference data: 1.2**):
 
-        curl http://x-road.eu/packages/xroad_repo.gpg | sudo apt-key add -
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 00A6F0A3C300EE8C
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB9B1D8886F44E2A
+        curl https://artifactory.niis.org/api/gpg/key/public | sudo apt-key add -
 
-3.  Issue the following commands to install the security server packages (use package xroad-securityserver-ee to include configuration specific to Estonia):
+3.  Issue the following commands to install the security server packages (use package xroad-securityserver-ee to include configuration specific to Estonia; use package xroad-securityserver-fi to include configuration specific to Finland):
 
         sudo apt-get update
         sudo apt-get install xroad-securityserver
@@ -303,8 +305,8 @@ The security server code and the software token’s PIN will be determined durin
 
  Ref  |                                                   | Explanation
  ---- | ------------------------------------------------- | --------------------------------------------------
- 2.1  | <http://x-road.eu/packages/>&lt;anchor file&gt;<br> ee-dev - development environment<br> ee-test - test environment<br> EE - production environment | Global configuration anchor file
- 2.2  | GOV - government<br> COM - commercial             | Member class of the security server's owner
+ 2.1  | &lt;global configuration anchor file&gt; or &lt;URL&gt; | Global configuration anchor file
+ 2.2  | E.g.<br>GOV - government<br> COM - commercial     | Member class of the security server's owner
  2.3  | &lt;security server owner register code&gt;       | Member code of the security server's owner
  2.4  | &lt;choose security server identificator name&gt; | Security server's code
  2.5  | &lt;choose PIN for software token&gt;             | Software token’s PIN

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -101,7 +101,6 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 The security server runs on the following platforms:
 
 * Ubuntu Server 14.04 Long-Term Support (LTS) operating system on a 64-bit platform. The security server software is distributed as .deb packages through the official X-Road repository at https://artifactory.niis.org/xroad-release-deb/
-* Red Hat Enterprise Linux 7 (RHEL7) operating system on a 64-bit platform. The security server software is distributed as .rpm packages through the official X-Road repository at https://artifactory.niis.org/xroad-release-rpm/
 
 The software can be installed both on physical and virtualized hardware (of the latter, Xen and Oracle VirtualBox have been tested).
 

--- a/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
+++ b/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
@@ -4,7 +4,7 @@
 
 # X-Road: Configuration Proxy Manual
 
-Version: 2.3  
+Version: 2.4  
 Doc. ID: UG-CP
 
 ## Version History
@@ -21,6 +21,7 @@ Doc. ID: UG-CP
 | 07.06.2017 | 2.1     | System parameter *signature-algorithm-id* replaced with *signature-digest-algorithm-id* | Cybernetica AS |
 | 05.03.2018 | 2.2     | Added references, terms and abbreviations reference, document link | Tatu Repo |
 | 10.04.2018 | 2.3     | Updated chapter "[Installing the Support for Hardware Tokens](#27-installing-the-support-for-hardware-tokens)" with configurable parameters described in the configuration file 'devices.ini' | Cybernetica AS |
+| 14.10.2018 | 2.4    | Update package repository address | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -84,7 +85,7 @@ The configuration proxy can be configured to mediate several global configuratio
 
 ### 2.1 Supported Platforms
 
-The configuration proxy runs on the *Ubuntu Server 14.04 Long-Term Support (LTS)* operating system on a 64-bit platform. The configuration proxy's software is distributed as .deb packages through the official X-Road repository at [http://x-road.eu](http://x-road.eu/).
+The configuration proxy runs on the *Ubuntu Server 14.04 Long-Term Support (LTS)* operating system on a 64-bit platform. The configuration proxy's software is distributed as .deb packages through the official X-Road repository at [https://artifactory.niis.org/xroad-release-deb](https://artifactory.niis.org/xroad-release-deb).
 
 The software can be installed both on physical and virtualized hardware (of the latter, Xen and Oracle VirtualBox have been tested).
 
@@ -98,8 +99,8 @@ The software can be installed both on physical and virtualized hardware (of the 
 | Ref  |                                          | Explanation                |
 |------|------------------------------------------|----------------------------|
 | 1.0  | Ubuntu 14.04, 64bit<br>2GB RAM, 3GB free disk space | Minimum requirements. |
-| 1.1  | http://x-road.eu/packages                | X-Road package repository.  |
-| 1.2  | http://x-road.eu/packages/xroad_repo.gpg | The repository’s key.       |
+| 1.1  | https://artifactory.niis.org/xroad-release-deb | X-Road package repository.  |
+| 1.2  | https://artifactory.niis.org/api/gpg/key/public | The repository’s key.       |
 | 1.3  | TCP 80                                   | Global configuration distribution.<br>Ports for inbound connections (from the external network to the configuration proxy). |
 | 1.4  | TCP 80                                   | Global configuration download.<br>Ports for outbound connections (from the configuration proxy to the external network). |
 | 1.5  |                                          | Configuration proxy’s public IP address, NAT address. |
@@ -134,24 +135,20 @@ LC_ALL=en_US.UTF-8
 
 To install the X-Road configuration proxy software, follow these steps.
 
-1. Add to */etc/apt/sources.list* the address of X-Road package repository (reference data: 1.1) and the nginx repository:
-```bash  
-deb http://x-road.eu/packages trusty main
-deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main
-deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main
-```
+1. Add the X-Road package repository (reference data: 1.1), and the nginx and opendjdk repositories:
+   
+           sudo apt-add-repository -y ppa:openjdk-r/ppa
+           sudo apt-add-repository -y ppa:nginx/stable
+           sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb trusty-current main"
+           
 2. Add the X-Road repository’s signing key to the list of trusted keys (reference data: 1.2):
-```bash
-curl http://x-road.eu/packages/xroad_repo.gpg | sudo apt-key add -
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 00A6F0A3C300EE8C
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB9B1D8886F44E2A
-```
-3.  Issue the following commands to install the configuration proxy packages:
-```bash
-sudo apt-get update
-sudo apt-get install xroad-confproxy
-```
 
+            curl https://artifactory.niis.org/api/gpg/key/public | sudo apt-key add -
+
+3.  Issue the following commands to install the configuration proxy packages:
+
+            sudo apt-get update
+            sudo apt-get install xroad-confproxy
 
 ### 2.6 Post-Installation Checks
 


### PR DESCRIPTION
Update Security Server and Central Server installation guides and Configuration Proxy user guide:

- Remove references to x-road.eu package repository
- Add references to NIIS's package repository
- Update installation instructions (commands)
- Update document's version number

Additional changes to Security Server installation guide:

- Add RHEL7 to supported platforms
- Add note about `xroad-securityserver-fi` metapackage
- Replace X-tee specific instructions with generic instructions