### PR TITLE
XRDDEV-724 fix SELinux rhel packages port 5000

### DIFF
--- a/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
+++ b/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
@@ -67,6 +67,11 @@ if [[ $(getenforce) != "Disabled" ]]; then
     semanage port -a -t http_port_t  -p tcp 4000 || true
 
     # allow httpd to connect to non-standard port 5000 (keep this as long as we have the dual old & new UI)
-    semanage port -m -t http_port_t  -p tcp 5000
+    if ! semanage port -m -t http_port_t  -p tcp 5000
+    then
+        echo "could not modify SELinux port 5000, will add instead"
+        semanage port -a -t http_port_t  -p tcp 5000 || true
+    fi
+
 fi
 

--- a/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
+++ b/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
@@ -65,5 +65,8 @@ if [[ $(getenforce) != "Disabled" ]]; then
 
     # allow httpd to connecto to non-standard port 4000
     semanage port -a -t http_port_t  -p tcp 4000 || true
+
+    # allow httpd to connect to non-standard port 5000 (keep this as long as we have the dual old & new UI)
+    semanage port -m -t http_port_t  -p tcp 5000
 fi
 


### PR DESCRIPTION
Enables nginx binding to port 5000 in machines where SELinux is used and port 5000 is associated with "commplex_main_port_t"

jenkins build: https://jenkins.niis.org/view/build/job/xroad-build-packages-pipeline/1137/

packages were installed to dev-rh1 and dev-rh2 (rh1 "vanilla", rh2 had manual semanage modify 5000 done earlier)