### PR TITLE
XRDDEV-591

### DIFF
--- a/src/common-util/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
@@ -49,7 +49,9 @@ public abstract class HandlerBase extends AbstractHandler {
      * @param ex exception that should be converted to a SOAP fault
      * @throws IOException if an I/O error occurred
      */
-    public void sendErrorResponse(HttpServletResponse response, CodedException ex) throws IOException {
+    public void sendErrorResponse(HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  CodedException ex) throws IOException {
         String faultXml = ex instanceof CodedException.Fault
                 ? ((CodedException.Fault) ex).getFaultXml() : SoapFault.createFaultXml(ex);
         String encoding = MimeUtils.UTF8;
@@ -92,6 +94,7 @@ public abstract class HandlerBase extends AbstractHandler {
         }
     }
 
-    protected void failure(HttpServletResponse response, CodedException ex) throws IOException {
+    protected void failure(HttpServletRequest request, HttpServletResponse response, CodedException ex)
+            throws IOException {
     }
 }

--- a/src/common-util/src/main/java/ee/ria/xroad/common/util/XmlUtils.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/util/XmlUtils.java
@@ -70,6 +70,7 @@ public final class XmlUtils {
             "http://xml.org/sax/features/external-parameter-entities";
 
     private static final String ELEMENT_NOT_FOUND_WARNING = "Element not found with getElementXPathNS {}";
+    private static final int DEFAULT_INDENT = 4;
 
     private XmlUtils() {
     }
@@ -242,7 +243,7 @@ public final class XmlUtils {
      * @throws Exception if any errors occur
      */
     public static String prettyPrintXml(Document document) throws Exception {
-        return prettyPrintXml(document, "UTF-8");
+        return prettyPrintXml(document, "UTF-8", DEFAULT_INDENT);
     }
 
     /**
@@ -252,14 +253,17 @@ public final class XmlUtils {
      * @return printed document in String form
      * @throws Exception if any errors occur
      */
-    public static String prettyPrintXml(Document document, String charset) throws Exception {
+    public static String prettyPrintXml(Document document, String charset, int indent) throws Exception {
         StringWriter stringWriter = new StringWriter();
         StreamResult output = new StreamResult(stringWriter);
 
         Transformer transformer = createTransformerFactory().newTransformer();
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty(OutputKeys.ENCODING, charset);
-        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        if (indent > 0) {
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount",
+                    String.format("%d", indent));
+        }
         transformer.transform(new DOMSource(document), output);
 
         return output.getWriter().toString().trim();

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
@@ -109,7 +109,7 @@ class OpMonitorDaemonRequestHandler extends HandlerBase {
         } catch (Throwable t) { // We want to catch serious errors as well
             log.error("Error while handling query request", t);
 
-            sendErrorResponse(response, translateWithPrefix(
+            sendErrorResponse(request, response, translateWithPrefix(
                     SERVER_SERVER_PROXY_OPMONITOR_X, t));
         }
     }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
@@ -113,7 +113,7 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
             // Exceptions caused by incoming message and exceptions derived from faults sent by serverproxy already
             // contain full error code. Thus, we must not attach additional error code prefixes to them.
 
-            failure(processor, response, e, opMonitoringData);
+            failure(processor, request, response, e, opMonitoringData);
         } catch (CodedExceptionWithHttpStatus e) {
             handled = true;
 
@@ -134,7 +134,7 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
 
             updateOpMonitoringSoapFault(opMonitoringData, cex);
 
-            failure(processor, response, cex, opMonitoringData);
+            failure(processor, request, response, cex, opMonitoringData);
         } finally {
             baseRequest.setHandled(handled);
 
@@ -162,15 +162,15 @@ abstract class AbstractClientProxyHandler extends HandlerBase {
         }
     }
 
-    protected void failure(MessageProcessorBase processor, HttpServletResponse response, CodedException e,
-            OpMonitoringData opMonitoringData) throws IOException {
+    protected void failure(MessageProcessorBase processor, HttpServletRequest request, HttpServletResponse response,
+                           CodedException e, OpMonitoringData opMonitoringData) throws IOException {
         MessageInfo info = processor != null ? processor.createRequestMessageInfo() : null;
 
         MonitorAgent.failure(info, e.getFaultCode(), e.getFaultString());
 
         updateOpMonitoringResponseOutTs(opMonitoringData);
 
-        sendErrorResponse(response, e);
+        sendErrorResponse(request, response, e);
     }
 
     protected void failure(HttpServletResponse response, CodedExceptionWithHttpStatus e,

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -37,12 +37,24 @@ import ee.ria.xroad.proxy.util.MessageProcessorBase;
 import com.google.gson.stream.JsonWriter;
 import org.apache.http.client.HttpClient;
 import org.eclipse.jetty.http.HttpStatus;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import static ee.ria.xroad.common.ErrorCodes.X_SSL_AUTH_FAILED;
 
@@ -54,6 +66,8 @@ import static ee.ria.xroad.common.ErrorCodes.X_SSL_AUTH_FAILED;
  */
 class ClientRestMessageHandler extends AbstractClientProxyHandler {
 
+    private String requestAcceptType;
+
     ClientRestMessageHandler(HttpClient client) {
         super(client, true);
     }
@@ -62,7 +76,7 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
     MessageProcessorBase createRequestProcessor(String target,
             HttpServletRequest request, HttpServletResponse response,
             OpMonitoringData opMonitoringData) throws Exception {
-
+        requestAcceptType = request.getHeader("Accept");
         if (target != null && target.startsWith("/r" + RestMessage.PROTOCOL_VERSION + "/")) {
             verifyCanProcess();
             return new ClientRestMessageProcessor(request, response, client,
@@ -92,17 +106,57 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
         } else {
             response.setStatus(HttpStatus.BAD_REQUEST_400);
         }
-        response.setContentType("application/json");
-        response.setCharacterEncoding(MimeUtils.UTF8);
-        response.setHeader("X-Road-Error", ex.getFaultCode());
+        if (requestAcceptType.equalsIgnoreCase("text/xml")
+                || requestAcceptType.equalsIgnoreCase("application/xml")) {
+            response.setContentType(requestAcceptType);
+            response.setCharacterEncoding(MimeUtils.UTF8);
+            response.setHeader("X-Road-Error", ex.getFaultCode());
 
-        final JsonWriter writer = new JsonWriter(new PrintWriter(response.getOutputStream()));
-        writer.beginObject()
-                .name("type").value(ex.getFaultCode())
-                .name("message").value(ex.getFaultString())
-                .name("detail").value(ex.getFaultDetail())
-                .endObject()
-                .close();
+            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+            try {
+                DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+                Document doc = docBuilder.newDocument();
+
+                Element errorRootElement = doc.createElement("error");
+                doc.appendChild(errorRootElement);
+
+                Element typeElement = doc.createElement("type");
+                typeElement.appendChild(doc.createTextNode(ex.getFaultCode()));
+                errorRootElement.appendChild(typeElement);
+
+                Element messageElement = doc.createElement("message");
+                messageElement.appendChild(doc.createTextNode(ex.getFaultString()));
+                errorRootElement.appendChild(messageElement);
+
+                Element detailElement = doc.createElement("detail");
+                detailElement.appendChild(doc.createTextNode(ex.getFaultDetail()));
+                errorRootElement.appendChild(detailElement);
+
+                TransformerFactory tf = TransformerFactory.newInstance();
+                Transformer transformer = tf.newTransformer();
+                StringWriter writer = new StringWriter();
+                transformer.transform(new DOMSource(doc), new StreamResult(writer));
+                String xmlString = writer.getBuffer().toString();
+                response.getOutputStream().write(xmlString.getBytes());
+            } catch (ParserConfigurationException e) {
+                e.printStackTrace();
+            } catch (TransformerConfigurationException e) {
+                e.printStackTrace();
+            } catch (TransformerException e) {
+                e.printStackTrace();
+            }
+        } else {
+            response.setContentType("application/json");
+            response.setCharacterEncoding(MimeUtils.UTF8);
+            response.setHeader("X-Road-Error", ex.getFaultCode());
+
+            final JsonWriter writer = new JsonWriter(new PrintWriter(response.getOutputStream()));
+            writer.beginObject()
+                    .name("type").value(ex.getFaultCode())
+                    .name("message").value(ex.getFaultString())
+                    .name("detail").value(ex.getFaultDetail())
+                    .endObject()
+                    .close();
+        }
     }
-
 }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -49,6 +49,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
@@ -155,12 +156,19 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
     }
 
     private String decideErrorResponseContentType(String acceptHeaderValue) {
-        String[] split = acceptHeaderValue.trim().split("\\s*,\\s*");
-        if (Arrays.stream(split).anyMatch(TEXT_XML::equalsIgnoreCase)) {
+        List<String> allPieces = new ArrayList<>();
+        String[] commaSplit = acceptHeaderValue.trim().split("\\s*,\\s*");
+        for (String s1: commaSplit) {
+            String[] colonSplit = s1.trim().split("\\s*;\\s*");
+            for (String s2: colonSplit) {
+                allPieces.add(s2);
+            }
+        }
+        if (allPieces.stream().anyMatch(TEXT_XML::equalsIgnoreCase)) {
             return TEXT_XML;
-        } else if (Arrays.stream(split).anyMatch(APPLICATION_XML::equalsIgnoreCase)) {
+        } else if (allPieces.stream().anyMatch(APPLICATION_XML::equalsIgnoreCase)) {
             return APPLICATION_XML;
-        } else if (Arrays.stream(split).anyMatch(TEXT_ANY::equalsIgnoreCase)) {
+        } else if (allPieces.stream().anyMatch(TEXT_ANY::equalsIgnoreCase)) {
             return TEXT_XML;
         } else {
             return APPLICATION_JSON;

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -37,6 +37,7 @@ import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
 import com.google.gson.stream.JsonWriter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
 import org.eclipse.jetty.http.HttpStatus;
 import org.w3c.dom.Document;
@@ -103,9 +104,9 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
         }
         response.setCharacterEncoding(MimeUtils.UTF8);
         response.setHeader("X-Road-Error", ex.getFaultCode());
-        if (requestAcceptType.equalsIgnoreCase("text/xml")
-                || requestAcceptType.equalsIgnoreCase("application/xml")) {
-            response.setContentType(requestAcceptType);
+        if (StringUtils.containsIgnoreCase(requestAcceptType, "text/xml")
+                || StringUtils.containsIgnoreCase(requestAcceptType, "application/xml")) {
+            response.setContentType("application/xml");
             DocumentBuilderFactory docFactory = XmlUtils.createDocumentBuilderFactory();
             try {
                 DocumentBuilder docBuilder = docFactory.newDocumentBuilder();

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -157,21 +157,21 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
 
     private String decideErrorResponseContentType(String acceptHeaderValue) {
         List<String> allPieces = new ArrayList<>();
-        String[] commaSplit = acceptHeaderValue.trim().split("\\s*,\\s*");
+        String[] commaSplit = acceptHeaderValue.trim().toLowerCase().split("\\s*,\\s*");
         for (String s1: commaSplit) {
             String[] colonSplit = s1.trim().split("\\s*;\\s*");
             for (String s2: colonSplit) {
                 allPieces.add(s2);
             }
         }
-        if (allPieces.stream().anyMatch(TEXT_XML::equalsIgnoreCase)) {
-            return TEXT_XML;
-        } else if (allPieces.stream().anyMatch(APPLICATION_XML::equalsIgnoreCase)) {
-            return APPLICATION_XML;
-        } else if (allPieces.stream().anyMatch(TEXT_ANY::equalsIgnoreCase)) {
-            return TEXT_XML;
-        } else {
-            return APPLICATION_JSON;
-        }
+        return allPieces.stream()
+                .filter(XML_TYPES::contains)
+                .findAny()
+                .map(orig -> mapTextToXml(orig))
+                .orElse(APPLICATION_JSON);
+    }
+
+    private String mapTextToXml(String orig) {
+        return TEXT_ANY.equals(orig) ? TEXT_XML : orig;
     }
 }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -160,8 +160,8 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
         String[] commaSplit = acceptHeaderValue.trim().toLowerCase().split("\\s*,\\s*");
         for (String s1: commaSplit) {
             String[] colonSplit = s1.trim().split("\\s*;\\s*");
-            for (String s2: colonSplit) {
-                allPieces.add(s2);
+            if (colonSplit.length > 0) {
+                allPieces.add(colonSplit[0]);
             }
         }
         return allPieces.stream()

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
@@ -111,7 +111,7 @@ class ServerProxyHandler extends HandlerBase {
             opMonitoringData.setSoapFault(cex);
             opMonitoringData.setResponseOutTs(getEpochMillisecond(), false);
 
-            failure(response, cex);
+            failure(request, response, cex);
         } finally {
             baseRequest.setHandled(true);
 
@@ -135,10 +135,10 @@ class ServerProxyHandler extends HandlerBase {
     }
 
     @Override
-    protected void failure(HttpServletResponse response, CodedException e) throws IOException {
+    protected void failure(HttpServletRequest request, HttpServletResponse response, CodedException e)
+            throws IOException {
         MonitorAgent.failure(null, e.getFaultCode(), e.getFaultString());
-
-        sendErrorResponse(response, e);
+        sendErrorResponse(request, response, e);
     }
 
     private static void logProxyVersion(HttpServletRequest request) {

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -36,8 +36,6 @@ import ee.ria.xroad.proxy.testutil.TestGlobalConf;
 import ee.ria.xroad.proxy.testutil.TestServerConf;
 import ee.ria.xroad.proxy.testutil.TestService;
 
-import io.restassured.http.Header;
-import io.restassured.http.Headers;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -46,10 +44,8 @@ import javax.servlet.ServletOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
@@ -431,20 +427,6 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .port(proxyClientPort)
                 .header("Content-Type", "application/json")
                 .header("Accept", "text/*")
-                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
-                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
-                .then()
-                .statusCode(Matchers.is(500))
-                .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "text/xml;charset=utf-8");
-
-        given()
-                .baseUri("http://127.0.0.1")
-                .port(proxyClientPort)
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
-                .header("Accept", "application/xml")
-                .header("Accept", "text/xml")
                 .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
                 .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
                 .then()

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -402,13 +402,13 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .baseUri("http://127.0.0.1")
                 .port(proxyClientPort)
                 .header("Content-Type", "application/json")
-                .header("Accept", "application/xml-patch+xml")
+                .header("Accept", "application/xml; q=0.2")
                 .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
                 .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "application/json;charset=utf-8");
+                .header("Content-Type", "application/xml;charset=utf-8");
 
         given()
                 .baseUri("http://127.0.0.1")

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -290,6 +290,79 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .body("value", Matchers.equalTo(42));
     }
 
+    @Test
+    public void shouldRespectAcceptHeaderInErrorResponse() throws IOException {
+
+        ServerConf.reload(new TestServerConf(servicePort) {
+            @Override
+            public DescriptionType getDescriptionType(ServiceId service) {
+                if ("wsdl".equals(service.getServiceCode())) {
+                    return DescriptionType.WSDL;
+                }
+                return DescriptionType.REST;
+            }
+        });
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/json;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "foobarbaz")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/json;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/json;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "text/xml;charset=utf-8");
+    }
+
     private static final TestService.Handler LARGE_OBJECT_HANDLER = (target, request, response) -> {
         response.setStatus(200);
         response.setContentType("application/octet-stream");

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -372,7 +372,7 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "text/xml;charset=utf-8");
+                .header("Content-Type", "application/xml;charset=utf-8");
 
         given()
                 .baseUri("http://127.0.0.1")

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -360,7 +360,31 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "text/xml;charset=utf-8");
+                .header("Content-Type", "application/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/xml, text/xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/xml, application/xml, application/json")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/xml;charset=utf-8");
     }
 
     private static final TestService.Handler LARGE_OBJECT_HANDLER = (target, request, response) -> {

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -36,6 +36,8 @@ import ee.ria.xroad.proxy.testutil.TestGlobalConf;
 import ee.ria.xroad.proxy.testutil.TestServerConf;
 import ee.ria.xroad.proxy.testutil.TestService;
 
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,8 +46,10 @@ import javax.servlet.ServletOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
@@ -360,7 +364,7 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "application/xml;charset=utf-8");
+                .header("Content-Type", "text/xml;charset=utf-8");
 
         given()
                 .baseUri("http://127.0.0.1")
@@ -372,7 +376,43 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "application/xml;charset=utf-8");
+                .header("Content-Type", "text/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/xml, application/xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "text/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/xml-patch+xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/json;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/xml-patch+xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "application/json;charset=utf-8");
 
         given()
                 .baseUri("http://127.0.0.1")
@@ -384,7 +424,33 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
                 .then()
                 .statusCode(Matchers.is(500))
                 .header("X-Road-Error", Matchers.notNullValue())
-                .header("Content-Type", "application/xml;charset=utf-8");
+                .header("Content-Type", "text/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/*")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "text/xml;charset=utf-8");
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header("Accept", "application/xml")
+                .header("Accept", "text/xml")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/subsystem")
+                .get(PREFIX + "/EE/BUSINESS/producer/sub/wsdl")
+                .then()
+                .statusCode(Matchers.is(500))
+                .header("X-Road-Error", Matchers.notNullValue())
+                .header("Content-Type", "text/xml;charset=utf-8");
     }
 
     private static final TestService.Handler LARGE_OBJECT_HANDLER = (target, request, response) -> {


### PR DESCRIPTION
- Security Server respects Accept-header from client when providing error responses
- Application/json, application/xml, text/xml are supported, where application/json is the default
- Added automatic tests for the feature
