### PR TITLE
XRDDEV-752: Update Akka to version 2.6

### DIFF
--- a/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/LogManagerTest.java
+++ b/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/LogManagerTest.java
@@ -32,7 +32,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.pattern.Patterns;
-import akka.testkit.JavaTestKit;
+import akka.testkit.javadsl.TestKit;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +43,9 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -62,20 +62,20 @@ public class LogManagerTest {
     @BeforeClass
     public static void setup() throws Exception {
         system = ActorSystem.create("Proxy", ConfigFactory.load().getConfig("proxy")
-                .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(0)));
+                .withValue("akka.remote.artery.canonical.port", ConfigValueFactory.fromAnyRef(0)));
         jobManager = new JobManager();
     }
 
     @AfterClass
     public static void teardown() throws Exception {
         jobManager.stop();
-        JavaTestKit.shutdownActorSystem(system);
+        TestKit.shutdownActorSystem(system);
         system = null;
     }
 
     @Test
     public void testControlMessageOvertakesOthers() throws Exception {
-        new JavaTestKit(system) {
+        new TestKit(system) {
             {
                 final Props props = Props.create(MessageRecordingLogManager.class, jobManager)
                         .withDispatcher("akka.control-aware-dispatcher");
@@ -85,9 +85,9 @@ public class LogManagerTest {
                 subject.tell(MessageRecordingLogManager.GET_INSTANCE_MESSAGE, getRef());
                 // wait for response with handle to logmanager
                 final int timeout = 5000;
-                final FiniteDuration timeoutDuration = FiniteDuration.create(timeout, TimeUnit.MILLISECONDS);
-                MessageRecordingLogManager logManager = expectMsgClass(timeoutDuration,
-                        MessageRecordingLogManager.class);
+                final Duration timeoutDuration = Duration.ofMillis(timeout);
+                MessageRecordingLogManager logManager =
+                        expectMsgClass(timeoutDuration, MessageRecordingLogManager.class);
 
                 // stop processing messages
                 log.debug("stopping processing");
@@ -96,7 +96,7 @@ public class LogManagerTest {
                 // send bunch of messages. first one will be received and
                 // then processing stops. once processing is freed, the
                 // next one (2nd overall) should be the control message
-                List<Future> replies = new ArrayList();
+                List<Future<?>> replies = new ArrayList<>();
 
                 log.debug("asking first message");
 
@@ -112,20 +112,20 @@ public class LogManagerTest {
                 // then the rest of the messages - these are the actual test targets
                 log.debug("asking the rest of messages");
 
-            replies.add(Patterns.ask(subject, "another-foostring", timeout));
-            replies.add(Patterns.ask(subject, new SoapLogMessage(null, null, false), timeout));
-            replies.add(Patterns.ask(subject, new FindByQueryId(null, null, null), timeout));
-            replies.add(Patterns.ask(subject, new SetTimestampingStatusMessage(
-                    SetTimestampingStatusMessage.Status.SUCCESS), timeout));
-            // enable processing
-            logManager.resumeProcessingMessages();
+                replies.add(Patterns.ask(subject, "another-foostring", timeout));
+                replies.add(Patterns.ask(subject, new SoapLogMessage(null, null, false), timeout));
+                replies.add(Patterns.ask(subject, new FindByQueryId(null, null, null), timeout));
+                replies.add(Patterns.ask(subject, new SetTimestampingStatusMessage(
+                        SetTimestampingStatusMessage.Status.SUCCESS), timeout));
+                // enable processing
+                logManager.resumeProcessingMessages();
 
                 // wait for all processed
-                for (Future f : replies) {
-                    Await.ready(f, timeoutDuration);
+                for (Future<?> f : replies) {
+                    Await.ready(f, FiniteDuration.fromNanos(timeoutDuration.toNanos()));
                 }
 
-                List<Object> messages = logManager.getMessages();
+                List<Object> messages = MessageRecordingLogManager.getMessages();
 
                 log.debug("logManager mailbox contents: " + dumpMailbox(messages));
 
@@ -139,7 +139,7 @@ public class LogManagerTest {
     }
 
     private String dumpMailbox(List<Object> messages) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int number = 1;
 
         for (Object o : messages) {

--- a/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/MessageRecordingLogManager.java
+++ b/src/addons/messagelog/src/test/java/ee/ria/xroad/proxy/messagelog/MessageRecordingLogManager.java
@@ -48,7 +48,7 @@ public class MessageRecordingLogManager extends LogManager {
     }
 
     @Getter
-    private static List messages = Collections.synchronizedList(new ArrayList<Object>());
+    private static List<Object> messages = Collections.synchronizedList(new ArrayList<>());
 
     // continue processing messages when 1) first message has been sent 2) test signals that it
     // is ready to continue (it has sent the first message)

--- a/src/addons/metaservice/build.gradle
+++ b/src/addons/metaservice/build.gradle
@@ -38,7 +38,7 @@ task runMetaserviceTest(type: JavaExec) {
             '-Dxroad.proxy.server-connector-so-linger=-1',
             '-Dxroad.proxy.serverServiceHandlers=ee.ria.xroad.proxy.serverproxy.MetadataServiceHandlerImpl',
             '-Dxroad.proxy.clientHandlers=ee.ria.xroad.proxy.clientproxy.MetadataHandler',
-            '-Dproxy.akka.remote.netty.tcp.port=0'
+            '-Dproxy.akka.remote.artery.canonical.port=0'
 
     main = 'ee.ria.xroad.proxy.testsuite.ProxyTestSuite'
     classpath = sourceSets.test.runtimeClasspath

--- a/src/addons/proxymonitor/metaservice/build.gradle
+++ b/src/addons/proxymonitor/metaservice/build.gradle
@@ -91,7 +91,7 @@ task runProxymonitorMetaserviceTest(type: JavaExec) {
             '-Dxroad.proxy.client-httpclient-so-linger=-1',
             '-Dxroad.proxy.server-connector-so-linger=-1',
             '-Dxroad.proxy.serverServiceHandlers=ee.ria.xroad.proxy.serverproxy.ProxyMonitorServiceHandlerImpl',
-            '-Dproxy.akka.remote.netty.tcp.port=0'
+            '-Dproxy.akka.remote.artery.canonical.port=0'
 
     main = 'ee.ria.xroad.proxy.testsuite.ProxyTestSuite'
     classpath = sourceSets.test.runtimeClasspath

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/ProxyMonitor.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/ProxyMonitor.java
@@ -66,6 +66,6 @@ public class ProxyMonitor implements AddOn {
             log.warn(String.format("Could not load configuration property %s - using the default port",
                     CONFIG_PROPERTY_PORT));
         }
-        return String.format("akka.tcp://xroad-monitor@127.0.0.1:%d", port);
+        return String.format("akka://xroad-monitor@127.0.0.1:%d", port);
     }
 }

--- a/src/addons/proxymonitor/metaservice/src/test/resources/application.conf
+++ b/src/addons/proxymonitor/metaservice/src/test/resources/application.conf
@@ -1,13 +1,14 @@
 akka {
   actor {
-    provider = "akka.remote.RemoteActorRefProvider"
+    provider = remote
+    allow-java-serialization = true
   }
   remote {
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 2552
+    artery {
+      canonical {
+          hostname = "127.0.0.1"
+          port = 2552
+      }
     }
   }
 }
-

--- a/src/center-service/src/main/resources/application.conf
+++ b/src/center-service/src/main/resources/application.conf
@@ -1,32 +1,8 @@
-include "akka-global"
-
 centerservice {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
-
-            }
-
-            gate-invalid-addresses-for = 5 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/center-ui/src/main/resources/application.conf
+++ b/src/center-ui/src/main/resources/application.conf
@@ -1,31 +1,8 @@
-include "akka-global"
-
 centerui {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
-            }
-
-            gate-invalid-addresses-for = 1 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/common-util/src/main/resources/akka-global.conf
+++ b/src/common-util/src/main/resources/akka-global.conf
@@ -1,31 +1,40 @@
 akka {
     stdout-loglevel = "OFF"
     loggers = ["akka.event.slf4j.Slf4jLogger"]
-    loglevel = "ERROR"
+    loglevel = "DEBUG"
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
     actor {
-        #debug {
-        #    lifecycle = on
-        #    fsm = on
-        #}
+        # for now, using java serialization
+        allow-java-serialization = true
+        warn-about-java-serializer-usage = false
     }
 
     remote {
-        gate-invalid-addresses-for = 1 s
-        quarantine-systems-for = off
+        artery {
+            transport = tcp
 
-        transport-failure-detector {
-            heartbeat-interval = 30 s
-            threshold = 20.0
-            acceptable-heartbeat-pause = 35 s
+            canonical {
+                port = 0
+                hostname = "127.0.0.1"
+            }
+
+            advanced {
+                # Maximum serialized message size, including header data.
+                maximum-frame-size = 256 KiB
+            }
         }
 
-        watch-failure-detector {
-            heartbeat-interval = 30 s
-            threshold = 20.0
-            acceptable-heartbeat-pause = 35 s
-            expected-response-after = 25 s
+        # for now, using remoting directly instead of a cluster
+        warn-about-direct-use = off
+
+        # allow remote watch
+        use-unsafe-remote-features-outside-cluster = on
+
+        # but disable remote deployment
+        deployment {
+            enable-whitelist = on
+            whitelist = []
         }
     }
 }

--- a/src/configuration-proxy/src/main/resources/application.conf
+++ b/src/configuration-proxy/src/main/resources/application.conf
@@ -1,19 +1,8 @@
-include "akka-global"
-
 configuration-proxy {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-            }
-
-            gate-invalid-addresses-for = 5 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -7,7 +7,7 @@ xroadVersion=6.24.0
 xroadBuildType=SNAPSHOT
 
 // common dependency versions
-akkaVersion=2.11:2.5.26
+akkaVersion=2.13:2.6.1
 metricsVersion=3.2.2
 jettyVersion=9.4.20.v20190813
 jaxbVersion=2.2.11

--- a/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/ClientActor.java
+++ b/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/ClientActor.java
@@ -40,7 +40,7 @@ public class ClientActor extends UntypedAbstractActor {
     private LoggingAdapter log = Logging.getLogger(getContext().system(), this);
 
     private ActorSelection selection =
-            getContext().actorSelection("akka.tcp://xroad-monitor@127.0.0.1:2552/user/MetricsProviderActor");
+            getContext().actorSelection("akka://xroad-monitor@127.0.0.1:2552/user/MetricsProviderActor");
 
     @Override
     public void preStart() throws Exception {

--- a/src/monitor-test/src/main/resources/application.conf
+++ b/src/monitor-test/src/main/resources/application.conf
@@ -1,12 +1,13 @@
+include "akka-global.conf"
 akka {
   actor {
-    provider = "akka.remote.RemoteActorRefProvider"
+    provider = remote
   }
   remote {
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 0
+    artery {
+        transport = tcp
+        canonical.hostname = "127.0.0.1"
+        canonical.port = 0
     }
     log-dead-letters = 1
     log-dead-letters-during-shutdown = off

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/MonitorMain.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/MonitorMain.java
@@ -60,7 +60,7 @@ public final class MonitorMain {
                 .load();
     }
 
-    private static final String AKKA_PORT = "akka.remote.netty.tcp.port";
+    private static final String AKKA_PORT = "akka.remote.artery.canonical.port";
 
     private static ActorSystem actorSystem;
     private static JmxReporter jmxReporter;

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/SystemMetricsSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/SystemMetricsSensor.java
@@ -54,7 +54,7 @@ public class SystemMetricsSensor extends AbstractSensor {
     private final String agentPath;
 
     private static final String DEFAULT_AGENT_PATH =
-            "akka.tcp://Proxy@127.0.0.1:" + SystemProperties.getProxyActorSystemPort() + "/user/ProxyMonitorAgent";
+            "akka://Proxy@127.0.0.1:" + SystemProperties.getProxyActorSystemPort() + "/user/ProxyMonitorAgent";
 
     private ActorRef agent;
     private long correlationId = 1;
@@ -141,7 +141,7 @@ public class SystemMetricsSensor extends AbstractSensor {
             if (agent != null) {
                 context().unwatch(agent);
             }
-            agent = message.getRef();
+            agent = message.getActorRef().orElse(null);
             if (agent != null) {
                 context().watch(agent);
                 log.info("ProxyMonitorAgent attached");

--- a/src/monitor/src/main/resources/application.conf
+++ b/src/monitor/src/main/resources/application.conf
@@ -1,17 +1,16 @@
-include "akka-global"
+include "akka-global.conf"
 
 akka {
   actor {
-    provider = "akka.remote.RemoteActorRefProvider"
+    provider = remote
   }
   remote {
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 2552
-      send-buffer-size = 384k
-      receive-buffer-size = 384k
-      maximum-frame-size = 256k
+    artery {
+      transport = tcp
+      canonical {
+        hostname = "127.0.0.1"
+        port = 2552
+      }
     }
     log-dead-letters = 1
     log-dead-letters-during-shutdown = off

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/SystemMetricsSensorTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/SystemMetricsSensorTest.java
@@ -32,8 +32,8 @@ import ee.ria.xroad.monitor.common.SystemMetricNames;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
-import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
+import akka.testkit.javadsl.TestKit;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
@@ -59,15 +59,15 @@ public class SystemMetricsSensorTest {
 
     @AfterClass
     public static void tearDown() {
-        JavaTestKit.shutdownActorSystem(actorSystem);
+        TestKit.shutdownActorSystem(actorSystem);
     }
 
     @Test
-    public void testSystemMetricsSensor() throws InterruptedException {
+    public void testSystemMetricsSensor() {
         final MetricRegistry registry = new MetricRegistry();
         MetricRegistryHolder.getInstance().setMetrics(registry);
 
-        final JavaTestKit agent = new JavaTestKit(actorSystem);
+        final TestKit agent = new TestKit(actorSystem);
         final ActorRef sensor = TestActorRef.create(actorSystem, Props.create(SystemMetricsSensor.class,
                 agent.getRef().path().toString()));
         agent.expectMsgClass(StatsRequest.class);

--- a/src/op-monitor-daemon/src/main/resources/application.conf
+++ b/src/op-monitor-daemon/src/main/resources/application.conf
@@ -1,19 +1,17 @@
-include "akka-global"
-
 opmonitordaemon {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
+            provider = remote
         }
 
         remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
+            artery {
+                canonical {
+                    hostname = "127.0.0.1"
+                    port = 0 // automatic
+                }
             }
-
-            gate-invalid-addresses-for = 5 s
-            quarantine-systems-for = off
         }
     }
 }

--- a/src/packages/src/xroad/common/monitor/etc/xroad/services/monitor.conf
+++ b/src/packages/src/xroad/common/monitor/etc/xroad/services/monitor.conf
@@ -14,7 +14,7 @@ done
 
 CP="/usr/share/xroad/jlib/monitor.jar"
 
-MONITOR_PARAMS=" -Xmx256m -XX:MaxMetaspaceSize=60m \
+MONITOR_PARAMS=" -Xmx256m -XX:MaxMetaspaceSize=70m \
 -Dserverconf.hibernate.hikari.maximumPoolSize=1 \
 -Dlogback.configurationFile=/etc/xroad/conf.d/addons/monitor-logback.xml "
 

--- a/src/packages/src/xroad/common/proxy/etc/xroad/services/jetty.conf
+++ b/src/packages/src/xroad/common/proxy/etc/xroad/services/jetty.conf
@@ -12,7 +12,7 @@ done
 
 CP="/usr/share/xroad/jetty9/start.jar"
 
-JETTY_PARAMS=" -Xmx192m -XX:MaxMetaspaceSize=120m -Djruby.compile.mode=OFF \
+JETTY_PARAMS=" -Xmx192m -XX:MaxMetaspaceSize=128m -Djruby.compile.mode=OFF \
 -Djna.tmpdir=/var/lib/xroad \
 -Djetty.admin.port=8083 \
 -Djetty.public.port=8084 \

--- a/src/packages/src/xroad/default-configuration/addons/monitor-logback.xml
+++ b/src/packages/src/xroad/default-configuration/addons/monitor-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -32,7 +32,8 @@
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
-    
+    <logger name="akka" level="WARN" />
+
     <!--TokenManager is very verbose /-->
     <logger name="ee.ria.xroad.signer.tokenmanager.TokenManager" level="OFF" />
 

--- a/src/packages/src/xroad/default-configuration/confclient-logback.xml
+++ b/src/packages/src/xroad/default-configuration/confclient-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -23,6 +23,7 @@
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
     <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
 
     <root level="INFO">

--- a/src/packages/src/xroad/default-configuration/confproxy-logback.xml
+++ b/src/packages/src/xroad/default-configuration/confproxy-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -16,6 +16,7 @@
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="FILE" />

--- a/src/packages/src/xroad/default-configuration/op-monitor-logback.xml
+++ b/src/packages/src/xroad/default-configuration/op-monitor-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -16,6 +16,7 @@
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="FILE" />

--- a/src/packages/src/xroad/default-configuration/proxy-logback.xml
+++ b/src/packages/src/xroad/default-configuration/proxy-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad"/>
 
@@ -48,6 +48,7 @@
     </logger>
 
     <logger name="ee.ria.xroad" level="INFO"/>
+    <logger name="akka" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="FILE"/>

--- a/src/packages/src/xroad/default-configuration/proxy-ui-api-logback.xml
+++ b/src/packages/src/xroad/default-configuration/proxy-ui-api-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -22,6 +22,7 @@
         </encoder>
     </appender>
 
+    <logger name="akka" level="WARN" />
     <logger name="ee.ria.xroad" level="INFO" />
     <logger name="ee.ria.xroad.common.SystemPropertiesLoader" level="OFF" />
 

--- a/src/packages/src/xroad/default-configuration/signer-logback.xml
+++ b/src/packages/src/xroad/default-configuration/signer-logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
     <property name="logOutputPath" value="/var/log/xroad" />
 
@@ -30,6 +30,7 @@
     </appender>
 
     <logger name="ee.ria.xroad" level="INFO" />
+    <logger name="akka" level="WARN" />
 
     <!--TokenManager is very verbose /-->
     <logger name="ee.ria.xroad.signer.tokenmanager.TokenManager" level="OFF" />

--- a/src/proxy-ui-api/src/main/resources/application.conf
+++ b/src/proxy-ui-api/src/main/resources/application.conf
@@ -1,32 +1,8 @@
-include "akka-global"
-
 proxyuiapi {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-//                hostname = "10.140.8.110"
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
-            }
-
-            gate-invalid-addresses-for = 1 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/proxy-ui/src/main/resources/application.conf
+++ b/src/proxy-ui/src/main/resources/application.conf
@@ -1,31 +1,8 @@
-include "akka-global"
-
 proxyui {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
-            }
-
-            gate-invalid-addresses-for = 1 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/proxy/build.gradle
+++ b/src/proxy/build.gradle
@@ -108,7 +108,8 @@ task runProxyTest(type: JavaExec) {
         '-Dxroad.proxy.client-httpclient-so-linger=-1',
         '-Dxroad.proxy.server-connector-so-linger=-1',
         '-Dlogback.configurationFile=src/test/logback-proxytest.xml',
-        '-Dproxy.akka.remote.netty.tcp.port=0'
+        '-Dproxy.akka.loglevel=DEBUG'
+        '-Dproxy.akka.remote.artery.canonical.port=0'
 //      '-Djava.security.properties==src/main/resources/java.security'
 
     main = 'ee.ria.xroad.proxy.testsuite.ProxyTestSuite'

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -166,7 +166,7 @@ public final class ProxyMain {
         log.trace("startup()");
         actorSystem = ActorSystem.create("Proxy", ConfigFactory.load().getConfig("proxy")
                 .withFallback(ConfigFactory.load())
-                .withValue("akka.remote.netty.tcp.port",
+                .withValue("akka.remote.artery.canonical.port",
                         ConfigValueFactory.fromAnyRef(PortNumbers.PROXY_ACTORSYSTEM_PORT)));
         log.info("Starting proxy ({})...", readProxyVersion());
     }

--- a/src/proxy/src/main/resources/application.conf
+++ b/src/proxy/src/main/resources/application.conf
@@ -1,35 +1,17 @@
-include "akka-global"
-
 proxy {
+    include "akka-global.conf"
+
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
+            provider = remote
         }
-
         remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 5567
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
+            artery {
+                canonical {
+                    hostname = "127.0.0.1"
+                    port = 5567
+                }
             }
-
-            gate-invalid-addresses-for = 1 s
-            quarantine-systems-for = off
-
-            # disable remote deployment
-            enable-whitelist = on
-            whitelist = []
         }
 
         control-aware-dispatcher {

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/AbstractProxyIntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/AbstractProxyIntegrationTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractProxyIntegrationTest {
 
         jobManager = new JobManager();
         actorSystem = ActorSystem.create("Proxy", ConfigFactory.load().getConfig("proxy")
-                .withValue("akka.remote.netty.tcp.port", ConfigValueFactory.fromAnyRef(0)));
+                .withValue("akka.remote.artery.canonical.port", ConfigValueFactory.fromAnyRef(0)));
 
         MessageLog.init(actorSystem, jobManager);
         OpMonitoring.init(actorSystem);

--- a/src/signer-console/src/main/resources/application.conf
+++ b/src/signer-console/src/main/resources/application.conf
@@ -1,31 +1,8 @@
-include "akka-global"
-
 signer-console {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
-        }
-
-        remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 0 // automatic
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
-            }
-
-            gate-invalid-addresses-for = 5 s
-            quarantine-systems-for = off
+            provider = remote
         }
     }
 }

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
@@ -139,7 +139,7 @@ public final class SignerClient {
     }
 
     private static String getSignerPath(String signerIpAddress) {
-        return "akka.tcp://" + SIGNER + "@" + signerIpAddress + ":"
+        return "akka://" + SIGNER + "@" + signerIpAddress + ":"
                 + SystemProperties.getSignerPort();
     }
 

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -185,7 +185,7 @@ public final class SignerMain {
     private static Config getConf(int signerPort) {
         Config conf = ConfigFactory.load().getConfig("signer-main")
                 .withFallback(ConfigFactory.load());
-        return conf.withValue("akka.remote.netty.tcp.port",
+        return conf.withValue("akka.remote.artery.canonical.port",
                 ConfigValueFactory.fromAnyRef(signerPort));
     }
 }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
@@ -167,7 +167,7 @@ public abstract class AbstractModuleManager extends AbstractUpdateableActor {
     }
 
     void deinitializeModuleWorker(String name) {
-        ActorRef worker = getContext().getChild(name);
+        ActorRef worker = getContext().findChild(name).orElse(null);
 
         if (worker != null) {
             log.trace("Stopping module worker for module '{}'", name);
@@ -180,7 +180,7 @@ public abstract class AbstractModuleManager extends AbstractUpdateableActor {
     }
 
     boolean isModuleInitialized(ModuleType module) {
-        return getContext().getChild(module.getType()) != null;
+        return getContext().findChild(module.getType()).isPresent();
     }
 
     private static boolean containsModule(String moduleId,

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleWorker.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import scala.concurrent.duration.Duration;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Module worker base class.
@@ -123,11 +124,11 @@ public abstract class AbstractModuleWorker extends AbstractUpdateableActor {
     }
 
     private boolean hasToken(TokenType tokenType) {
-        return getToken(tokenType) != null;
+        return getToken(tokenType).isPresent();
     }
 
-    private ActorRef getToken(TokenType tokenType) {
-        return getContext().getChild(tokenType.getId());
+    private Optional<ActorRef> getToken(TokenType tokenType) {
+        return getContext().findChild(tokenType.getId());
     }
 
     private ActorRef createToken(TokenInfo tokenInfo, TokenType tokenType) {

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/DefaultModuleManagerImpl.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/DefaultModuleManagerImpl.java
@@ -41,7 +41,7 @@ public class DefaultModuleManagerImpl extends AbstractModuleManager {
     }
 
     void initializeSoftwareModule(SoftwareModuleType softwareModule) {
-        if (getContext().getChild(softwareModule.getType()) != null) {
+        if (getContext().findChild(softwareModule.getType()).isPresent()) {
             // already initialized
             return;
         }

--- a/src/signer/src/main/resources/application.conf
+++ b/src/signer/src/main/resources/application.conf
@@ -1,31 +1,19 @@
-include "akka-global"
-
 signer-main {
+    include "akka-global.conf"
     akka {
         actor {
-            provider = "akka.remote.RemoteActorRefProvider"
+            provider = remote
         }
 
         remote {
-            netty.tcp {
-                hostname = "127.0.0.1"
-                port = 2552 // will be overridden by application
-
-                # Sets the send buffer size of the Sockets,
-                # set to 0b for platform default
-                send-buffer-size = 384k
-
-                # Sets the receive buffer size of the Sockets,
-                # set to 0b for platform default
-                receive-buffer-size = 384k
-
-                # Maximum message size the transport will accept, but at least
-                # 32000 bytes.
-                maximum-frame-size = 256k
+            artery {
+                canonical {
+                    hostname = "127.0.0.1"
+                    port = 2552 // will be overridden by application
+                }
+                untrusted-mode = on
+                trusted-selection-paths = ["/user/RequestProcessor"]
             }
-
-            gate-invalid-addresses-for = 1 s
-            quarantine-systems-for = off
         }
 
         log-dead-letters = 1


### PR DESCRIPTION
* Update Akka to version 2.6.1 (Scala 2.13)
* Update outdated Akka config
* Use Artery instead of the classic remoting
  * For now, use Java serialization
  * At least for now, use remoting directly (no cluster)