### PR TITLE
Update nginx configuration

### DIFF
--- a/src/packages/src/xroad/common/center/etc/xroad/nginx/insecure-xroad-center.conf
+++ b/src/packages/src/xroad/common/center/etc/xroad/nginx/insecure-xroad-center.conf
@@ -2,7 +2,7 @@ server {
     listen 4400;
 
     location / {
-        proxy_pass http://localhost:8084;
-        proxy_set_header Host $host:$server_port;
+        proxy_pass http://127.0.0.1:8084;
+        proxy_set_header Host $http_host;
     }
 }

--- a/src/packages/src/xroad/common/center/etc/xroad/nginx/xroad-center.conf
+++ b/src/packages/src/xroad/common/center/etc/xroad/nginx/xroad-center.conf
@@ -1,6 +1,5 @@
 server {
-    listen 4001;
-    ssl on;
+    listen 4001 ssl;
     ssl_certificate /etc/xroad/ssl/internal.crt;
     ssl_certificate_key /etc/xroad/ssl/internal.key;
 
@@ -23,15 +22,14 @@ server {
         limit_except POST {
             deny all;
         }
-        proxy_pass http://localhost:8084;
-        proxy_set_header Host $host:$server_port;
+        proxy_pass http://127.0.0.1:8084;
+        proxy_set_header Host $http_host;
         proxy_redirect http:// https://;
     }
 }
 
 server {
-    listen 4002;
-    ssl on;
+    listen 4002 ssl;
     ssl_certificate /etc/xroad/ssl/internal.crt;
     ssl_certificate_key /etc/xroad/ssl/internal.key;
 
@@ -54,8 +52,8 @@ server {
         limit_except POST {
             deny all;
         }
-        proxy_pass http://localhost:8084;
-        proxy_set_header Host $host:$server_port;
+        proxy_pass http://127.0.0.1:8084;
+        proxy_set_header Host $http_host;
         proxy_redirect http:// https://;
     }
 }

--- a/src/packages/src/xroad/common/nginx/etc/xroad/nginx/default-xroad.conf
+++ b/src/packages/src/xroad/common/nginx/etc/xroad/nginx/default-xroad.conf
@@ -1,6 +1,5 @@
 server {
-        listen 4000;
-        ssl on;
+        listen 4000 ssl;
         ssl_certificate /etc/xroad/ssl/nginx.crt;
         ssl_certificate_key /etc/xroad/ssl/nginx.key;
 
@@ -19,8 +18,8 @@ server {
         keepalive_timeout    60;
 
         location / {
-                proxy_pass http://localhost:8083;
-                proxy_set_header Host $host:$server_port;
+                proxy_pass http://127.0.0.1:8083;
+                proxy_set_header Host $http_host;
                 proxy_redirect http:// https://;
                 proxy_read_timeout 600s;
         }


### PR DESCRIPTION
* remove usage of deprecated "ssl on" directive
* use 127.0.0.1 instead of "localhost" in proxy_pass
* pass http_host; fixes cannot access admin gui via a redirected port