### PR TITLE
XRDDEV-474

### DIFF
--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.44  
+Version: 2.45  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -54,6 +54,7 @@ Doc. ID: UG-SYSPAR
 | 03.02.2019 | 2.42     | Added new Central Server parameter *auto-approve-client-reg-requests* | Petteri Kivimäki |
 | 02.04.2019 | 2.43     | Added new message log parameter *clean-transaction-batch* | Jarkko Hyöty |
 | 08.04.2019 | 2.44     | Update REST related message log parameters' descriptions | Petteri Kivimäki |
+| 30.04.2019 | 2.45     | Added new parameter *timestamp-retry-delay* | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -312,6 +313,7 @@ This chapter describes the system parameters used by the components of the X-Roa
 | timestamp-records-limit                          | 10000                                      |   |   | Maximum number of message records to time-stamp in one batch. If the number of message records in a single batch exceeds 70 % of `timestamp-records-limit` value, a warning is logged in `proxy.log`. |
 | timestamper-client-connect-timeout               | 20000                                      |   |   | The timestamper client connect timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
 | timestamper-client-read-timeout                  | 60000                                      |   |   | The timestamper client read timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
+| timestamp-retry-delay                            | 60                                         |   |   | Time-stamp retry delay in seconds when batch time-stamping fails. After failing to batch time-stamp, the timestamper waits for the time period defined by "timestamp-retry-delay" before trying again. This is repeated until fetching a time-stamp succeeds. After successfully fetching a time-stamp, the timestamper returns to normal time-stamping schedule. If the value of "timestamp-retry-delay" is higher than the value of the central server system parameter "timeStampingIntervalSeconds", the value of "timeStampingIntervalSeconds" is used. If the value of "timestamp-retry-delay" is zero, the value of "timeStampingIntervalSeconds" is used. |
 | archive-transaction-batch                        | 10000                                      |   |   | Size of transaction batch for archiving messagelog. This size is not exact because it will always make sure that last archived batch includes timestamp also (this might mean that it will go over transaction size).
 | max-loggable-body-size                           | 10485760 (10 MiB)                          |   |   | Maximum loggable REST message body size |
 | truncated-body-allowed                           | false                                      |   |   | If the REST message body exceeds the maximum loggable body size, truncate the body in the log (true) or reject the message (false). |

--- a/src/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
+++ b/src/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
@@ -51,6 +51,8 @@ public final class MessageLogProperties {
 
     private static final int DEFAULT_TIMESTAMPER_CLIENT_READ_TIMEOUT = 60000;
 
+    private static final int DEFAULT_TIMESTAMP_RETRY_DELAY = 60;
+
     private static final int DEFAULT_ARCHIVE_TRANSACTION_BATCH_SIZE = 10000;
     private static final int DEFAULT_CLEAN_TRANSACTION_BATCH_SIZE = 10000;
 
@@ -68,6 +70,9 @@ public final class MessageLogProperties {
     public static final String TIMESTAMP_IMMEDIATELY = PREFIX + "timestamp-immediately";
 
     public static final String TIMESTAMP_RECORDS_LIMIT = PREFIX + "timestamp-records-limit";
+
+    /** Property name of the timestamp retry delay (seconds). */
+    public static final String TIMESTAMP_RETRY_DELAY = PREFIX + "timestamp-retry-delay";
 
     public static final String ACCEPTABLE_TIMESTAMP_FAILURE_PERIOD = PREFIX + "acceptable-timestamp-failure-period";
 
@@ -141,6 +146,15 @@ public final class MessageLogProperties {
     public static int getTimestamperClientReadTimeout() {
         return getInt(System.getProperty(TIMESTAMPER_CLIENT_READ_TIMEOUT),
                 DEFAULT_TIMESTAMPER_CLIENT_READ_TIMEOUT);
+    }
+
+    /**
+     * @return the timestamp retry delay in seconds. A retry delay of zero is
+     * interpreted as retry delay is disabled. '60' by default.
+     */
+    public static int getTimestampRetryDelay() {
+        return getInt(System.getProperty(TIMESTAMP_RETRY_DELAY),
+                DEFAULT_TIMESTAMP_RETRY_DELAY);
     }
 
     /**


### PR DESCRIPTION
Implement time-stamping recovery mode when time-stamping fails.

- Add `timestamp-retry-delay` property that defines recovery interval when batch time-stamping fails.
- Time-stamping is tried using the recovery interval until a time-stamp is successfully fetched.
- After a successful time-stamp, the time-stamper returns to use the value of the central server system parameter `timeStampingIntervalSeconds`.
- Update System Parameters document.
- Time-stamping recovery mode tries to time-stamp one message only.
- Once time-stamping a single message succeeds, the time-stamper tries to time-stamp maximum number of messages defined by the timestamp-records-limit property.
- The time-stamper does not wait for `timestamp-retry-delay` or `timeStampingIntervalSeconds` - all queued messages are time-stamped immediately at the of the recovery mode.
- At the end of the recovery mode, next normal batch is scheduled using `timeStampingIntervalSeconds`.
