### PR TITLE
XRDDEV-439

### DIFF
--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.42  
+Version: 2.43  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -52,6 +52,7 @@ Doc. ID: UG-SYSPAR
 | 23.01.2019 | 2.40     | Added new Central Server parameter *auto-approve-auth-cert-reg-requests* | Petteri Kivimäki |
 | 31.01.2019 | 2.41     | REST message log parameters | Jarkko Hyöty |
 | 03.02.2019 | 2.42     | Added new Central Server parameter *auto-approve-client-reg-requests* | Petteri Kivimäki |
+| 02.04.2019 | 2.43     | Added new message log parameter *clean-transaction-batch* | Jarkko Hyöty |
 
 ## Table of Contents
 
@@ -310,8 +311,9 @@ This chapter describes the system parameters used by the components of the X-Roa
 | timestamper-client-connect-timeout               | 20000                                      |   |   | The timestamper client connect timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
 | timestamper-client-read-timeout                  | 60000                                      |   |   | The timestamper client read timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
 | archive-transaction-batch                        | 10000                                      |   |   | Size of transaction batch for archiving messagelog. This size is not exact because it will always make sure that last archived batch includes timestamp also (this might mean that it will go over transaction size).
-| max-loggable-body-size                           | 1073741824 (1 GiB)                         |   |   | Maximum loggable REST message body size |
-| truncated-body-allowed                           | false                                      |   |   | If the REST message body exceeds the maximum loggable body size, truncate the body in the log (true) or reject the message (false) |
+| max-loggable-body-size                           | 10485760 (10 MiB)                          |   |   | Maximum loggable REST message body size |
+| truncated-body-allowed                           | false                                      |   |   | If the REST message body exceeds the maximum loggable body size, truncate the body in the log (true) or reject the message (false). |
+| clean-transaction-batch                          | 10000                                      |   |   | Maximun number of log records to remove in one transaction. |
 
 #### 3.7.1 Note on logged X-Road message headers
 If the messagelog add-on has the SOAP body logging disabled, only a preconfigured set of the SOAP headers will be included in the message log.

--- a/src/addons/messagelog/src/main/resources/messagelog.hbm.xml
+++ b/src/addons/messagelog/src/main/resources/messagelog.hbm.xml
@@ -29,7 +29,7 @@
             <property name="signatureHash" access="field" type="text"/>
 
             <many-to-one name="timestampRecord" access="field" cascade="none" lazy="false"
-                class="ee.ria.xroad.common.messagelog.TimestampRecord"/>
+                         class="ee.ria.xroad.common.messagelog.TimestampRecord"/>
 
             <property name="timestampHashChain" access="field" type="text"/>
             <property name="response" access="field" type="boolean"/>
@@ -42,12 +42,6 @@
             <property name="hashChainResult" access="field" type="text"/>
         </subclass>
 
-<!--
-        <subclass name="EncryptedMessageRecord" discriminator-value="e">
-            ...
-        </subclass>
- -->
-
     </class>
 
     <class name="ee.ria.xroad.common.messagelog.archive.DigestEntry" table="LAST_ARCHIVE_DIGEST">
@@ -58,5 +52,27 @@
         <property name="digest" access="field" type="text"/>
         <property name="fileName" access="field" type="string"/>
     </class>
+
+    <!--
+    Implementation notes:
+
+    Correctness (and performance) of this query assumes that log records are archived in primary key order
+    (if archived(id1) = true and archived(id2) = false then id1 < id2). The current log archiving implementation
+    keeps this property.
+
+    The extra "id > 0" condition makes PostgreSQL to prefer index scan using primary key,
+    which is faster than table scan if the log is large.
+    -->
+
+    <sql-query name="delete-logrecords">
+        <![CDATA[
+        DELETE FROM logrecord
+          WHERE archived = true
+          AND time <= :time
+          AND id > 0
+          AND id <= (SELECT max(l.id) FROM (
+            SELECT id FROM logrecord ORDER BY id LIMIT :limit) l)
+        ]]>
+    </sql-query>
 
 </hibernate-mapping>

--- a/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogCleaner.java
+++ b/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogCleaner.java
@@ -24,8 +24,6 @@
  */
 package ee.ria.xroad.proxy.messagelog;
 
-import org.hibernate.Session;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -42,9 +40,9 @@ class TestLogCleaner extends LogCleaner {
     }
 
     @Override
-    protected void handleClean(Session session) {
-        super.handleClean(session);
-
+    protected long handleClean() throws Exception {
+        final long removed = super.handleClean();
         gate.countDown();
+        return removed;
     }
 }

--- a/src/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
+++ b/src/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
@@ -52,6 +52,7 @@ public final class MessageLogProperties {
     private static final int DEFAULT_TIMESTAMPER_CLIENT_READ_TIMEOUT = 60000;
 
     private static final int DEFAULT_ARCHIVE_TRANSACTION_BATCH_SIZE = 10000;
+    private static final int DEFAULT_CLEAN_TRANSACTION_BATCH_SIZE = 10000;
 
     private static final long DEFAULT_MAX_LOGGABLE_MESSAGE_BODY_SIZE = 10 * 1024 * 1024;
     private static final long MAX_LOGGABLE_MESSAGE_BODY_SIZE_LIMIT = 1024 * 1024 * 1024;
@@ -81,6 +82,8 @@ public final class MessageLogProperties {
     public static final String ARCHIVE_TRANSACTION_BATCH = PREFIX + "archive-transaction-batch";
 
     public static final String CLEAN_INTERVAL = PREFIX + "clean-interval";
+
+    private static final String CLEAN_TRANSACTION_BATCH = "clean-transaction-batch";
 
     public static final String HASH_ALGO_ID = PREFIX + "hash-algo-id";
 
@@ -275,6 +278,10 @@ public final class MessageLogProperties {
 
     public static boolean isTruncatedBodyAllowed() {
         return Boolean.getBoolean(REST_TRUNCATED_BODY_ALLOWED);
+    }
+
+    public static int getCleanTransactionBatchSize() {
+        return Integer.getInteger(CLEAN_TRANSACTION_BATCH, DEFAULT_CLEAN_TRANSACTION_BATCH_SIZE);
     }
 
     private static String getMessageBodyLoggingOverrideParameterName(boolean enable, boolean local) {

--- a/src/packages/src/xroad/default-configuration/addons/message-log.ini
+++ b/src/packages/src/xroad/default-configuration/addons/message-log.ini
@@ -38,7 +38,10 @@ archive-path=/var/lib/xroad/
 
 ; Time interval as Cron expression for cleaning archived records from
 ; online database.
-clean-interval=0 0 0/12 1/1 * ? *
+clean-interval=0 0 3/6 1/1 * ? *
+
+; Maximum number of records cleaned in one transaction
+;clean-transaction-batch=10000
 
 ; The hash algorithm that is used for hashing in message log.
 hash-algo-id=SHA-512


### PR DESCRIPTION
Message log cleaning can fail with 'out of shared memory' if there are
tens of thousands of REST messages to clean. This is due to PostgreSQL
acquiring a lock when a LOB is deleted.

Clean records in configurable batches, avoiding too many locks in
one transaction.