### PR TITLE
TLSv1.3 support

### DIFF
--- a/ansible/roles/xroad-base/tasks/ubuntu.yml
+++ b/ansible/roles/xroad-base/tasks/ubuntu.yml
@@ -47,7 +47,7 @@
     repo: "ppa:{{ item }}"
   with_items:
     - openjdk-r/ppa
-    - nginx/stable
+    - ondrej/nginx
 
 - name: enable UTF-8 locales
   lineinfile:

--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -156,10 +156,14 @@ Add X-Road package repository (**reference data: 1.1**)
   sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb $(lsb_release -sc)-current main"
   ```
 
-  *Ubuntu 14.04 only*: Add openjdk and nginx repositories
+  Add nginx repository
+  ```
+  sudo apt-add-repository -y ppa:ondrej/nginx
+  ```
+
+  *Ubuntu 14.04 only*: Add openjdk repository
   ```
   sudo apt-add-repository -y ppa:openjdk-r/ppa
-  sudo apt-add-repository -y ppa:nginx/stable
   ```
 
 Issue the following commands to install the central server packages:

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -193,10 +193,13 @@ To install the X-Road security server software on *Ubuntu* operating system, fol
 
         sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb $(lsb_release -sc)-current main"
 
-    *Only Ubuntu 14.04 (trusty)*: Add OpenJDK and nginx repositories
+    Add nginx repository
+
+        sudo apt-add-repository -y ppa:ondrej/nginx
+
+    *Only Ubuntu 14.04 (trusty)*: Add OpenJDK repository
 
         sudo apt-add-repository -y ppa:openjdk-r/ppa
-        sudo apt-add-repository -y ppa:nginx/stable
 
 3.  Issue the following commands to install the security server packages (use package xroad-securityserver-ee to include configuration specific to Estonia; use package xroad-securityserver-fi to include configuration specific to Finland):
 

--- a/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
+++ b/doc/Manuals/ug-cp_x-road_v6_configuration_proxy_manual.md
@@ -146,10 +146,13 @@ To install the X-Road configuration proxy software, follow these steps.
 
         sudo apt-add-repository -y "deb https://artifactory.niis.org/xroad-release-deb $(lsb_release -sc)-current main"
 
-    *Only Ubuntu 14.04*: Add openjdk and nginx repositories
+    Add nginx repository
+
+        sudo apt-add-repository -y ppa:ondrej/nginx
+
+    *Only Ubuntu 14.04*: Add openjdk repository
 
         sudo apt-add-repository -y ppa:openjdk-r/ppa
-        sudo apt-add-repository -y ppa:nginx/stable
 
 3.  Issue the following commands to install the configuration proxy packages:
 

--- a/src/packages/src/xroad/common/center/etc/xroad/nginx/xroad-center.conf
+++ b/src/packages/src/xroad/common/center/etc/xroad/nginx/xroad-center.conf
@@ -4,7 +4,7 @@ server {
         ssl_certificate /etc/xroad/ssl/internal.crt;
         ssl_certificate_key /etc/xroad/ssl/internal.key;
 
-        ssl_protocols TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
         ssl_prefer_server_ciphers on;
         ssl_dhparam /etc/xroad/ssl/rfc3526group15.pem;

--- a/src/packages/src/xroad/common/nginx/etc/xroad/nginx/default-xroad.conf
+++ b/src/packages/src/xroad/common/nginx/etc/xroad/nginx/default-xroad.conf
@@ -4,7 +4,7 @@ server {
         ssl_certificate /etc/xroad/ssl/nginx.crt;
         ssl_certificate_key /etc/xroad/ssl/nginx.key;
 
-        ssl_protocols TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
         ssl_prefer_server_ciphers on;
         ssl_dhparam /etc/xroad/ssl/rfc3526group15.pem;


### PR DESCRIPTION
Hello.
I've changed nginx repository, as this one is compiled with openssl 1.1.1 and has support for tls 1.3.