### PR TITLE
Fix undefined method error when WSDL is refreshed

### DIFF
--- a/src/proxy-ui/app/controllers/clients/services.rb
+++ b/src/proxy-ui/app/controllers/clients/services.rb
@@ -688,7 +688,7 @@ module Clients::Services
       end if deleted.has_key?(wsdl.url)
 
       services_deleted.each do |service|
-        service.wsdl = nil
+        service.serviceDescription = nil
         wsdl.service.remove(service)
         @session.delete(service)
       end


### PR DESCRIPTION
- Fix incorrect property name referencing WSDL in service object.
- New property name is `serviceDescription`.