### PR TITLE
XRDDEV-225

### DIFF
--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -32,7 +32,7 @@ Doc. ID: UG-CS
 | 05.03.2018 | 2.5     | Added terms and abbreviations reference and document links | Tatu Repo |
 | 18.08.2018 | 2.6     | Corrected `ocspFetchInterval` default value (Chapter 16.2) | Petteri Kivimäki |
 | 15.11.2018 | 2.7     | Minor corrections for Ubuntu 18 | Jarkko Hyöty |
-| 23.01.2019 | 2.8     | Information about automatic approval of auth cert registration requests added. Updates in Chapters 6 and 7. | Petteri Kivimäki |
+| 23.01.2019 | 2.8     | Information about automatic approval of auth cert registration requests added. Updates in Chapters 6-8. | Petteri Kivimäki |
 
 ## Table of Contents
 <!-- toc -->

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -587,7 +587,7 @@ To add a subsystem to an X-Road member, follow these steps.
 
 Access rights: Registration Officer
 
-Registering an X-Road member's security server can be done 
+The actions required to register an X-Road member's security server depend on whether automatic approval of authentication certificate registration requests is enabled or disabled (_default_).
 
 When automatic approval of authentication certificate registration requests is enabled, the following action must be taken:
 - An authentication certificate registration request must be sent from the security server to the central server by the security server administrator.

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server User Guide
 
-Version: 2.6  
+Version: 2.8  
 Doc. ID: UG-CS
 
 
@@ -28,10 +28,11 @@ Doc. ID: UG-CS
 | 17.12.2015 | 2.1     | Added user instructions for monitoring. ||
 | 14.4.2016  | 2.2     | Added chapter for additional configuration options. ||
 | 5.9.2016   | 2.3     | Added instructions for configuring OCSP fetch interval. ||
-| 20.01.2017 | 2.4       | Added license text and version history | Sami Kallio |
+| 20.01.2017 | 2.4     | Added license text and version history | Sami Kallio |
 | 05.03.2018 | 2.5     | Added terms and abbreviations reference and document links | Tatu Repo |
 | 18.08.2018 | 2.6     | Corrected `ocspFetchInterval` default value (Chapter 16.2) | Petteri Kivimäki |
 | 15.11.2018 | 2.7     | Minor corrections for Ubuntu 18 | Jarkko Hyöty |
+| 23.01.2019 | 2.8     | Information about automatic approval of auth cert registration requests added. Updates in Chapters 6 and 7. | Petteri Kivimäki |
 
 ## Table of Contents
 <!-- toc -->
@@ -457,7 +458,7 @@ To delete an anchor file, follow these steps.
 # 6. The Management Requests System
 ## 6.1 Registration Requests
 
-As the registration of associations in the X-Road governing authority is security-critical, the following measures are applied to increase security:
+As the registration of associations in the X-Road governing authority is security-critical, the following measures are applied to increase security by default:
 
 - The registration request must be submitted to the X-Road governing authority over two channels, or in other words, the registration wish must be expressed through two complementary requests:
 one request is submitted to the X-Road central server through the security server,
@@ -468,6 +469,8 @@ There are two types of registration requests:
 
 - authentication certificate registration request (see Sections 7.4 and 8.3);
 - security server client registration request (see Section 7.5).
+
+It is possible to streamline the registration process of authentication certificates by enabling automatic approval of authentication certificate registration requests. When automatic approval is enabled, it is enough to submit a registration request to the X-Road central server through the security server, and the request will be automatically approved immediately. By default, automatic approval of authentication certificate registration requests is disabled. It can be enabled by setting the `auto-approve-auth-cert-reg-requests` property value to `true` on central server.
 
 ### 6.1.1 State Machine Model for Registration Requests
 
@@ -492,6 +495,8 @@ Approved – the complementary registration requests have been approved. The ass
 Declined – the complementary registration requests have been declined.
 
 Revoked – a registration request has been revoked.
