### PR TITLE
Support for adding autologin pin via environment varible

### DIFF
--- a/Docker/securityserver/Dockerfile
+++ b/Docker/securityserver/Dockerfile
@@ -2,16 +2,16 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
-&& apt-get -qq upgrade \
-&& apt-get -qq install ca-certificates gnupg supervisor net-tools locales setpriv openjdk-8-jre-headless rlwrap ca-certificates-java crudini adduser expect nginx-light curl rsyslog authbind \
-&& echo "LC_ALL=en_US.UTF-8" >>/etc/environment \
-&& locale-gen en_US.UTF-8 \
-&& adduser --quiet --system --uid 998 --home /var/lib/postgresql --no-create-home --shell /bin/bash --group postgres \
-&& adduser --quiet --system --uid 999 --home /var/lib/xroad --no-create-home --shell /bin/bash --group xroad \
-&& useradd -m xrd -s /usr/sbin/nologin -p '$6$JeOzaeWnLAQSUVuO$GOJ0wUKSVQnOR4I2JgZxdKr.kMO.YGS21SGaAshaYhayv8kSV9WuIFCZHTGAX8WRRTB/2ojuLnJg4kMoyzpcu1' \
-&& echo "xroad-proxy xroad-common/username string xrd" | debconf-set-selections \
-&& apt-get -qq install postgresql postgresql-contrib \
-&& apt-get -qq clean
+    && apt-get -qq upgrade \
+    && apt-get -qq install ca-certificates gnupg supervisor net-tools locales setpriv openjdk-8-jre-headless rlwrap ca-certificates-java crudini adduser expect nginx-light curl rsyslog authbind \
+    && echo "LC_ALL=en_US.UTF-8" >>/etc/environment \
+    && locale-gen en_US.UTF-8 \
+    && adduser --quiet --system --uid 998 --home /var/lib/postgresql --no-create-home --shell /bin/bash --group postgres \
+    && adduser --quiet --system --uid 999 --home /var/lib/xroad --no-create-home --shell /bin/bash --group xroad \
+    && useradd -m xrd -s /usr/sbin/nologin -p '$6$JeOzaeWnLAQSUVuO$GOJ0wUKSVQnOR4I2JgZxdKr.kMO.YGS21SGaAshaYhayv8kSV9WuIFCZHTGAX8WRRTB/2ojuLnJg4kMoyzpcu1' \
+    && echo "xroad-proxy xroad-common/username string xrd" | debconf-set-selections \
+    && apt-get -qq install postgresql postgresql-contrib \
+    && apt-get -qq clean
 
 
 ARG DIST=bionic-current
@@ -22,26 +22,26 @@ ARG COMPONENT=main
 ADD ["$REPO_KEY","/tmp/repokey.gpg"]
 ADD ["${REPO}/dists/${DIST}/Release","/tmp/Release"]
 RUN echo "deb $REPO $DIST $COMPONENT" >/etc/apt/sources.list.d/xroad.list \
-&& apt-key add '/tmp/repokey.gpg'
+    && apt-key add '/tmp/repokey.gpg'
 
 RUN pg_ctlcluster 10 main start \
-&& apt-get update \
-&& apt-get -qq install xroad-securityserver xroad-autologin \
-&& apt-get -qq clean \
-&& pg_ctlcluster 10 main stop \
-&& nginx -s stop \
-&& rm -f /var/run/nginx.pid \
-&& sed -i 's/proxy_set_header Host $host:$server_port;/proxy_set_header Host $http_host;/' /etc/xroad/nginx/default-xroad.conf
+    && apt-get update \
+    && apt-get -qq install xroad-securityserver xroad-autologin \
+    && apt-get -qq clean \
+    && pg_ctlcluster 10 main stop \
+    && nginx -s stop \
+    && rm -f /var/run/nginx.pid \
+    && sed -i 's/proxy_set_header Host $host:$server_port;/proxy_set_header Host $http_host;/' /etc/xroad/nginx/default-xroad.conf
 
 # back up read-only config (for volume support)
 RUN mkdir -p /root/etc/xroad \
