### PR TITLE
Remove RANDFILE var from CA.cnf

### DIFF
--- a/ansible/roles/xroad-ca/common-files/home/ca/CA/CA.cnf
+++ b/ansible/roles/xroad-ca/common-files/home/ca/CA/CA.cnf
@@ -2,7 +2,6 @@
 HOME		= .
 INTERMEDIATE    = intermediate
 INTERMEDIATE    = ${ENV::INTERMEDIATE}
-RANDFILE	= $HOME/private/.rnd
 
 [ ca ]
 # `man ca`


### PR DESCRIPTION
This fixes TEST CA's openssl internal error, when we sign CSR file.

Error massage
```
Can't load ./private/.rnd into RNG
140277469962688:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=./private/.rnd
```

system
OS: Ubuntu 18.04
Openssl: 1.1.1