### PR TITLE
Added Icelandic is_IS.UTF-8 locale support ansible task ubuntu.yml

### DIFF
--- a/ansible/roles/xroad-base/tasks/ubuntu.yml
+++ b/ansible/roles/xroad-base/tasks/ubuntu.yml
@@ -59,6 +59,7 @@
   with_items:
     - "fi_FI.UTF-8 UTF-8"
     - "en_US.UTF-8 UTF-8"
+    - "is_IS.UTF-8 UTF-8"
 
 - name: generate locales
   command: "/usr/sbin/locale-gen"


### PR DESCRIPTION
As a system administrator I would like to be able to log into a ubuntu machine with my LC_LANG* variables set without getting locale errors when my language is set to is_IS.UTF-8. That can be fixed by adding is_IS.UTF-8 as one of the pre-generated locales on the ubuntu machines.  This is achieved by adding support for the locale to ansible/roles/xroad-base/tasks/ubuntu.yml 