+
+If automatic approval of authentication certificate registration requests is enabled, the complimentary registration request is created and approved automatically. Therefore, the request moves directly to Approved state.
 
 ## 6.2 Deletion Requests
 
@@ -582,7 +587,12 @@ To add a subsystem to an X-Road member, follow these steps.
 
 Access rights: Registration Officer
 
-To register an X-Road member's security server, the following actions must be taken.
+Registering an X-Road member's security server can be done 
+
+When automatic approval of authentication certificate registration requests is enabled, the following action must be taken:
+- An authentication certificate registration request must be sent from the security server to the central server by the security server administrator.
+
+Automatic approval of authentication certificate registration requests is disabled by default. In that case, to register an X-Road member's security server, the following actions must be taken.
 - An authentication certificate registration request must be sent from the security server to the central server by the security server administrator;
 - The complementary authentication certificate registration request must be formalized in the central server by the central server administrator, on the appeal of the security server's owner.
 - The complimentary requests must be approved by the central server administrator.

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -781,7 +781,12 @@ To change the security server address, follow these steps.
 
 Access rights: Registration Officer
 
-To register a security server's authentication certificate, the following actions must be taken.
+The actions required to register a security server's authentication certificate depend on whether automatic approval of authentication certificate registration requests is enabled or disabled (_default_).
+
+When automatic approval of authentication certificate registration requests is enabled, the following action must be taken:
+- An authentication certificate registration request must be sent from the security server to the central server by the security server administrator.
+
+Automatic approval of authentication certificate registration requests is disabled by default. In that case, to register a security server's authentication certificate, the following actions must be taken.
 - An authentication certificate registration request must be sent from the security server to the central server by the security server administrator;
 - The complementary authentication certificate registration request must be formalized in the central server by the central server administrator, on the appeal of the security server's owner.
 - The complimentary requests must be approved by the central server administrator.

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.39  
+Version: 2.40  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -49,6 +49,7 @@ Doc. ID: UG-SYSPAR
 | 08.11.2018 | 2.37     | Improved definition of *minimum-global-configuration-version* on the central server and configuration proxy | Ilkka Seppälä |
 | 19.12.2018 | 2.38     | Fixed the default value of trusted-anchors-allowed | Ilkka Seppälä |
 | 21.12.2018 | 2.39     | Add connector initial idle time parameters | Jarkko Hyöty |
