### PR TITLE
WIP XRDDEV-580

### DIFF
--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -234,7 +234,7 @@ Upon the first installation of the packages, the system asks for the following i
 
             IP:1.2.3.4,IP:4.3.2.1,DNS:servername,DNS:servername2.domain.tld
 
-The meta-package `xroad-securityserver` also installs metaservices module `xroad-addon-metaservices`, messagelog module `xroad-addon-messagelog` and WSDL validator module `xroad-addon-wsdlvalidator`. The meta-package `xroad-securityserver-ee` installs operational data monitoring module `xroad-addon-opmonitoring`.
+The meta-package `xroad-securityserver` also installs metaservices module `xroad-addon-metaservices`, messagelog module `xroad-addon-messagelog` and WSDL validator module `xroad-addon-wsdlvalidator`. Both meta-packages `xroad-securityserver-ee` and `xroad-securityserver-fi` install operational data monitoring module `xroad-addon-opmonitoring`.
 
 
 ### 2.6 Post-Installation Checks

--- a/src/packages/src/xroad/redhat/SPECS/xroad-securityserver-fi.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-securityserver-fi.spec
@@ -9,7 +9,7 @@ Summary:            X-Road security server with Finnish settings
 BuildArch:          noarch
 Group:              Applications/Internet
 License:            MIT
-Requires:           xroad-securityserver = %version-%release
+Requires:           xroad-securityserver = %version-%release, xroad-addon-opmonitoring = %version-%release
 Conflicts:          xroad-centralserver
 
 %define src %{_topdir}/..

--- a/src/packages/src/xroad/ubuntu/generic/control
+++ b/src/packages/src/xroad/ubuntu/generic/control
@@ -136,7 +136,7 @@ Description: X-Road central cluster scripts
 Package: xroad-securityserver-fi
 Conflicts: xroad-centralserver
 Architecture: all
-Depends: xroad-securityserver (=${binary:Version})
+Depends: xroad-securityserver (=${binary:Version}), xroad-addon-opmonitoring (=${binary:Version})
 Description: X-Road security server with Finnish settings
  This is meta-package of X-Road security server with Finnish settings.
 


### PR DESCRIPTION
- Added xroad-addon-opmonitoring package as required for installation of meta-package of X-Road security server with Finnish settings, xroad-securityserver-fi.
- Updated security server installation instructions to indicate that xroad-securityserver-fi meta-package installs xroad-addon-opmonitoring module.