### PR TITLE
XRDDEV-560

### DIFF
--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server User Guide
 
-Version: 2.9  
+Version: 2.10  
 Doc. ID: UG-CS
 
 
@@ -34,6 +34,7 @@ Doc. ID: UG-CS
 | 15.11.2018 | 2.7     | Minor corrections for Ubuntu 18 | Jarkko Hyöty |
 | 23.01.2019 | 2.8     | Information about automatic approval of auth cert registration requests added. Updates in Chapters 6-8. | Petteri Kivimäki |
 | 06.02.2019 | 2.9     | Information about automatic approval of security server client registration requests added. Updates in Chapters 6-8. | Petteri Kivimäki |
+| 02.07.2019 | 2.10    | Security Server owner change added (Chapter 7.10) | Petteri Kivimäki |
 
 ## Table of Contents
 <!-- toc -->
@@ -85,6 +86,7 @@ Doc. ID: UG-CS
   * [7.7 Changing the Global Group Membership of an X-Road Member’s Subsystem](#77-changing-the-global-group-membership-of-an-x-road-members-subsystem)
   * [7.8 Deleting a Subsystem](#78-deleting-a-subsystem)
   * [7.9 Deleting an X-Road Member](#79-deleting-an-x-road-member)
+  * [7.10 Changing a Security Server's Owner](#710-changing-a-security-servers-owner)
 - [8. Managing the Security Servers](#8-managing-the-security-servers)
   * [8.1 Viewing the Security Server Details](#81-viewing-the-security-server-details)
   * [8.2 Changing the Security Server Address](#82-changing-the-security-server-address)
@@ -463,13 +465,15 @@ As the registration of associations in the X-Road governing authority is securit
 
 - The registration request must be submitted to the X-Road governing authority over two channels, or in other words, the registration wish must be expressed through two complementary requests:
 one request is submitted to the X-Road central server through the security server,
-the other request is submitted to the X-Road governing authority through means independent of the X-Road (for example, over a digitally signed e-mail). This request must be formalized in the central server by the central server administrator.
+the other request is submitted to the X-Road governing authority through means independent of the X-Road (for example, over a digitally signed e-mail). This request must be formalized in the central server by the central server administrator. 
+  - Security server owner change request is an exception - it is enough to submit one request through security server and the complementary request is generated automatically. Manual approval is still required by default.
 - The association must be approved by the X-Road governing authority.
 
-There are two types of registration requests:
+There are three types of registration requests:
 
 - authentication certificate registration request (see Sections 7.4 and 8.3);
-- security server client registration request (see Section 7.5).
+- security server client registration request (see Section 7.5);
+- security server owner change request (see Section 7.10)
 
 It is possible to streamline the registration process of authentication certificates and security server clients by enabling automatic approval.
  
@@ -481,7 +485,11 @@ It is possible to streamline the registration process of authentication certific
   - When automatic approval is enabled, it is enough to submit a security server client registration request to the X-Road central server through the security server, and the request will be automatically approved immediately.
   - Automatic approval is applied to existing members only. In addition, automatic approval is applied only if the client registration request has been signed by the member owning the subsystem to be registered as a security server client.
   - By default, automatic approval of security server client registration requests is disabled. It can be enabled by setting the `auto-approve-client-reg-requests` property value to `true` on central server.
-
+- security server owner change requests
+    - When automatic approval is enabled, it is enough to submit a security server owner change request to the X-Road central server through the security server, and the request will be automatically approved immediately.
+    - Automatic approval is applied to existing members only.
+    - By default, automatic approval of security server owner change requests is disabled. It can be enabled by setting the `auto-approve-owner-change-requests` property value to `true` on central server.
+    
 ### 6.1.1 State Machine Model for Registration Requests
 
 A registration request can be in one of the following states. See Figure 1 for the state machine diagram.
@@ -758,6 +766,25 @@ When an X-Road member is deleted, information about all security servers in its 
 To delete an X-Road member, follow these steps.
 1. On the Configuration menu, select Members, select a member that you wish to delete, and click Details.
 2. In the view that opens, locate the Member Details section and click Delete. In the confirmation window that opens, click Confirm.
+
+## 7.10 Changing a Security Server's Owner
+
+Access rights: Registration Officer
+
+The actions required to change a security server's owner depend on whether automatic approval of security server owner change requests is enabled or disabled (_default_).
+
+When automatic approval of security server owner change requests is enabled, the following action must be taken:
+- A security server owner chang request must be sent from the security server to the central server by the security server administrator.
+
+Automatic approval of security server owner change requests is disabled by default. In that case, to change the owner of a security server, the following actions must be taken.
+- A security server owner change request must be sent from the security server to the central server by the security server administrator;
+- The complementary security server owner change request is formalized in the central server automatically;
+- The complimentary requests must be approved by the central server administrator, on the appeal of the security server's owner.
+
+Registration requests in the state "Submitted for approval" can be approved or rejected by the central server administrator.
+
+- To approve a request open one of its complementary requests in detail view and click Approve. On the approval of the request, the complementary requests move to the "Approved" state. 
+- To decline a request, open one of the complementary requests in detail view and click Decline. Upon declining a request, its complementary requests move to the "Declined" state.
 
 # 8. Managing the Security Servers
 ## 8.1 Viewing the Security Server Details

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.45  
+Version: 2.46  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -55,6 +55,7 @@ Doc. ID: UG-SYSPAR
 | 02.04.2019 | 2.43     | Added new message log parameter *clean-transaction-batch* | Jarkko Hyöty |
 | 08.04.2019 | 2.44     | Update REST related message log parameters' descriptions | Petteri Kivimäki |
 | 30.04.2019 | 2.45     | Added new parameter *timestamp-retry-delay* | Petteri Kivimäki |
+| 02.07.2019 | 2.46     | Added new Central Server parameter *auto-approve-owner-change-requests* | Petteri Kivimäki |
 
 ## Table of Contents
 
@@ -378,6 +379,7 @@ For instructions on how to change the parameter values, see section [Changing th
 | minimum-global-configuration-version | 2                          | The minimum supported global configuration version on the central server. This parameter is used if the central server needs to generate multiple versions of global configuration. Note that the support for global configuration V1 has been dropped in X-Road 6.20.0 and since that version the minimum value for this parameter is 2. |
 | auto-approve-auth-cert-reg-requests | false                       | True if automatic approval of auth cert registration requests is enabled for this X-Road instance. Automatic approval is applied to existing members only. |
 | auto-approve-client-reg-requests | false                          | True if automatic approval of client registration requests is enabled for this X-Road instance. Automatic approval is applied to existing members only. In addition, automatic approval is applied only if the client registration request has been signed by the member owning the subsystem to be registered as a security server client. |
+| auto-approve-owner-change-requests | false                        | True if automatic approval of owner change requests is enabled for this X-Road instance. Automatic approval is applied to existing members only. |
 
 #### 4.1.3 Signer parameters: `[signer]`
 

--- a/src/center-common/app/models/invalid_owner_change_request_exception.rb
+++ b/src/center-common/app/models/invalid_owner_change_request_exception.rb
@@ -1,0 +1,27 @@
+#
+# The MIT License
+# Copyright (c) 2018 Estonian Information System Authority (RIA),
+# Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+# Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+class InvalidOwnerChangeRequestException < StandardError
+end

--- a/src/center-common/app/models/owner_change_request.rb
+++ b/src/center-common/app/models/owner_change_request.rb
@@ -117,6 +117,14 @@ class OwnerChangeRequest < RequestWithProcessing
             :user => sec_serv_user))
     end
 
+    # New owner must be registered as a client on the security server
+    if !client.security_servers.include?(server)
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.not_registered_client",
+            :user => sec_serv_user,
+            :security_server => security_server))
+    end
+
     # Client cannot be the current owner of the security server
     if server.get_server_id.matches_client_id(sec_serv_user)
       raise InvalidOwnerChangeRequestException.new(

--- a/src/center-common/app/models/owner_change_request.rb
+++ b/src/center-common/app/models/owner_change_request.rb
@@ -75,7 +75,7 @@ class OwnerChangeRequest < RequestWithProcessing
     end
 
     verify_against_submitted_requests()
-    verify_new_owner()
+    validate_request()
   end
 
   def verify_against_submitted_requests()
@@ -94,7 +94,7 @@ class OwnerChangeRequest < RequestWithProcessing
     end
   end
 
-  def verify_new_owner
+  def validate_request
     server = SecurityServer.find_server_by_id(security_server)
     client = SecurityServerClient.find_by_id(sec_serv_user)
 
@@ -131,7 +131,7 @@ class OwnerChangeRequest < RequestWithProcessing
       server.server_code, client.member_code, client.member_class.code)
 
     if existing_server
-      raise I18n.t("validation.securitserver_exists",
+      raise I18n.t("requests.server_code_exists",
         :member_class => client.member_class.code,
         :member_code => client.member_code,
         :server_code => server.server_code)

--- a/src/center-common/app/models/owner_change_request.rb
+++ b/src/center-common/app/models/owner_change_request.rb
@@ -98,6 +98,18 @@ class OwnerChangeRequest < RequestWithProcessing
     server = SecurityServer.find_server_by_id(security_server)
     client = SecurityServerClient.find_by_id(sec_serv_user)
 
+    if server == nil
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.server_not_found",
+            :server => security_server))
+    end
+
+    if client == nil
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.client_not_found",
+            :client => sec_serv_user))
+    end
+
     # Client cannot be a subsystem
     if client.subsystem_code != nil
       raise InvalidOwnerChangeRequestException.new(
@@ -112,6 +124,17 @@ class OwnerChangeRequest < RequestWithProcessing
             :user => sec_serv_user,
             :security_server => security_server))
 
