### PR TITLE
XRDDEV-144

### DIFF
--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.32  
+Version: 2.34  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -43,6 +43,7 @@ Doc. ID: UG-SYSPAR
 | 06.04.2018 | 2.31     | Removed TLSv1.1 support (client-side interfaces for incoming request) and TLS SHA-1 ciphers from default ciphers list. | Kristo Heero |
 | 18.08.2018 | 2.32     | Added new parameter *ocsp-retry-delay* | Petteri Kivimäki |
 | 08.10.2018 | 2.33     | Added new parameter *xroad-tls-ciphers* | Henri Haapakanni |
+| 18.10.2018 | 2.34     | Default value of the parameter *signer.client-timeout* set to 60000 | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -246,7 +247,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 |--------------------------------------------------|--------------------------------------------|----------------------|----------------------|-----------------|
 | ocsp-cache-path                                  | /var/cache/xroad                           |   |   | Absolute path to the directory where the cached OCSP responses are stored. |
 | enforce-token-pin-policy                         | false                                      | true |   | Controls enforcing the token pin policy. When set to true, software token pin is required to be at least 10 ASCII characters from at least tree character classes (lowercase letters, uppercase letters, digits, special characters). (since version 6.7.7) |
-| client-timeout                                   | 15000                                      |   |   | Signing timeout in milliseconds. |
+| client-timeout                                   | 60000                                      |   |   | Signing timeout in milliseconds. |
 | device-configuration-file                        | /etc/xroad/signer/devices.ini              |   |   | Absolute filename of the configuration file of the signature creation devices. |
 | key-configuration-file                           | /etc/xroad/signer/keyconf.xml              |   |   | Absolute filename of the configuration file containing signature and authentication keys and certificates. |
 | port                                             | 5556                                       |   |   | TCP port on which the signer process listens. |

--- a/src/proxy/src/main/java/ee/ria/xroad/common/signature/BatchSigner.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/signature/BatchSigner.java
@@ -25,6 +25,7 @@
 package ee.ria.xroad.common.signature;
 
 import ee.ria.xroad.common.CodedException;
+import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.signer.protocol.SignerClient;
 import ee.ria.xroad.signer.protocol.message.GetTokenBatchSigningEnabled;
 import ee.ria.xroad.signer.protocol.message.Sign;
@@ -73,13 +74,15 @@ import static ee.ria.xroad.common.util.CryptoUtils.getDigestAlgorithmId;
 @Slf4j
 public class BatchSigner extends UntypedActor {
 
-    private static final Timeout DEFAULT_TIMEOUT = new Timeout(30000, TimeUnit.MILLISECONDS);
+    private static final int TIMEOUT_MILLIS = SystemProperties.getSignerClientTimeout();
+    private static final Timeout DEFAULT_TIMEOUT = new Timeout(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // Holds the actor instance, which sends and receives messages.
     private static ActorRef instance;
 
     /**
      * Initializes the batch signer with the given actor system.
+     *
      * @param actorSystem actor system the batch signer should use
      */
     public static void init(ActorSystem actorSystem) {
@@ -90,6 +93,7 @@ public class BatchSigner extends UntypedActor {
 
     /**
      * Submits the given signing request for batch signing.
+     *
      * @param keyId the signing key
      * @param signatureAlgorithmId ID of the signature algorithm to use
      * @param request the signing request


### PR DESCRIPTION
Fix timeout value used in batch signing.

- Replace hard coded timeout value with the value defined by the `signer.client-timeout` system property.
- Update the correct `signer.client-timeout` default value to System Parameters document.