+| 23.01.2019 | 2.40     | Added new Central Server parameter *auto-approve-auth-cert-reg-requests* | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -353,6 +354,7 @@ For instructions on how to change the parameter values, see section [Changing th
 | internal-directory      | internalconf                            | Name of the signed internal configuration directory that is distributed to the configuration clients (security servers and/or configuration proxies) of this X-Road instance. |
 | trusted-anchors-allowed | true                                    | True if federation is allowed for this X-Road instance. |
 | minimum-global-configuration-version | 2                          | The minimum supported global configuration version on the central server. This parameter is used if the central server needs to generate multiple versions of global configuration. Note that the support for global configuration V1 has been dropped in X-Road 6.20.0 and since that version the minimum value for this parameter is 2. |
+| auto-approve-auth-cert-reg-requests | false                       | True if automatic approval of auth cert registration requests is enabled for this X-Road instance. |
 
 #### 4.1.3 Signer parameters: `[signer]`
 

--- a/src/center-service/app/controllers/management_requests_controller.rb
+++ b/src/center-service/app/controllers/management_requests_controller.rb
@@ -25,6 +25,7 @@
 
 require 'thread'
 
+java_import Java::ee.ria.xroad.common.SystemProperties
 java_import Java::ee.ria.xroad.common.request.ManagementRequestHandler
 java_import Java::ee.ria.xroad.common.request.ManagementRequestParser
 java_import Java::ee.ria.xroad.common.request.ManagementRequestUtil
@@ -94,14 +95,30 @@ class ManagementRequestsController < ApplicationController
     verify_owner(security_server)
 
     req = nil
+    auth_cert_reg_request = nil
+
+    auth_cert_bytes = String.from_java_bytes(req_type.getAuthCert())
 
     @@auth_cert_registration_mutex.synchronize do
       req = AuthCertRegRequest.new(
         :security_server => security_server,
-        :auth_cert => String.from_java_bytes(req_type.getAuthCert()),
+        :auth_cert => auth_cert_bytes,
         :address => req_type.getAddress(),
         :origin => Request::SECURITY_SERVER)
       req.register()
+
+      if auto_approve_auth_cert_reg_requests?
+        auth_cert_reg_request = AuthCertRegRequest.new(
+          :security_server => security_server,
+          :auth_cert => auth_cert_bytes,
+          :address => req_type.getAddress(),
+          :origin => Request::CENTER)
+        auth_cert_reg_request.register()
+      end
+    end
+
+    if auto_approve_auth_cert_reg_requests?
+      RequestWithProcessing.approve(auth_cert_reg_request.id)
     end
 
     req.id
@@ -195,4 +212,8 @@ class ManagementRequestsController < ApplicationController
       raise t("request.incorrect_instance")
     end
   end
+
+   def auto_approve_auth_cert_reg_requests?
+      Java::ee.ria.xroad.common.SystemProperties::getCenterAutoApproveAuthCertRegRequests
+   end
 end

--- a/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -245,6 +245,8 @@ public final class SystemProperties {
 
     private static final String DEFAULT_CENTER_TRUSTED_ANCHORS_ALLOWED = "false";
 
+    private static final String DEFAULT_CENTER_AUTO_APPROVE_AUTH_CERT_REG_REQUESTS = "false";
+
     private static final String DEFAULT_SERVERPROXY_CONNECTOR_MAX_IDLE_TIME = "0";
 
     private static final String DEFAULT_PROXY_CONNECTOR_INITIAL_IDLE_TIME = "30000";
@@ -419,6 +421,10 @@ public final class SystemProperties {
     /** Property name of the path where conf backups are created. */
     public static final String CONF_BACKUP_PATH =
             PREFIX + "center.conf-backup-path";
+
+    /** Property name of enabling automatic approval of auth cert registration requests. */
+    public static final String CENTER_AUTO_APPROVE_AUTH_CERT_REG_REQUESTS =
+            PREFIX + "center.auto-approve-auth-cert-reg-requests";
 
     // Misc -------------------------------------------------------------------
 
@@ -955,6 +961,14 @@ public final class SystemProperties {
      */
     public static String getCenterGeneratedConfDir() {
         return System.getProperty(CENTER_GENERATED_CONF_DIR, DefaultFilepaths.DISTRIBUTED_GLOBALCONF_PATH);
+    }
+
+    /**
+     * @return whether automatic approval of auth cert registration requests is enabled, 'false' by default.
+     */
+    public static boolean getCenterAutoApproveAuthCertRegRequests() {
+        return Boolean.parseBoolean(System.getProperty(CENTER_AUTO_APPROVE_AUTH_CERT_REG_REQUESTS,
+                DEFAULT_CENTER_AUTO_APPROVE_AUTH_CERT_REG_REQUESTS));
     }
 
     /**


### PR DESCRIPTION
Implement automatic approval of auth cert registration requests:

- Add new `auto-approve-auth-cert-reg-requests` system paramameter to Central Server.
- Auth cert registration requests are automatically approved when `auto-approve-auth-cert-reg-requests` is set to `true` on Central Server.
- Central Server automatically duplicates the approval request and approves it after that.
- Manual approval is required if `auto-approve-auth-cert-reg-requests` is not defined in `local.ini` or it is set to `false`.
- Update system parameters document (UG-SYSPAR).
- Update Central Server User Guide (UG-CS).