+    end
+
+    # Check that server with the new server id does not exist yet
+    existing_server = SecurityServer.find_server(
+      server.server_code, client.member_code, client.member_class.code)
+
+    if existing_server
+      raise I18n.t("validation.securitserver_exists",
+        :member_class => client.member_class.code,
+        :member_code => client.member_code,
+        :server_code => server.server_code)
     end
   end
 

--- a/src/center-common/app/models/owner_change_request.rb
+++ b/src/center-common/app/models/owner_change_request.rb
@@ -1,0 +1,122 @@
+#
+# The MIT License
+# Copyright (c) 2018 Estonian Information System Authority (RIA),
+# Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+# Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Request for adding client to a security server.
+# Fields: security_server, sec_serv_user, origin
+# Usage:
+# OwnerChangeRequest.new(
+#     :security_server => serverId,
+#     :sec_serv_user => clientId,
+#     :origin => origin).register()
+class OwnerChangeRequest < RequestWithProcessing
+  before_create do |rec|
+    Request.set_server_owner_name(rec)
+    Request.set_server_user_name(rec)
+  end
+
+  def self.find_by_server_and_client(server_id, client_id,
+      processing_status = nil)
+    Request.find_by_server_and_client(OwnerChangeRequest, server_id, client_id,
+        processing_status)
+  end
+
+  # Revokes owner change request with specific database id. Raises error if not
+  # found.
+  def self.revoke(request_id)
+    owner_change_request = OwnerChangeRequest.find(request_id)
+
+    unless owner_change_request
+      raise "No owner change request with id '#{request_id}'"
+    end
+
+    if !reg_request.can_revoke?
+      raise "Cannot revoke owner change request "\
+        "in state '#{owner_change_request.request_processing.status}' and with origin "\
+        "'#{owner_change_request.origin}'"
+    end
+
+  end
+
+  def find_processing
+    OwnerChangeRequestProcessing.find_by_server_and_client(
+        security_server, sec_serv_user)
+  end
+
+  def new_processing
+    OwnerChangeRequestProcessing.new
+  end
+
+  def verify_request()
+    if from_center?
+      require_client(security_server.owner_id)
+      require_security_server(security_server)
+    end
+
+    verify_against_submitted_requests()
+    verify_new_owner()
+  end
+
+  def verify_against_submitted_requests()
+    processings = OwnerChangeRequest.find_by_server_and_client(
+        security_server, sec_serv_user,
+        RequestProcessing::SUBMITTED_FOR_APPROVAL)
+    if processings != nil and not processings.empty?
+      previous_request = processings.first
+
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.duplicate_owner_change_requests",
+            :user => sec_serv_user,
+            :security_server => security_server,
+            :received => previous_request.created_at,
+            :id => previous_request.id))
+    end
+  end
+
+  def verify_new_owner
+    server = SecurityServer.find_server_by_id(security_server)
+    client = SecurityServerClient.find_by_id(sec_serv_user)
+
+    # Client cannot be a subsystem
+    if client.subsystem_code != nil
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.must_be_member",
+            :user => sec_serv_user))
+    end
+
+    # Client cannot be the current owner of the security server
+    if server.get_server_id.matches_client_id(sec_serv_user)
+      raise InvalidOwnerChangeRequestException.new(
+          I18n.t("requests.already_owner",
+            :user => sec_serv_user,
+            :security_server => security_server))
+
+    end
+  end
+
+  def get_revoking_request_id
+    nil
+  end
+
+end

