### PR TITLE
XRDDEV-806 fix broken GetTokenInfoForKeyId

### DIFF
--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoForKeyIdRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoForKeyIdRequestHandler.java
@@ -32,7 +32,7 @@ import ee.ria.xroad.signer.tokenmanager.TokenManager;
 /**
  * Handles requests for TokenInfo based on key id.
  */
-public class GetTokenInfoForKeyIdHandler
+public class GetTokenInfoForKeyIdRequestHandler
         extends AbstractRequestHandler<GetTokenInfoForKeyId> {
 
     @Override


### PR DESCRIPTION
was broken due to bad RequestHandler name.