### PR TITLE
hsm recovery

### DIFF
--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleManagerImpl.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleManagerImpl.java
@@ -24,7 +24,10 @@
  */
 package ee.ria.xroad.signer.tokenmanager.module;
 
+import ee.ria.xroad.signer.SignerMain;
+
 import akka.actor.Props;
+import akka.actor.Terminated;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -48,10 +51,37 @@ public class HardwareModuleManagerImpl extends DefaultModuleManagerImpl {
         if (!isModuleInitialized(hardwareModule)) {
             try {
                 Props props = Props.create(HardwareModuleWorker.class, hardwareModule).withDispatcher(DISPATCHER);
-                initializeModuleWorker(hardwareModule.getType(), props);
+                initializeModuleWorker(hardwareModule, props);
             } catch (Exception e) {
                 log.error("Error initializing hardware module '" + hardwareModule.getType() + "'", e);
             }
+        }
+    }
+
+    @Override
+    public void onMessage(Object message) throws Exception {
+        if (message instanceof Terminated) {
+            Terminated terminatedMessage = (Terminated) message;
+            String name = terminatedMessage.getActor().path().name();
+            log.error("Hardware module " + name + " terminated.");
+
+            SignerMain.exit(1);
+        } else {
+            super.onMessage(message);
+        }
+    }
+
+    @Override
+    protected ModuleBackoffOptions getModuleBackoffOptions(ModuleType module) {
+        if (module instanceof HardwareModuleType) {
+            HardwareModuleType hardwareModuleType = (HardwareModuleType) module;
+            ModuleBackoffOptions moduleBackoffOptions = new ModuleBackoffOptions();
+            moduleBackoffOptions.setMaxNrOfRetries(hardwareModuleType.getBackoffMaxRetries());
+            moduleBackoffOptions.setMinSeconds(hardwareModuleType.getBackoffMinSeconds());
+            moduleBackoffOptions.setMaxSeconds(hardwareModuleType.getBackoffMaxSeconds());
+            return moduleBackoffOptions;
+        } else {
+            return super.getModuleBackoffOptions(module);
         }
     }
 }

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleWorker.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleWorker.java
@@ -72,15 +72,8 @@ public class HardwareModuleWorker extends AbstractModuleWorker {
 
         log.info("Initializing module '{}' (library: {})", module.getType(), module.getPkcs11LibraryPath());
 
-        try {
-            pkcs11Module = moduleGetInstance(module.getPkcs11LibraryPath());
-
-            pkcs11Module.initialize(getInitializeArgs(module.getLibraryCantCreateOsThreads(), module.getOsLockingOk()));
-        } catch (Throwable t) {
-            // Note that we catch all serious errors here since we do not want Signer to crash if the module could
-            // not be loaded for some reason.
-            throw new RuntimeException(t);
-        }
+        pkcs11Module = moduleGetInstance(module.getPkcs11LibraryPath());
+        pkcs11Module.initialize(getInitializeArgs(module.getLibraryCantCreateOsThreads(), module.getOsLockingOk()));
     }
 
     private static InitializeArgs getInitializeArgs(Boolean libraryCantCreateOsThreads, Boolean osLockingOk) {

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenWorker.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenWorker.java
@@ -180,7 +180,7 @@ public class HardwareTokenWorker extends AbstractTokenWorker {
 
             log.error("Error initializing token ({})", getWorkerId(), e);
 
-            return;
+            throw e;
         }
 
         try {

--- a/src/packages/src/xroad/default-configuration/devices.ini
+++ b/src/packages/src/xroad/default-configuration/devices.ini
@@ -43,6 +43,10 @@
 ;   Specifies private key allowed mechanisms. Supported values:
 ;   CKM_RSA_PKCS, CKM_SHA256_RSA_PKCS, CKM_SHA384_RSA_PKCS, CKM_SHA512_RSA_PKCS, and
 ;   CKM_RSA_PKCS_PSS, CKM_SHA256_RSA_PKCS_PSS, CKM_SHA384_RSA_PKCS_PSS, CKM_SHA512_RSA_PKCS_PSS.
+; backoff_min_seconds = LONG (optional, default: 10)
+; backoff_max_seconds = LONG (optional, default: 600)
+; backoff_max_retries = INTEGER (optional, default: 6)
+;   Set to -1 for infinite retries.
 
 ;[hsm_ncipher]
 ;library = libcknfast.so

--- a/src/signer/src/main/java/ee/ria/xroad/signer/Signer.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/Signer.java
@@ -65,11 +65,6 @@ public class Signer implements StartStop {
     private static final String MODULE_MANAGER_IMPL_CLASS =
             SystemProperties.PREFIX + "signer.moduleManagerImpl";
 
-    private static final int MODULE_MANAGER_UPDATE_INTERVAL_SECONDS = SystemProperties.getModuleManagerUpdateInterval();
-
-    private static final FiniteDuration MODULE_MANAGER_UPDATE_INTERVAL =
-            Duration.create(MODULE_MANAGER_UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
-
     private final ActorSystem actorSystem;
 
     private FileWatcherRunner keyConfFileWatcherRunner;
@@ -163,7 +158,7 @@ public class Signer implements StartStop {
     private static class ModuleManagerJob extends PeriodicJob {
 
         ModuleManagerJob() {
-            super(MODULE_MANAGER, new Update(), MODULE_MANAGER_UPDATE_INTERVAL);
+            super(MODULE_MANAGER, new Update(), SignerProperties.MODULE_MANAGER_UPDATE_INTERVAL);
         }
 
         @Override

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -44,7 +44,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
 
 import static ee.ria.xroad.common.SystemProperties.CONF_FILE_CENTER;
 import static ee.ria.xroad.common.SystemProperties.CONF_FILE_CONFPROXY;
@@ -126,14 +125,6 @@ public final class SignerMain {
         } catch (Exception e) {
             log.error("Error stopping admin port", e);
         }
-
-        try {
-            Await.ready(actorSystem.terminate(), Duration.Inf());
-        } catch (TimeoutException e) {
-            log.error("Timed out while waiting for akka to terminate");
-        } catch (InterruptedException e) {
-            log.error("Interrupted while waiting for akka to terminate");
-        }
     }
 
     private static AdminPort createAdminPort(int signerPort) {
@@ -188,4 +179,16 @@ public final class SignerMain {
         return conf.withValue("akka.remote.netty.tcp.port",
                 ConfigValueFactory.fromAnyRef(signerPort));
     }
+
+    /**
+      * Terminate the actor system and exit with status code.
+      * @param statusCode
+      */
+    public static void exit(int statusCode) {
+        if (actorSystem != null) {
+            actorSystem.terminate();
+        }
+        System.exit(statusCode);
+    }
+
 }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerProperties.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerProperties.java
@@ -1,8 +1,6 @@
 /**
  * The MIT License
- * Copyright (c) 2018 Estonian Information System Authority (RIA),
- * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
- * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ * Copyright (c) 2019 Planetway Europe OÜ
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,33 +20,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package ee.ria.xroad.signer.tokenmanager.module;
+package ee.ria.xroad.signer;
 
-import akka.actor.Props;
-import lombok.extern.slf4j.Slf4j;
+import ee.ria.xroad.common.SystemProperties;
+
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.TimeUnit;
 
 /**
- * Default module manager supporting only software modules.
+ * Contains Signer properties.
  */
-@Slf4j
-public class DefaultModuleManagerImpl extends AbstractModuleManager {
+public final class SignerProperties {
 
-    @Override
-    protected void initializeModule(ModuleType module) {
-        if (module instanceof SoftwareModuleType) {
-            initializeSoftwareModule((SoftwareModuleType) module);
-        }
+    private SignerProperties() {
     }
 
-    void initializeSoftwareModule(SoftwareModuleType softwareModule) {
-        if (getContext().getChild(softwareModule.getType()) != null) {
-            // already initialized
-            return;
-        }
+    private static final int MODULE_MANAGER_UPDATE_INTERVAL_SECONDS = SystemProperties.getModuleManagerUpdateInterval();
 
-        log.debug("Initializing software module");
-
-        Props props = Props.create(SoftwareModuleWorker.class);
-        initializeModuleWorker(softwareModule, props);
-    }
+    public static final FiniteDuration MODULE_MANAGER_UPDATE_INTERVAL =
+            Duration.create(MODULE_MANAGER_UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
 }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/ServiceLocator.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/ServiceLocator.java
@@ -67,8 +67,9 @@ public final class ServiceLocator {
      */
     public static ActorSelection getToken(UntypedActorContext context,
             String tokenId) {
-        String path = String.format("/user/%s/%s/%s", MODULE_MANAGER,
-                getModuleId(tokenId), tokenId);
+        String moduleId = getModuleId(tokenId);
+        String path = String.format("/user/%s/%s/%s/%s", MODULE_MANAGER,
+                moduleId, moduleId, tokenId);
         return context.actorSelection(path);
     }
 

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleType.java
@@ -53,4 +53,10 @@ public class HardwareModuleType implements ModuleType {
     private final PrivKeyAttributes privKeyAttributes;
 
     private final PubKeyAttributes pubKeyAttributes;
+
+    private final Long backoffMinSeconds;
+
+    private final Long backoffMaxSeconds;
+
+    private final Integer backoffMaxRetries;
 }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
@@ -327,7 +327,7 @@ public final class SignerUtil {
     public static OneForOneStrategy createPKCS11ExceptionEscalatingStrategy() {
         return new OneForOneStrategy(-1, Duration.Inf(),
                 throwable -> {
-                    if (throwable instanceof PKCS11Exception) {
+                    if (throwable instanceof PKCS11Exception || throwable.getCause() instanceof PKCS11Exception) {
                         return SupervisorStrategy.escalate();
                     } else {
                         return SupervisorStrategy.resume();


### PR DESCRIPTION
Current state is that in case of a module failure due to a PKCS11 exception, the module is restarted. If module (re)initialization fails, the actor is stopped and the only way to get hsm back up is to manually restart signer.

The purpose of this PR is to make hsm recovery happen with a configurable exponential back-off strategy that optionally, in case of no success for some time makes signer exit with error code 1 causing it to be restarted.

Some points to emphasize:

    * Module and token full actor paths changed due to Akka's supervisor strategy being implemented by a wrapper actor. See ServiceLocator.java.

    * a PKCS11 failure in token worker is escalated to module worker. So a single failing token will cause the entire module to be restarted.

    * Changed the way module workers are periodically updated. So that in case module is restarted, it is also updated right away.

    * I actually didn't want to include the BackoffSupervisor for softtokens, but since adding one for the hardware modules causes the actor ref path to change, i thought it'd be nice for the paths to be the same for both software and hardware modules.


Additionally I removed the `Await.ready(actorSystem.terminate(), Duration.Inf()); ` from Signer shutdown method because it only reaches there after `Await.result(actorSystem.whenTerminated(), Duration.Inf());`. It seemed to deadlock there for some reason otherwise.