--- a/src/center-common/app/models/owner_change_request_processing.rb
+++ b/src/center-common/app/models/owner_change_request_processing.rb
@@ -1,0 +1,78 @@
+#
+# The MIT License
+# Copyright (c) 2018 Estonian Information System Authority (RIA),
+# Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+# Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Processing info for changing the owner of a security server.
+class OwnerChangeRequestProcessing < RequestProcessing
+  def self.find_by_server_and_client(server_id, client_id)
+    requests = OwnerChangeRequest.find_by_server_and_client(server_id, client_id)
+
+    return processing_from_requests(requests)
+  end
+
+  def execute(request)
+    server_id = request.security_server
+
+    # Find the security server
+    server = SecurityServer.find_server_by_id(server_id)
+    if server == nil
+      raise I18n.t("requests.server_not_found",
+                  :server => request.security_server.to_s)
+    end
+
+    # Find the current owner.
+    owner_id = request.security_server.owner_id
+    owner = XRoadMember.find_by_id(owner_id)
+    if owner == nil
+      raise I18n.t("requests.client_not_found",
+          :client => owner_id.to_s)
+    end
+
+    # Find the new owner.
+    client = SecurityServerClient.find_by_id(request.sec_serv_user)
+    if client == nil
+      raise I18n.t("requests.client_not_found",
+          :client => request.sec_serv_user.to_s)
+    end
+
+    # Remove new owner from security server clients
+    client.security_servers.delete(server)
+
+    # Update security server owner
+    SecurityServer.update_owner(server_id, client)
+
+    # Add current owner as security server client
+    owner.security_servers << server
+
+    # Update Security Server Owners global group
+    owners_group = GlobalGroup.security_server_owners_group
+    if owners_group != nil
+      # New owner must be added as a member
+      owners_group.add_member(request.sec_serv_user)
+      # The current owner must be removed if this was its only server
+      owners_group.remove_member(owner_id) if owner.owned_servers.size == 0
+    end
+
+  end
+end

