### PR TITLE
XRDDEV-602 add note about inode exhaustion to tests

### DIFF
--- a/src/common-util/src/test/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunnerTest.java
+++ b/src/common-util/src/test/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunnerTest.java
@@ -44,7 +44,17 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for {@link FileWatcherRunner}
+ * Tests for {@link FileWatcherRunner}.
+ *
+ * If the tests fail, you could be experiencing inode watch exhaustion.
+ * This would show up as errors in the log such as:
+ * <pre>
+ * 11:49:24.920 [pool-1-thread-1] ERROR e.r.x.c.util.filewatcher.FileWatcher -
+ * Stopped watching containing directory: /tmp/junit1947693984851435332 due to an error!
+ * java.io.IOException: User limit of inotify watches reached
+ * </pre>
+ * To fix the problem, increase you OS limit of inode watches
+ * (e.g. <code>max_user_watches</code>)
  */
 public class FileWatcherRunnerTest {
 
@@ -95,6 +105,7 @@ public class FileWatcherRunnerTest {
         Files.move(overridingFile.toPath(), shouldChangeFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         // verify
+        // if listener was not called, check if this was caused by "out of inode watchers" (see class javadoc)
         verify(shouldBeCalledListener, timeout(TIMEOUT)).fileModified();
     }
 
@@ -123,6 +134,7 @@ public class FileWatcherRunnerTest {
         assertTrue("test setup fail: could not change last modified time", changeSucceeded);
 
         // verify
+        // if listener was not called, check if this was caused by "out of inode watchers" (see class javadoc)
         verify(shouldBeCalledListener, timeout(TIMEOUT)).fileModified();
     }
 
@@ -151,6 +163,7 @@ public class FileWatcherRunnerTest {
         Files.delete(shouldChangeFile.toPath());
 
         // verify
+        // if listener was not called, check if this was caused by "out of inode watchers" (see class javadoc)
         verify(shouldBeCalledListener, timeout(TIMEOUT)).fileModified();
     }
 }


### PR DESCRIPTION
Add some javadoc comments hopefully helping someone who runs into the "out of inode watchers" problem and wonders why FileWatcherRunnerTest fails.

https://jenkins.niis.org/job/xroad-pull-request-test/59/ (success)