### PR TITLE
estonian-6.20.0-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 6.20.0 - XXXX-XX-XX
+- XTE-427 / XRDDEV-108: Operational monitoring timestamp 'responseOutTs' is taken just before payload byte array is sent out with HTTP response.
 - TBD
 
 ## 6.19.0 - 2018-09-27

--- a/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
@@ -6,14 +6,15 @@
 
 **Technical Specification**
 
-Version: 0.4  
+Version: 0.5  
 Doc. ID: PR-OPMON
 
-| Date       | Version     | Description                                                                  | Author             |
-|------------|-------------|------------------------------------------------------------------------------|--------------------|
-|  | 0.2       | Initial version               |          |
-| 23.01.2017 | 0.3       | Added license text, table of contents and version history | Sami Kallio |
-| 05.03.2018 | 0.4       | Added terms and abbreviations reference | Tatu Repo
+| Date | Version | Description | Author|
+|------|---------|-------------|-------|
+|            | 0.2 | Initial version |   |
+| 23.01.2017 | 0.3 | Added license text, table of contents and version history | Sami Kallio |
+| 05.03.2018 | 0.4 | Added terms and abbreviations reference | Tatu Repo |
+| 04.12.2018 | 0.5 | More detailed descriptions for *[request/response][In/Out]Ts* fields | Cybernetica AS |
 
 ## Table of Contents
 
@@ -979,7 +980,9 @@ properties:
             milliseconds when the request was received by the client''s security
             server. In the service provider''s security server: the Unix
             timestamp in milliseconds when the request was received by the
-            service provider''s security server.'
+            service provider''s security server. In both cases, the timestamp is
+            taken just before received payload byte array is decoded and
+            processed'
           type: integer
           minimum: 0
         requestOutTs:
@@ -988,7 +991,8 @@ properties:
             security server to the client''s information system. In the service
             provider''s security server: the Unix timestamp in milliseconds when
             the request was sent out from the service provider''s security
-            server.'
+            server. In both cases, the timestamp is taken just before payload
+            byte array is sent out with HTTP POST request'
           type: integer
           minimum: 0
         responseInTs:
@@ -996,7 +1000,9 @@ properties:
             milliseconds when the response was received by the client''s
             security server. In the service provider''s security server: the
             Unix timestamp in milliseconds when the response was received by the
-            service provider''s security server.'
+            service provider''s security server. In both cases, the timestamp is
+            taken just before received payload byte array is decoded and
+            processed.'
           type: integer
           minimum: 0
         responseOutTs:
@@ -1005,7 +1011,8 @@ properties:
             security server to the client''s information system. In the service
             provider''s security server: the Unix timestamp in milliseconds when
             the response was sent out from the service provider''s security
-            server.'
+            server. In both cases, the timestamp is taken just before payload
+            byte array is sent out with HTTP response'
           type: integer
           minimum: 0
         clientXRoadInstance:
@@ -1090,7 +1097,7 @@ properties:
           minimum: 0
         requestMimeSize:
           description: Size of the MIME-container of the request (sum of the
-              SOAP request message and attachments data size in bytes)
+            SOAP request message and attachments data size in bytes)
           type: integer
           minimum: 0
         requestAttachmentCount:
@@ -1103,7 +1110,7 @@ properties:
           minimum: 0
         responseMimeSize:
           description: Size of the MIME-container of the response (sum of the
-             SOAP response message and attachments data size in bytes)
+            SOAP response message and attachments data size in bytes)
           type: integer
           minimum: 0
         responseAttachmentCount:

--- a/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferMemoryUsage.java
+++ b/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferMemoryUsage.java
@@ -151,23 +151,20 @@ public final class OpMonitoringBufferMemoryUsage {
         return runtime.totalMemory() - runtime.freeMemory();
     }
 