--- a/src/center-common/app/models/security_server.rb
+++ b/src/center-common/app/models/security_server.rb
@@ -39,7 +39,7 @@ class SecurityServer < ActiveRecord::Base
         SecurityServer.find_server(server_code, member_code, member_class_code)
 
       if potentially_existing_server
-        raise I18n.t("validation.securitserver_exists",
+        raise I18n.t("requests.server_code_exists",
                   :member_class => member_class.code,
                   :member_code => member_code,
                   :server_code => server_code)

--- a/src/center-common/app/models/security_server.rb
+++ b/src/center-common/app/models/security_server.rb
@@ -124,6 +124,11 @@ class SecurityServer < ActiveRecord::Base
     return get_search_relation(searchable).count
   end
 
+  def self.update_owner(server_id, owner)
+    server = SecurityServer.find_server_by_id(server_id)
+    server.update_attributes!(:owner => owner)
+  end
+
   # Server is hash including keys :member_class, :member_code and :server_code.
   def self.get_management_requests(server, query_params)
     return get_management_requests_relation(server).

--- a/src/center-common/config/locales/en.yml
+++ b/src/center-common/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
     duplicate_owner_change_requests: "A request for registering '%{user}', as the owner of the security server '%{security_server}' has already been submitted (%{received}, request ID: '%{id}')"
     must_be_member: "'%{user}' is a subsystem. New owner must be a member"
     already_owner: "'%{user}' is already the owner of the security server '%{security_server}'"
+    server_code_exists: "Member '%{member_class} : %{member_code}' already owns a security server with server code '%{server_code}'"
 
   errors:
     format: "%{message}"

--- a/src/center-common/config/locales/en.yml
+++ b/src/center-common/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
     client_not_found: "Client not found: %{client}"
     request_with_same_cert_already_exists: "Certificate is already submitted for registration with request '%{id}'"
     security_server_exists: "Certificate is already registered, request id '%{id}"
+    duplicate_owner_change_requests: "A request for registering '%{user}', as the owner of the security server '%{security_server}' has already been submitted (%{received}, request ID: '%{id}')"
+    must_be_member: "'%{user}' is a subsystem. New owner must be a member"
+    already_owner: "'%{user}' is already the owner of the security server '%{security_server}'"
 
   errors:
     format: "%{message}"

--- a/src/center-common/config/locales/en.yml
+++ b/src/center-common/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
     must_be_member: "'%{user}' is a subsystem. New owner must be a member"
     already_owner: "'%{user}' is already the owner of the security server '%{security_server}'"
     server_code_exists: "Member '%{member_class} : %{member_code}' already owns a security server with server code '%{server_code}'"
+    not_registered_client: "'%{user}' is not registered as a client on the security server '%{security_server}'"
 
   errors:
     format: "%{message}"

--- a/src/center-service/app/controllers/registration_management_controller.rb
+++ b/src/center-service/app/controllers/registration_management_controller.rb
@@ -49,6 +49,8 @@ class RegistrationManagementController < ManagementRequestController
                 handle_client_registration
             when ManagementRequests::CLIENT_DELETION
                 handle_client_deletion
+            when ManagementRequests::OWNER_CHANGE
+                handle_owner_change
             else
                 raise "Unknown service code '#{service}'"
         end
@@ -141,6 +143,10 @@ class RegistrationManagementController < ManagementRequestController
             :origin => Request::SECURITY_SERVER)
         req.register()
         req.id
