### PR TITLE
XRDDEV-54

### DIFF
--- a/src/center-ui/app/controllers/init_controller.rb
+++ b/src/center-ui/app/controllers/init_controller.rb
@@ -30,14 +30,12 @@ class InitController < ApplicationController
   skip_before_filter :check_conf
 
   def index
+    authorize!(:init_config)
+
     if request.xhr?
       # come back without ajax
       render_redirect(root_path, "common.initialization_required")
       return
-    end
-
-    if cannot?(:init_config)
-      raise t('init.not_authorized')
     end
 
     if initialized?

--- a/src/center-ui/config/locales/controllers_en.yml
+++ b/src/center-ui/config/locales/controllers_en.yml
@@ -32,7 +32,6 @@ en:
       set_locale: "set application locale"
 
   init:
-    not_authorized: "Not authorized - contact system administrator"
     already_initialized: "Central Server already initialized"
     mismatching_pins: "Software token pins do not match"
     init_params:

--- a/src/proxy-ui/app/controllers/init_controller.rb
+++ b/src/proxy-ui/app/controllers/init_controller.rb
@@ -42,14 +42,12 @@ class InitController < ApplicationController
   skip_before_filter :check_conf, :read_server_id, :read_owner_name
 
   def index
+    authorize!(:init_config)
+
     if request.xhr?
       # come back without ajax
       render_redirect(root_path, "common.initialization_required")
       return
-    end
-
-    if cannot?(:init_config)
-      raise t('init.not_authorized')
     end
 
     if initialized?

--- a/src/proxy-ui/config/locales/controllers_en.yml
+++ b/src/proxy-ui/config/locales/controllers_en.yml
@@ -32,7 +32,6 @@ en:
     error_code_logmanager_unavailable: "Unable to obtain message log timestamping status"
 
   init:
-    not_authorized: "Not authorized - contact system administrator"
     already_initialized: "Security Server already initialized"
     mismatching_pins: "Software token pins do not match"
     unregistered_member: "The person/organisation '%{member_class} : %{member_code}' is not registered as X-Road member"


### PR DESCRIPTION
Update error message when logging in to uninitialized Central Server or Security Server with wrong user account.

- Add authorization check in the beginning of the init process.
- Change error message to `not authorized`.
- Remove unused translation strings.