### PR TITLE
XRDDEV-368: Fix XRDDEV-368

### DIFF
--- a/src/common-ui/app/views/application/_activate_token_dialog.html.erb
+++ b/src/common-ui/app/views/application/_activate_token_dialog.html.erb
@@ -2,7 +2,9 @@
   <table class="details">
     <tr>
       <td><%= t 'common.pin' %></td>
-      <td><form><%= password_field_tag "activate_token_pin", nil, :autocomplete => "off" %></form></td>
+      <td><form method="post" onsubmit="return false;">
+        <%= password_field_tag "activate_token_pin", nil, :autocomplete => "off" %>
+      </form></td>
     </tr>
   </table>
 <% end %>


### PR DESCRIPTION
Ensure that token activation form can not be submitted (can reveal the pin code on the URL bar).