+    end
+
+    def handle_owner_change
+      id = 123
     end
 
     def auto_approve_client_reg_requests?

--- a/src/center-service/src/main/java/ee/ria/xroad/common/request/ManagementRequestParser.java
+++ b/src/center-service/src/main/java/ee/ria/xroad/common/request/ManagementRequestParser.java
@@ -38,6 +38,7 @@ import static ee.ria.xroad.common.request.ManagementRequests.AUTH_CERT_DELETION;
 import static ee.ria.xroad.common.request.ManagementRequests.AUTH_CERT_REG;
 import static ee.ria.xroad.common.request.ManagementRequests.CLIENT_DELETION;
 import static ee.ria.xroad.common.request.ManagementRequests.CLIENT_REG;
+import static ee.ria.xroad.common.request.ManagementRequests.OWNER_CHANGE;
 
 /**
  * Parser for management requests.
@@ -93,6 +94,29 @@ public final class ManagementRequestParser {
     public static ClientRequestType parseClientDeletionRequest(
             SoapMessageImpl message) throws Exception {
         return parse(message, CLIENT_DELETION);
+    }
+
+    /**
+     * Parses a client registration request.
+     * @param message the request SOAP message
+     * @return the client registration request
+     * @throws Exception in case of any errors
+     */
+    public static ClientRequestType parseOwnerChangeRequest(SoapMessageImpl message)
+            throws Exception {
+        return parse(message, OWNER_CHANGE);
+    }
+
+    /**
+     * Parses a management request with the given name.
+     * @param message the request SOAP message
+     * @param managementRequestName name of the management request
+     * @return the management request
+     * @throws Exception in case of any errors
+     */
+    public static ClientRequestType parseRequest(SoapMessageImpl message, String managementRequestName)
+            throws Exception {
+        return parse(message, managementRequestName);
     }
 
     // -- Private helper methods ----------------------------------------------

--- a/src/center-ui/app/controllers/requests_controller.rb
+++ b/src/center-ui/app/controllers/requests_controller.rb
@@ -142,6 +142,17 @@ class RequestsController < ApplicationController
     render_json(get_client_data(request))
   end
 
+  def get_owner_change_request_data
+    authorize!(:view_management_request_details)
+
+    validate_params({
+      :id => [:required]
+    })
+
+    request = OwnerChangeRequest.find(params[:id])
+    render_json(get_client_data(request))
+  end
+
   # -- Specific GET methods - end ---
 
   # -- Specific POST methods - start ---
@@ -227,6 +238,45 @@ class RequestsController < ApplicationController
     render_json
   end
 
+  def approve_owner_change_request
+    audit_log("Approve owner change request", audit_log_data = {})
+
+    authorize!(:view_management_request_details)
+
+    validate_params({
+      :requestId => [:required]
+    })
+
+    audit_log_data[:requestId] = params[:requestId]
+
+    request_id = params[:requestId]
+    RequestWithProcessing.approve(request_id)
+
+    notice(t("requests.request_approved",
+        {:id => request_id}))
+
+    render_json
+  end
+
+  def decline_owner_change_request
+    audit_log("Decline owner change request", audit_log_data = {})
+
+    authorize!(:view_management_request_details)
+
+    validate_params({
+      :requestId => [:required]
+    })
+
+    audit_log_data[:requestId] = params[:requestId]
+
+    request_id = params[:requestId]
+    RequestWithProcessing.decline(request_id)
+
+    notice(t("requests.request_declined",
+        {:id => request_id}))
+
+    render_json
+  end
   # -- Specific POST methods - end ---
 
   private