-&& cp -a /etc/xroad/* /root/etc/xroad/ \
-&& rm /root/etc/xroad/services/local.conf \
-   /root/etc/xroad/conf.d/local.ini \
-   /root/etc/xroad/devices.ini \
-   /root/etc/xroad/db.properties \
-&& dpkg-query --showformat='${Version}' --show xroad-proxy >/root/VERSION \
-&& cp /root/VERSION /etc/xroad/VERSION
+    && cp -a /etc/xroad/* /root/etc/xroad/ \
+    && rm /root/etc/xroad/services/local.conf \
+    /root/etc/xroad/conf.d/local.ini \
+    /root/etc/xroad/devices.ini \
+    /root/etc/xroad/db.properties \
+    && dpkg-query --showformat='${Version}' --show xroad-proxy >/root/VERSION \
+    && cp /root/VERSION /etc/xroad/VERSION
 
 COPY files/ss-entrypoint.sh /root/entrypoint.sh
 COPY --chown=root:root files/ss-xroad.conf /etc/supervisor/conf.d/xroad.conf
@@ -50,3 +50,4 @@ CMD ["/root/entrypoint.sh"]
 VOLUME /var/lib/postgresql/10/main
 VOLUME /etc/xroad
 EXPOSE 80 443 4000 5500 5577
+ENV XROAD_AUTOLOGIN_PIN=""

--- a/Docker/securityserver/README.md
+++ b/Docker/securityserver/README.md
@@ -12,45 +12,88 @@ The installed security server is in uninitialized state.
 Admin UI credentials: xrd/secret
 
 ## Running
-```
-# Simple example 
+
+```shell
+# Simple example
 docker run --name my-ss niis/xroad-security-server
+
+# Simple example passing in the XROAD_AUTOLOGIN_PIN for autologin
+docker run --name my-ss niis/xroad-security-server -e XROAD_AUTOLOGIN_PIN="1234"
 
 # Running exact version instead of the default latest version
 docker run --name my-ss niis/xroad-security-server:bionic-6.20.0
+
+# Running exact version instead of the default latest version passing in the XROAD_AUTOLOGIN_PIN for autologin
+docker run --name my-ss niis/xroad-security-server:bionic-6.20.0 -e XROAD_AUTOLOGIN_PIN="1234"
 ```
 
 ## Accessing the container
 
-##### Running a single security server (Linux/Windows/MacOS)
-```
+### Running a single security server (Linux/Windows/MacOS)
+
+```shell
 # Publish the container ports (80 and/or 443, 4000, and optionally 5500 and 5577) e.g. to localhost (loopback address).
-docker run -p 4000:4000 -p 4001:80 --name my-ss niis/xroad-security-server
+docker run -p 4000:4000 -p 4001:80 --name my-ss niis/xroad-security-server -e XROAD_AUTOLOGIN_PIN="1234"
 ```
 
 ## Running multiple dockerized security servers
 If you are running multiple containers and map container ports to localhost, it is recommended that you use a separate loopback address for each container and create a x-road spesific network so that containers can communicate. 
 Accessing admin-ui of a server from the same domain will break session on other servers. You can get over this by setting multiple mappings to localhost in hosts-file.
 
-```
+```shell
 # Create a custom network for x-road containers
 docker network create -d bridge x-road-network
 
 # Create more than one security server containers and (optionally) assign them a network-alias for easier reference
-docker run -p 4000:4000 -p 4001:80 --network x-road-network --name my-ss1 niis/xroad-security-server
-docker run -p 4100:4000 -p 4101:80 --network x-road-network --name my-ss2 niis/xroad-security-server
+docker run -p 4000:4000 -p 4001:80 --network x-road-network --name my-ss1 niis/xroad-security-server -e XROAD_AUTOLOGIN_PIN="1234"
+docker run -p 4100:4000 -p 4101:80 --network x-road-network --name my-ss2 niis/xroad-security-server -e XROAD_AUTOLOGIN_PIN="1234"
+```
+
+## Running multiple security servers via docker-compose
+
+docker-compose.yml example file:
+
+```yaml
+version: '3.3'
+
+services:
+  my-ss-1:
+    image: niis/xroad-security-server:latest
+    environment:
+      - XROAD_AUTOLOGIN_PIN="1234"
+    ports:
+      - "4000:4000"
+      - "4001:80"
+    networks:
+      - x-road-network
+
+  my-ss-2:
+    image: niis/xroad-security-server:latest
+    environment: 
+      - XROAD_AUTOLOGIN_PIN="1234"
+    ports:
+      - "4100:4000"
+      - "4101:80"
+    networks:
+      - x-road-network
+
+networks:
+  x-road-network:
+    driver: bridge
 ```
 
 ## Notes
+
 xroad-autologin is installed, but there is no default PIN set, so the following error at startup is normal:
-```
+
+```text
 ... INFO exited: xroad-autologin (exit status 0; not expected)
 ... INFO gave up: xroad-autologin entered FATAL state, too many start retries too quickly
 ```
+
 One can create the autologin file by hand after initializing the security server:
 
-```
-$ docker exec my-ss su -c 'echo 1234 >/etc/xroad/autologin' xroad
-$ docker exec my-ss supervisorctl start xroad-autologin
-
+```shell
+docker exec my-ss su -c 'echo 1234 >/etc/xroad/autologin' xroad
+docker exec my-ss supervisorctl start xroad-autologin
 ```

--- a/Docker/securityserver/README.md
+++ b/Docker/securityserver/README.md
@@ -18,7 +18,7 @@ Admin UI credentials: xrd/secret
 docker run --name my-ss niis/xroad-security-server
 
 # Simple example passing in the XROAD_AUTOLOGIN_PIN for autologin
-docker run --name my-ss niis/xroad-security-server -e XROAD_AUTOLOGIN_PIN="1234"
+docker run --name my-ss -e XROAD_AUTOLOGIN_PIN="1234" niis/xroad-security-server 
 
 # Running exact version instead of the default latest version
 docker run --name my-ss niis/xroad-security-server:bionic-6.20.0

--- a/Docker/securityserver/files/ss-entrypoint.sh
+++ b/Docker/securityserver/files/ss-entrypoint.sh
@@ -28,7 +28,8 @@ fi
 
 if [  -z "${XROAD_AUTOLOGIN_PIN}" ]
 then
-    echo "WARN: XROAD_AUTOLOGIN_PIN variable is not set"
+    # Optional notification if we want to notify user of optional XROAD_AUTOLOGIN_PIN environment variable. Leaving blank for now.
+    echo ""
 else
     echo "XROAD_AUTOLOGIN_PIN variable set, writing to /etc/xroad/autologin"
     echo ${XROAD_AUTOLOGIN_PIN} > /etc/xroad/autologin

--- a/Docker/securityserver/files/ss-entrypoint.sh
+++ b/Docker/securityserver/files/ss-entrypoint.sh
@@ -26,4 +26,13 @@ else
     echo "WARN: Installed version ($INSTALLED_VERSION) does not match packaged version ($PACKAGED_VERSION)" >&2
 fi
 
+if [  -z "${XROAD_AUTOLOGIN_PIN}" ]
+then
+    echo "WARN: XROAD_AUTOLOGIN_PIN variable is not set"
+else
+    echo "XROAD_AUTOLOGIN_PIN variable set, writing to /etc/xroad/autologin"
+    echo ${XROAD_AUTOLOGIN_PIN} > /etc/xroad/autologin
+    unset XROAD_AUTOLOGIN_PIN
+fi
+
 exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
As a common way of injecting data to containers I have added environment variable that is used at startup if it is defined. This variable is then written to /etc/xroad/autologin

* Added support for injecting autologin pin at runtime which allows usage of secrets f.example in kubernetes or openshift
* Fixed linting errors in readme
* Added example docker-compose.yml in README.md