### PR TITLE
XRDDEV-692: Update jackson-databind

### DIFF
--- a/src/common-util/build.gradle
+++ b/src/common-util/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile "com.typesafe.akka:akka-remote_2.11:$akkaVersion"
     compile "com.typesafe.akka:akka-slf4j_2.11:$akkaVersion"
 
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9.3'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'com.google.guava:guava:28.0-jre'
 


### PR DESCRIPTION
Update jackson-databind to version 2.9.10; fixes two known
vulnerabilities in jackson-databind.