--- a/src/center-ui/app/views/requests/index.html.erb
+++ b/src/center-ui/app/views/requests/index.html.erb
@@ -49,4 +49,5 @@
   <%= render :partial => "shared/client_reg_request_edit_dialog" %>
   <%= render :partial => "shared/auth_cert_deletion_request_edit_dialog" %>
   <%= render :partial => "shared/client_deletion_request_edit_dialog" %>
+  <%= render :partial => "shared/owner_change_request_edit_dialog" %>
 <% end %>

--- a/src/center-ui/app/views/shared/_member_edit_dialog.html.erb
+++ b/src/center-ui/app/views/shared/_member_edit_dialog.html.erb
@@ -158,3 +158,4 @@
 <%= render :partial => "shared/client_reg_request_edit_dialog" %>
 <%= render :partial => "shared/client_deletion_request_edit_dialog" %>
 <%= render :partial => "shared/securityserver_client_remove_dialog" %>
+<%= render :partial => "shared/owner_change_request_edit_dialog" %>

--- a/src/center-ui/app/views/shared/_owner_change_request_edit_dialog.html.erb
+++ b/src/center-ui/app/views/shared/_owner_change_request_edit_dialog.html.erb
@@ -1,0 +1,7 @@
+<%= dialog "owner_change_request_edit_dialog", t("management_requests.details.owner_change.title") do %>
+  <%= render :partial => "shared/common_details" %>
+  <section class="container">
+    <h2><span><%= t 'management_requests.details.owner_change.legend' %></span></h2>
+    <%= render :partial => "shared/client_details" %>
+  </section>
+<% end %>

--- a/src/center-ui/config/locales/views_en.yml
+++ b/src/center-ui/config/locales/views_en.yml
@@ -124,6 +124,7 @@ en:
     client_reg: "Client registration"
     auth_cert_deletion: "Certificate deletion"
     client_deletion: "Client deletion"
+    owner_change: "Owner change"
     source: "Source"
     source_center: "X-Road center"
     source_security_server: "Security server"
@@ -148,6 +149,9 @@ en:
       client_reg:
         title: "Security Server Client Registration Request Details"
         legend: "Client Submitted for Registration"
+      owner_change:
+          title: "Security Server Owner Change Request Details"
+          legend: "New Owner Submitted for Registration"
       approve_confirm: "Are you sure you want to approve request?"
       revoke_confirm: "Are you sure you want to revoke request?"
       decline_confirm: "Are you sure you want to decline request?"

--- a/src/center-ui/public/javascripts/centerui_common.js
+++ b/src/center-ui/public/javascripts/centerui_common.js
@@ -76,6 +76,8 @@ var XROAD_CENTERUI_COMMON = function() {
             return _("management_requests.auth_cert_deletion");
         case 'ClientDeletionRequest':
             return _("management_requests.client_deletion");
+        case 'OwnerChangeRequest':
+            return _("management_requests.owner_change");
         default:
             alert("Type '" + rawRequestType + "'is not supported");
         break;

--- a/src/center-ui/public/javascripts/request_edit.js
+++ b/src/center-ui/public/javascripts/request_edit.js
@@ -96,6 +96,14 @@ var XROAD_REQUEST_EDIT = function(){
                 fillClientData(response.data);
             }, "json");
             break;
+        case 'OwnerChangeRequest':
+            $.get("requests/get_owner_change_request_data", params,
+                    function(response) {
+                openRequestEditDialog(
+                    $("#owner_change_request_edit_dialog"));
+                fillClientData(response.data);
+            }, "json");
+            break;
         default:
             // Should not reach this point!
             alert("Type '" + requestData.type + "'is not supported");
