### PR TITLE
XRDDEV-229

### DIFF
--- a/src/packages/src/xroad/default-configuration/override-securityserver-fi.ini
+++ b/src/packages/src/xroad/default-configuration/override-securityserver-fi.ini
@@ -2,7 +2,7 @@
 
 [signer]
 ; Auth and sign key length (2048/3072/4096 bits)
-key-length=2048
+key-length=3072
 enforce-token-pin-policy=true
 ; Certificate signing request signature digest algorithm,
 ; possible values: SHA-256, SHA-384, SHA-512


### PR DESCRIPTION
Update default authentication and signing key length to 3072 bits (Finnish national settings only)