### PR TITLE
XRDDEV-730: Validate security server addresses

### DIFF
--- a/src/center-ui/app/controllers/securityservers_controller.rb
+++ b/src/center-ui/app/controllers/securityservers_controller.rb
@@ -254,7 +254,7 @@ class SecurityserversController < ApplicationController
       :serverCode => [:required],
       :ownerCode => [:required],
       :ownerClass => [:required],
-      :address => [:required]
+      :address => [:required, :host]
     })
 
     audit_log_data[:serverCode] = params[:serverCode]

--- a/src/center-ui/app/helpers/cert_transformation_helper.rb
+++ b/src/center-ui/app/helpers/cert_transformation_helper.rb
@@ -91,7 +91,7 @@ module CertTransformationHelper
       return nil
     end
 
-    id = cert_id.is_a?(Integer) ? cert_id :cert_id.to_i
+    id = cert_id.is_a?(Integer) ? cert_id : cert_id.to_i
 
     result = session[:temp_certs][id]
 

--- a/src/center-ui/public/javascripts/securityserver_edit.js
+++ b/src/center-ui/public/javascripts/securityserver_edit.js
@@ -352,7 +352,7 @@ var XROAD_SECURITYSERVER_EDIT = function() {
 
     function editAddress(dialog) {
         var params = getEditableServerId();
-        params.address = $("#securityserver_edit_address_new").val();
+        params.address = $.trim($("#securityserver_edit_address_new").val());
 
         $.post("securityservers/address_edit", params, function(response) {
             $("#securityserver_edit_address").text(response.data.address);

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
@@ -69,7 +69,6 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.Writer;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -86,7 +85,6 @@ import static ee.ria.xroad.common.ErrorCodes.X_MISSING_SIGNATURE;
 import static ee.ria.xroad.common.ErrorCodes.X_MISSING_SOAP;
 import static ee.ria.xroad.common.ErrorCodes.X_SERVICE_FAILED_X;
 import static ee.ria.xroad.common.ErrorCodes.translateException;
-import static ee.ria.xroad.common.SystemProperties.getServerProxyPort;
 import static ee.ria.xroad.common.SystemProperties.isSslEnabled;
 import static ee.ria.xroad.common.util.AbstractHttpSender.CHUNKED_LENGTH;
 import static ee.ria.xroad.common.util.CryptoUtils.decodeBase64;
@@ -266,25 +264,6 @@ class ClientMessageProcessor extends AbstractClientMessageProcessor {
             if (reqIns != null) {
                 reqIns.close();
             }
-        }
-    }
-
-    private static URI getServiceAddress(URI[] addresses) {
-        if (addresses.length == 1 || !isSslEnabled()) {
-            return addresses[0];
-        }
-        //postpone actual name resolution to the fastest connection selector
-        return DUMMY_SERVICE_ADDRESS;
-    }
-
-    private static final URI DUMMY_SERVICE_ADDRESS;
-
-    static {
-        try {
-            DUMMY_SERVICE_ADDRESS = new URI("https", null, "localhost", getServerProxyPort(), "/", null, null);
-        } catch (URISyntaxException e) {
-            //can not happen
-            throw new IllegalStateException("Unexpected", e);
         }
     }
 

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
@@ -180,13 +180,12 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
         try {
             final String contentType = MimeUtils.mpMixedContentType("xtop" + RandomStringUtils.randomAlphabetic(30));
             opMonitoringData.setRequestOutTs(getEpochMillisecond());
-            httpSender.doPost(addresses[0], new ProxyMessageEntity(contentType));
+            httpSender.doPost(getServiceAddress(addresses), new ProxyMessageEntity(contentType));
             opMonitoringData.setResponseInTs(getEpochMillisecond());
         } catch (Exception e) {
             MonitorAgent.serverProxyFailed(createRequestMessageInfo());
             throw e;
         }
-
     }
 
     private void parseResponse(HttpSender httpSender) throws Exception {

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxy.java
@@ -54,7 +54,7 @@ public class SslSelectFastestProxy extends SslMessageTestCase {
         GlobalConf.reload(new TestSuiteGlobalConf() {
             @Override
             public Collection<String> getProviderAddress(ClientId provider) {
-                return Arrays.asList("127.0.0.42", "localhost", "server.invalid");
+                return Arrays.asList("127.0.0.42", "localhost", "server.invalid.", "127.0.0,1");
             }
         });
     }

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxyNoConnections.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxyNoConnections.java
@@ -56,7 +56,7 @@ public class SslSelectFastestProxyNoConnections extends SslMessageTestCase {
         GlobalConf.reload(new TestSuiteGlobalConf() {
             @Override
             public Collection<String> getProviderAddress(ClientId provider) {
-                return Arrays.asList("foo.invalid.", "bar.invalid.", "baz.invalid.");
+                return Arrays.asList("foo.invalid.", "bar.invalid.", "127.0.0,1");
             }
         });
     }


### PR DESCRIPTION
Reject invalid host names in security server and central server
configuration (fixes also XRDDEV-732).

For additional robustness, fix service provider host selection fails to
select a host if some of the host addresses are syntactically invalid.