@@ -211,6 +219,18 @@ var XROAD_REQUEST_EDIT = function(){
 
     function declineRegRequest(dialog) {
         handleManagementRequestDialogAction(
+            "decline_owner_change_request", dialog,
+            "management_requests.details.decline_confirm");
+    }
+
+    function approveOwnerChangeRequest(dialog) {
+        handleManagementRequestDialogAction(
+            "approve_owner_change_request", dialog,
+            "management_requests.details.approve_confirm");
+    }
+
+    function declineOwnerChangeRequest(dialog) {
+        handleManagementRequestDialogAction(
             "decline_reg_request", dialog,
             "management_requests.details.decline_confirm");
     }
@@ -236,6 +256,7 @@ var XROAD_REQUEST_EDIT = function(){
         initClientRegRequestEditDialog();
         initAuthCertDeletionRequestEditDialog();
         initClientDeletionRequestEditDialog();
+        initOwnerChangeRequestEditDialog();
     }
 
     function initAuthCertRegRequestEditDialog() {
@@ -341,6 +362,35 @@ var XROAD_REQUEST_EDIT = function(){
               }]
         });
     }
+
+    function initOwnerChangeRequestEditDialog() {
+        $("#owner_change_request_edit_dialog").initDialog({
+            autoOpen: false,
+            modal: true,
+            height: "auto",
+            width: 600,
+            minWidth: 500,
+            buttons: [
+              { text: _("common.approve"),
+                  class: "reg_request_post_submit",
+                  click: function() {
+                      approveOwnerChangeRequest($(this));
+                  }
+              },
+              { text: _("common.decline"),
+                  class: "reg_request_post_submit",
+                  click: function() {
+                      declineOwnerChangeRequest($(this));
+                  }
+              },
+              { text: _("common.close"),
+                  class: "right",
+                  click: function() {
+                      $(this).dialog("close");
+                  }
+              }]
+        });
+    }
     /* -- DIALOGS - END -- */
     function initTestability() {
         // add data-name attributes to improve testability
@@ -348,6 +398,7 @@ var XROAD_REQUEST_EDIT = function(){
         $("#client_reg_request_edit_dialog").parent().attr("data-name", "client_reg_request_edit_dialog");
         $("#auth_cert_deletion_request_edit_dialog").parent().attr("data-name", "auth_cert_deletion_request_edit_dialog");
         $("#client_deletion_request_edit_dialog").parent().attr("data-name", "client_deletion_request_edit_dialog");
+        $("#owner_change_request_edit_dialog").parent().attr("data-name", "owner_change_request_edit_dialog");
         $("button span:contains('Close')").parent().attr("data-name", "close");
         $("button span:contains('Cancel')").parent().attr("data-name", "cancel");
         $("button span:contains('OK')").parent().attr("data-name", "ok");

--- a/src/center-ui/public/javascripts/requests.js
+++ b/src/center-ui/public/javascripts/requests.js
@@ -50,6 +50,9 @@ var XROAD_REQUESTS = function() {
         mapTranslationToDbValue(
                 getTranslatedRequestType('ClientDeletionRequest'),
                 'ClientDeletionRequest');
+        mapTranslationToDbValue(
+                getTranslatedRequestType('OwnerChangeRequest'),
+                'OwnerChangeRequest');
     }
 
     /**

--- a/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -249,6 +249,8 @@ public final class SystemProperties {
 
     private static final String DEFAULT_CENTER_AUTO_APPROVE_CLIENT_REG_REQUESTS = "false";
 
+    private static final String DEFAULT_CENTER_AUTO_APPROVE_OWNER_CHANGE_REQUESTS = "false";
+
     private static final String DEFAULT_SERVERPROXY_CONNECTOR_MAX_IDLE_TIME = "0";
 
     private static final String DEFAULT_PROXY_CONNECTOR_INITIAL_IDLE_TIME = "30000";
@@ -431,6 +433,10 @@ public final class SystemProperties {
     /** Property name of enabling automatic approval of client registration requests. */
     public static final String CENTER_AUTO_APPROVE_CLIENT_REG_REQUESTS =
             PREFIX + "center.auto-approve-client-reg-requests";
+
+    /** Property name of enabling automatic approval of owner change requests. */
+    public static final String CENTER_AUTO_APPROVE_OWNER_CHANGE_REQUESTS =
+            PREFIX + "center.auto-approve-owner-change-requests";
 
     // Misc -------------------------------------------------------------------
 
@@ -983,6 +989,14 @@ public final class SystemProperties {
     public static boolean getCenterAutoApproveClientRegRequests() {
         return Boolean.parseBoolean(System.getProperty(CENTER_AUTO_APPROVE_CLIENT_REG_REQUESTS,
                 DEFAULT_CENTER_AUTO_APPROVE_CLIENT_REG_REQUESTS));
+    }
+
+    /**
+     * @return whether automatic approval of owner change requests is enabled, 'false' by default.
+     */
+    public static boolean getCenterAutoApproveOwnerChangeRequests() {
+        return Boolean.parseBoolean(System.getProperty(CENTER_AUTO_APPROVE_OWNER_CHANGE_REQUESTS,
+                DEFAULT_CENTER_AUTO_APPROVE_OWNER_CHANGE_REQUESTS));
     }
 
     /**

--- a/src/common-util/src/main/java/ee/ria/xroad/common/request/ManagementRequests.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/request/ManagementRequests.java
@@ -41,4 +41,6 @@ public final class ManagementRequests {
 
     public static final String CLIENT_DELETION = "clientDeletion";
 
+    public static final String OWNER_CHANGE = "ownerChange";
+
 }

--- a/src/common-util/src/main/resources/request.xsd
+++ b/src/common-util/src/main/resources/request.xsd
@@ -9,6 +9,7 @@
     <element name="authCertDeletion" type="tns:AuthCertDeletionRequestType"/>
     <element name="clientReg" type="tns:ClientRequestType"/>
     <element name="clientDeletion" type="tns:ClientRequestType"/>
+    <element name="ownerChange" type="tns:ClientRequestType"/>
 
     <complexType name="AuthCertRegRequestType">
         <sequence>

--- a/src/packages/src/xroad/default-configuration/managementservices.wsdl
+++ b/src/packages/src/xroad/default-configuration/managementservices.wsdl
@@ -138,6 +138,8 @@
             <xsd:element name="authCertRegResponse" type="tns:AuthCertRegRequestType"/>
             <xsd:element name="authCertDeletion" type="tns:AuthCertDeletionRequestType"/>
             <xsd:element name="authCertDeletionResponse" type="tns:AuthCertDeletionRequestType"/>
+            <xsd:element name="ownerChange" type="tns:ClientRequestType"/>
+            <xsd:element name="ownerChangeResponse" type="tns:ClientRequestType"/>
             <!-- Header fields -->
             <xsd:element name="client" type="id:XRoadClientIdentifierType"/>
             <xsd:element name="service" type="id:XRoadServiceIdentifierType"/>
@@ -259,6 +261,12 @@
     <wsdl:message name="authCertDeletionResponse">
         <wsdl:part element="xroad:authCertDeletionResponse" name="parameters"/>
     </wsdl:message>
+    <wsdl:message name="ownerChange">
+        <wsdl:part element="xroad:ownerChange" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ownerChangeResponse">
+        <wsdl:part element="xroad:ownerChangeResponse" name="parameters"/>
+    </wsdl:message>
     <wsdl:portType name="centralservice">
         <wsdl:operation name="clientReg">
             <wsdl:input message="tns:clientReg"/>
@@ -271,6 +279,10 @@
         <wsdl:operation name="authCertDeletion">
             <wsdl:input message="tns:authCertDeletion"/>
             <wsdl:output message="tns:authCertDeletionResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="ownerChange">
+            <wsdl:input message="tns:ownerChange"/>
+            <wsdl:output message="tns:ownerChangeResponse"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="centralserviceSOAP" type="tns:centralservice">
@@ -312,6 +324,24 @@
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="authCertDeletion">
+            <soap:operation soapAction=""/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestheader" part="client" use="literal"/>
+                <soap:header message="tns:requestheader" part="service" use="literal"/>
+                <soap:header message="tns:requestheader" part="id" use="literal"/>
+                <soap:header message="tns:requestheader" part="protocolVersion" use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestheader" part="client" use="literal"/>
+                <soap:header message="tns:requestheader" part="service" use="literal"/>
+                <soap:header message="tns:requestheader" part="id" use="literal"/>
+                <soap:header message="tns:requestheader" part="protocolVersion" use="literal"/>
+                <soap:header message="tns:requestheader" part="requestHash" use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ownerChange">
             <soap:operation soapAction=""/>
             <wsdl:input>
                 <soap:body use="literal"/>


### PR DESCRIPTION
Implement Security Server `ownerChange` management service:

- Add `ownerChange` management service.
- Update CS UI so that requests can be approved / declined.
  - UI does not provide features for creating `ownerChange` requests manually - a complementary request is created automatically from a request from Security Server is received.
- Implement automatic approval of `ownerChange` management requests.
- Update documentation.
- Update `managementservices.wsdl ` and  `request.xsd`