-    private static Map<Long, OpMonitoringData> createBuffer(int count,
-            int shortStrLen, int longStrLen) {
+    private static Map<Long, OpMonitoringData> createBuffer(int count, int shortStrLen, int longStrLen) {
         Map<Long, OpMonitoringData> buffer = new LinkedHashMap<>();
         OpMonitoringData record;
 
         for (long i = 0; i < count; ++i) {
-            record = new OpMonitoringData(
-                    OpMonitoringData.SecurityServerType.PRODUCER, MILLIS);
+            record = new OpMonitoringData(OpMonitoringData.SecurityServerType.PRODUCER, MILLIS);
             record.setRequestInTs(MILLIS);
             record.setRequestOutTs(MILLIS);
             record.setResponseInTs(MILLIS);
-            record.setResponseOutTs(MILLIS);
+            record.setResponseOutTs(MILLIS, true);
 
             record.setClientId(createClient(shortStrLen, longStrLen));
             record.setServiceId(createService(shortStrLen, longStrLen));
-            record.setRepresentedParty(createRepresentedParty(shortStrLen,
-                    longStrLen));
+            record.setRepresentedParty(createRepresentedParty(shortStrLen, longStrLen));
 
             record.setMessageId(getDummyStr(longStrLen));
             record.setMessageUserId(getDummyStr(longStrLen));

--- a/src/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringData.java
+++ b/src/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringData.java
@@ -211,12 +211,17 @@ public class OpMonitoringData {
     }
 
     /**
-     * Sets the "response out" timestamp. In case the field
-     * assignResponseOutTsToResponseInTs is true,
-     * the same value is assigned to the "response in" also.
+     * Sets the "response out" timestamp. In case the field assignResponseOutTsToResponseInTs is
+     * true, the same value is assigned to the "response in" also.
+     *
      * @param timestamp Unix timestamp in milliseconds
+     * @param overwrite if true, old value is overwritten, otherwise old value remains
      */
-    public void setResponseOutTs(long timestamp) {
+    public void setResponseOutTs(long timestamp, boolean overwrite) {
+        if (!overwrite && data.get(RESPONSE_OUT_TIMESTAMP) != null) {
+            return;
+        }
+
         if (assignResponseOutTsToResponseInTs) {
             setResponseInTs(timestamp);
         }

--- a/src/op-monitor-daemon/src/main/resources/query_operational_data_response_payload_schema.yaml
+++ b/src/op-monitor-daemon/src/main/resources/query_operational_data_response_payload_schema.yaml
@@ -8,8 +8,7 @@ properties:
       type: object
       properties:
         monitoringDataTs:
-          description: The Unix timestamp in seconds when the record was
-            received by the monitoring daemon
+          description: The Unix timestamp in seconds when the record was received by the monitoring daemon
           type: integer
           minimum: 0
         securityServerInternalIp:
@@ -24,37 +23,19 @@ properties:
           - Client
           - Producer
         requestInTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the request was received by the client''s security
-            server. In the service provider''s security server: the Unix
-            timestamp in milliseconds when the request was received by the
-            service provider''s security server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the request was received by the client''s security server. In the service provider''s security server: the Unix timestamp in milliseconds when the request was received by the service provider''s security server. In both cases, the timestamp is taken just before received payload byte array is decoded and processed'
           type: integer
           minimum: 0
         requestOutTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the request was sent out from the client''s
-            security server to the client''s information system. In the service
-            provider''s security server: the Unix timestamp in milliseconds when
-            the request was sent out from the service provider''s security
-            server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the request was sent out from the client''s security server to the client''s information system. In the service provider''s security server: the Unix timestamp in milliseconds when the request was sent out from the service provider''s security server. In both cases, the timestamp is taken just before payload byte array is sent out with HTTP POST request'
           type: integer
           minimum: 0
         responseInTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the response was received by the client''s
-            security server. In the service provider''s security server: the
-            Unix timestamp in milliseconds when the response was received by the
-            service provider''s security server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the response was received by the client''s security server. In the service provider''s security server: the Unix timestamp in milliseconds when the response was received by the service provider''s security server. In both cases, the timestamp is taken just before received payload byte array is decoded and processed.'
           type: integer
           minimum: 0
         responseOutTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the response was sent out from the client''s
-            security server to the client''s information system. In the service
-            provider''s security server: the Unix timestamp in milliseconds when
-            the response was sent out from the service provider''s security
-            server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the response was sent out from the client''s security server to the client''s information system. In the service provider''s security server: the Unix timestamp in milliseconds when the response was sent out from the service provider''s security server. In both cases, the timestamp is taken just before payload byte array is sent out with HTTP response'
           type: integer
           minimum: 0
         clientXRoadInstance:
@@ -74,8 +55,7 @@ properties:
           type: string
           maxLength: 255
         serviceXRoadInstance:
-          description: Instance identifier of the instance used by the service
-            provider
+          description: Instance identifier of the instance used by the service provider
           type: string
           maxLength: 255
         serviceMemberClass:
@@ -115,8 +95,7 @@ properties:
           type: string
           maxLength: 255
         messageIssue:
-          description: Client's internal identifier of a file or document
-            related to the service
+          description: Client's internal identifier of a file or document related to the service
           type: string
           maxLength: 255
         messageProtocolVersion:
@@ -124,13 +103,11 @@ properties:
           type: string
           maxLength: 255
         clientSecurityServerAddress:
-          description: External address of client's security server (IP or name)
-            defined in global configuration
+          description: External address of client's security server (IP or name) defined in global configuration
           type: string
           maxLength: 255
         serviceSecurityServerAddress:
-          description: External address of service provider's security server
-            (IP or name) defined in global configuration
+          description: External address of service provider's security server (IP or name) defined in global configuration
           type: string
           maxLength: 255
         requestSoapSize:

--- a/src/op-monitor-daemon/src/main/resources/store_operational_data_request_schema.yaml
+++ b/src/op-monitor-daemon/src/main/resources/store_operational_data_request_schema.yaml
@@ -18,37 +18,19 @@ properties:
           - Client
           - Producer
         requestInTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the request was received by the client''s 
-            security server. In the service provider''s security server: the
-            Unix timestamp in milliseconds when the request was received by the
-            service provider''s security server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the request was received by the client''s security server. In the service provider''s security server: the Unix timestamp in milliseconds when the request was received by the service provider''s security server. In both cases, the timestamp is taken just before received payload byte array is decoded and processed'
           type: integer
           minimum: 0
         requestOutTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the request was sent out from the client''s
-            security server to the client''s information system. In the service
-            provider''s security server: the Unix timestamp in milliseconds when
-            the request was sent out from the service provider''s security
-            server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the request was sent out from the client''s security server to the client''s information system. In the service provider''s security server: the Unix timestamp in milliseconds when the request was sent out from the service provider''s security server. In both cases, the timestamp is taken just before payload byte array is sent out with HTTP POST request'
           type: integer
           minimum: 0
         responseInTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the response was received by the client''s 
-            security server. In the service provider''s security server: the
-            Unix timestamp in milliseconds when the response was received by the
-            service provider''s security server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the response was received by the client''s security server. In the service provider''s security server: the Unix timestamp in milliseconds when the response was received by the service provider''s security server. In both cases, the timestamp is taken just before received payload byte array is decoded and processed.'
           type: integer
           minimum: 0
         responseOutTs:
-          description: 'In the client''s security server: the Unix timestamp in
-            milliseconds when the response was sent out from the client''s
-            security server to the client''s information system. In the service
-            provider''s security server: the Unix timestamp in milliseconds when
-            the response was sent out from the service provider''s security
-            server.'
+          description: 'In the client''s security server: the Unix timestamp in milliseconds when the response was sent out from the client''s security server to the client''s information system. In the service provider''s security server: the Unix timestamp in milliseconds when the response was sent out from the service provider''s security server. In both cases, the timestamp is taken just before payload byte array is sent out with HTTP response'
           type: integer
           minimum: 0
         clientXRoadInstance:
@@ -64,8 +46,7 @@ properties:
           description: Subsystem code of the X-Road member (client)
           type: string
         serviceXRoadInstance:
-          description: Instance identifier of the instance used by the service
-            provider
+          description: Instance identifier of the instance used by the service provider
           type: string
         serviceMemberClass:
           description: Member class of the X-Road member (service provider)
@@ -95,19 +76,16 @@ properties:
           description: Personal code of the client that initiated the request
           type: string
         messageIssue:
-          description: Client's internal identifier of a file or document
-            related to the service
+          description: Client's internal identifier of a file or document related to the service
           type: string
         messageProtocolVersion:
           description: X-Road message protocol version
           type: string
         clientSecurityServerAddress:
-          description: External address of client's security server (IP or name)
-            defined in global configuration
+          description: External address of client's security server (IP or name) defined in global configuration
           type: string
         serviceSecurityServerAddress:
-          description: External address of service provider's security server
-            (IP or name) defined in global configuration
+          description: External address of service provider's security server (IP or name) defined in global configuration
           type: string
         requestSoapSize:
           description: Size of the request (bytes)

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
@@ -69,37 +69,36 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
             OpMonitoringData opMonitoringData) throws Exception;
 
     @Override
-    public void handle(String target, Request baseRequest,
-            HttpServletRequest request, HttpServletResponse response)
-                    throws IOException, ServletException {
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
         if (baseRequest.isHandled()) {
             // If some handler already processed the request, we do nothing.
             return;
         }
 
         boolean handled = false;
+
         OpMonitoringData opMonitoringData = storeOpMonitoringData
                 ? new OpMonitoringData(CLIENT, getEpochMillisecond()) : null;
 
-        long start = PerformanceLogger.log(log, "Received request from "
-                + request.getRemoteAddr());
+        long start = PerformanceLogger.log(log, "Received request from " + request.getRemoteAddr());
+
         log.info("Received request from {}", request.getRemoteAddr());
 
         MessageProcessorBase processor = null;
 
         try {
-            processor = createRequestProcessor(target, request, response,
-                    opMonitoringData);
+            processor = createRequestProcessor(target, request, response, opMonitoringData);
 
             if (processor != null) {
                 handled = true;
+
                 start = logPerformanceBegin(request);
                 processor.process();
                 success(processor, start, opMonitoringData);
 
                 if (log.isTraceEnabled()) {
-                    log.info("Request successfully handled ({} ms)",
-                            System.currentTimeMillis() - start);
+                    log.info("Request successfully handled ({} ms)", System.currentTimeMillis() - start);
                 } else {
                     log.info("Request successfully handled");
                 }
@@ -108,47 +107,44 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
             handled = true;
 
             String errorMessage = e instanceof ClientException
-                    ? "Request processing error (" + e.getFaultDetail() + ")"
-                    : "Request processing error";
+                    ? "Request processing error (" + e.getFaultDetail() + ")" : "Request processing error";
 
             log.error(errorMessage, e);
 
             updateOpMonitoringSoapFault(opMonitoringData, e);
 
-            // Exceptions caused by incoming message and exceptions
-            // derived from faults sent by serverproxy already contain
-            // full error code. Thus, we must not attach additional
-            // error code prefixes to them.
+            // Exceptions caused by incoming message and exceptions derived from faults sent by serverproxy already
+            // contain full error code. Thus, we must not attach additional error code prefixes to them.
 
-            failure(processor, response, e);
+            failure(processor, response, e, opMonitoringData);
         } catch (CodedExceptionWithHttpStatus e) {
             handled = true;
 
             // No need to log faultDetail hence not sent to client.
             log.error("Request processing error", e);
 
-            // Respond with HTTP status code and plain text error message
-            // instead of SOAP fault message. No need to update operational
-            // monitoring fields here either.
+            // Respond with HTTP status code and plain text error message instead of SOAP fault message.
+            // No need to update operational monitoring fields here either.
 
-            failure(response, e);
+            failure(response, e, opMonitoringData);
         } catch (Throwable e) { // We want to catch serious errors as well
             handled = true;
 
             // All the other exceptions get prefix Server.ClientProxy...
             CodedException cex = translateWithPrefix(SERVER_CLIENTPROXY_X, e);
 
-            updateOpMonitoringSoapFault(opMonitoringData, cex);
-
             log.error("Request processing error ({})", cex.getFaultDetail(), e);
 
-            failure(processor, response, cex);
+            updateOpMonitoringSoapFault(opMonitoringData, cex);
+
+            failure(processor, response, cex, opMonitoringData);
         } finally {
             baseRequest.setHandled(handled);
 
             if (handled) {
                 if (storeOpMonitoringData) {
-                    opMonitoringData.setResponseOutTs(getEpochMillisecond());
+                    updateOpMonitoringResponseOutTs(opMonitoringData);
+
                     OpMonitoring.store(opMonitoringData);
                 }
 
@@ -157,67 +153,50 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
         }
     }
 
-    protected static void success(MessageProcessorBase processor, long start,
-            OpMonitoringData opMonitoringData) {
+    private static void success(MessageProcessorBase processor, long start, OpMonitoringData opMonitoringData) {
         updateOpMonitoringSucceeded(opMonitoringData);
 
         MonitorAgent.success(processor.createRequestMessageInfo(), new Date(start), new Date());
     }
 
-    protected void failure(MessageProcessorBase processor,
-            HttpServletResponse response, CodedException e)
-            throws IOException {
-        MessageInfo info = processor != null
-                ? processor.createRequestMessageInfo()
-                : null;
+    protected void failure(MessageProcessorBase processor, HttpServletResponse response, CodedException e,
+            OpMonitoringData opMonitoringData) throws IOException {
+        MessageInfo info = processor != null ? processor.createRequestMessageInfo() : null;
 
         MonitorAgent.failure(info, e.getFaultCode(), e.getFaultString());
 
-        sendErrorResponse(response, e);
-    }
-
-    @Override
-    protected void failure(HttpServletResponse response, CodedException e)
-            throws IOException {
-        MonitorAgent.failure(null, e.getFaultCode(), e.getFaultString());
+        updateOpMonitoringResponseOutTs(opMonitoringData);
 
         sendErrorResponse(response, e);
     }
 
-    protected void failure(HttpServletResponse response,
-            CodedExceptionWithHttpStatus e) throws IOException {
+    protected void failure(HttpServletResponse response, CodedExceptionWithHttpStatus e,
+            OpMonitoringData opMonitoringData) throws IOException {
         MonitorAgent.failure(null, e.withPrefix(SERVER_CLIENTPROXY_X).getFaultCode(), e.getFaultString());
+
+        updateOpMonitoringResponseOutTs(opMonitoringData);
 
         sendPlainTextErrorResponse(response, e.getStatus(), e.getFaultString());
     }
 
-    protected static boolean isGetRequest(HttpServletRequest request) {
+    static boolean isGetRequest(HttpServletRequest request) {
         return request.getMethod().equalsIgnoreCase("GET");
     }
 
-    protected static boolean isPostRequest(HttpServletRequest request) {
+    static boolean isPostRequest(HttpServletRequest request) {
         return request.getMethod().equalsIgnoreCase("POST");
     }
 
-    protected static final String stripSlash(String str) {
-        return str != null && str.startsWith("/")
-                ? str.substring(1) : str; // Strip '/'
-    }
+    static IsAuthenticationData getIsAuthenticationData(HttpServletRequest request) {
+        X509Certificate[] certs = (X509Certificate[]) request.getAttribute("javax.servlet.request.X509Certificate");
 
-    protected static IsAuthenticationData getIsAuthenticationData(
-            HttpServletRequest request) {
-        X509Certificate[] certs =
-                (X509Certificate[]) request.getAttribute(
-                        "javax.servlet.request.X509Certificate");
-        return new IsAuthenticationData(
-            certs != null && certs.length != 0 ? certs[0] : null,
-            !"https".equals(request.getScheme()) // if not HTTPS, it's plaintext
-        );
+        return new IsAuthenticationData(certs != null && certs.length != 0 ? certs[0] : null,
+                !"https".equals(request.getScheme())); // if not HTTPS, it's plaintext
     }
 
     private static long logPerformanceBegin(HttpServletRequest request) {
-        long start = PerformanceLogger.log(log, "Received request from "
-                + request.getRemoteAddr());
+        long start = PerformanceLogger.log(log, "Received request from " + request.getRemoteAddr());
+
         log.info("Received request from {}", request.getRemoteAddr());
 
         return start;
@@ -227,15 +206,19 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
         PerformanceLogger.log(log, start, "Request handled");
     }
 
-    private static void updateOpMonitoringSoapFault(
-            OpMonitoringData opMonitoringData, CodedException e) {
+    private static void updateOpMonitoringResponseOutTs(OpMonitoringData opMonitoringData) {
+        if (opMonitoringData != null) {
+            opMonitoringData.setResponseOutTs(getEpochMillisecond(), false);
+        }
+    }
+
+    private static void updateOpMonitoringSoapFault(OpMonitoringData opMonitoringData, CodedException e) {
         if (opMonitoringData != null) {
             opMonitoringData.setSoapFault(e);
         }
     }
 
-    private static void updateOpMonitoringSucceeded(
-            OpMonitoringData opMonitoringData) {
+    private static void updateOpMonitoringSucceeded(OpMonitoringData opMonitoringData) {
         if (opMonitoringData != null) {
             opMonitoringData.setSucceeded(true);
         }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
@@ -199,17 +199,16 @@ class ClientMessageProcessor extends MessageProcessorBase {
         Future<?> soapHandler = SOAP_HANDLER_EXECUTOR.submit(this::handleSoap);
 
         try {
-            // Wait for the request SOAP message to be parsed before we can
-            // start sending stuff.
+            // Wait for the request SOAP message to be parsed before we can start sending stuff.
             waitForSoapMessage();
 
             // If the handler thread excepted, do not continue.
             checkError();
 
-            // Verify that the client is registered
+            // Verify that the client is registered.
             verifyClientStatus();
 
-            // Check client authentication mode
+            // Check client authentication mode.
             verifyClientAuthentication();
 
             processRequest();
@@ -222,8 +221,7 @@ class ClientMessageProcessor extends MessageProcessorBase {
                 reqIns.close();
             }
 
-            // Let's interrupt the handler thread so that it won't
-            // block forever waiting for us to do something.
+            // Let's interrupt the handler thread so that it won't block forever waiting for us to do something.
             soapHandler.cancel(true);
 
             throw e;
@@ -472,6 +470,8 @@ class ClientMessageProcessor extends MessageProcessorBase {
 
     private void sendResponse() throws Exception {
         log.trace("sendResponse()");
+
+        opMonitoringData.setResponseOutTs(getEpochMillisecond(), true);
 
         servletResponse.setStatus(HttpServletResponse.SC_OK);
         servletResponse.setCharacterEncoding(MimeUtils.UTF8);

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
@@ -515,9 +515,10 @@ class ServerMessageProcessor extends MessageProcessorBase {
                 exception = translateWithPrefix(SERVER_SERVERPROXY_X, ex);
             }
 
-            opMonitoringData.setSoapFault(exception);
-
             monitorAgentNotifyFailure(exception);
+
+            opMonitoringData.setSoapFault(exception);
+            opMonitoringData.setResponseOutTs(getEpochMillisecond(), false);
 
             encoder.fault(SoapFault.createFaultXml(exception));
             encoder.close();
@@ -637,9 +638,11 @@ class ServerMessageProcessor extends MessageProcessorBase {
         @Override
         public void soap(SoapMessage message, Map<String, String> headers) throws Exception {
             responseSoap = (SoapMessageImpl) message;
-            encoder.soap(responseSoap, headers);
 
             opMonitoringData.setResponseSoapSize(responseSoap.getBytes().length);
+            opMonitoringData.setResponseOutTs(getEpochMillisecond(), true);
+
+            encoder.soap(responseSoap, headers);
         }
 
         @Override

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
@@ -98,12 +98,13 @@ class ServerProxyHandler extends HandlerBase {
             log.error("Request processing error ({})", cex.getFaultDetail(), e);
 
             opMonitoringData.setSoapFault(cex);
+            opMonitoringData.setResponseOutTs(getEpochMillisecond(), false);
 
             failure(response, cex);
         } finally {
             baseRequest.setHandled(true);
 
-            opMonitoringData.setResponseOutTs(getEpochMillisecond());
+            opMonitoringData.setResponseOutTs(getEpochMillisecond(), false);
             OpMonitoring.store(opMonitoringData);
 
             PerformanceLogger.log(log, start, "Request handled");


### PR DESCRIPTION
XTE-427 / XRDDEV-108: Operational monitoring timestamp 'responseOutTs' is taken just before payload byte array is sent out with HTTP response.