### PR TITLE
XRDDEV-540

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/xroad-center.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-center.postinst
@@ -59,12 +59,15 @@ case "$1" in
 
     #add groups
     groups="xroad-security-officer xroad-system-administrator xroad-registration-officer"
-    for groupname in $groups
-    do
-      if ! getent group $groupname > /dev/null; then
-        addgroup --system --quiet  $groupname
-      fi
-        adduser $AUSER $groupname
+
+    usergroups=" $(id -Gn "$AUSER") "
+    for groupname in $groups; do
+        if ! getent group "$groupname" > /dev/null; then
+            groupadd --system "$groupname" || true
+        fi
+        if [[ $usergroups != *" $groupname "* ]]; then
+            usermod -a -G "$groupname" "$AUSER" || true
+        fi
     done
 
     #mkdir -p  /var/lib/xroad/public

--- a/src/packages/src/xroad/ubuntu/generic/xroad-proxy.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-proxy.postinst
@@ -132,12 +132,14 @@ case "$1" in
       groupnames=$groups
   fi
 
-  for groupname in $groupnames
-  do
-      if ! getent group $groupname > /dev/null; then
-          addgroup --system --quiet  $groupname
+  usergroups=" $(id -Gn "$AUSER") "
+  for groupname in $groupnames; do
+      if ! getent group "$groupname" > /dev/null; then
+          groupadd --system "$groupname" || true
       fi
-      adduser $AUSER $groupname
+      if [[ $usergroups != *" $groupname "* ]]; then
+          usermod -a -G "$groupname" "$AUSER" || true
+      fi
   done
 
   #migrating possible local configuration for modified configuration values (for version 6.17.0)


### PR DESCRIPTION
Check if the X-Road admin user already belongs to a group.
Do not fail installation if modifying X-Road admin user groups fails.