### PR TITLE
XRDDEV-813

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/xroad-center.preinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-center.preinst
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+
 if [ "$1" = "upgrade" ];
 then
   if dpkg --compare-versions "$2" lt-nl "6.5"
@@ -6,8 +7,18 @@ then
     echo "direct upgrade from version <6.5 is not supported"
     exit 1
   fi
+
+  if dpkg --compare-versions "$2" lt-nl "6.23" && pg_isready -q 2>/dev/null; then
+    # check for local BDR and configure node name
+    ha_node_name="$(crudini --get /etc/xroad/conf.d/local.ini center ha-node-name 2>/dev/null || true)"
+    if [[ -z "$ha_node_name" ]]; then
+      ha_node_name="$(sudo -u postgres psql -d centerui_production -qAtc 'select bdr.bdr_get_local_node_name()' 2>/dev/null || true)"
+      if [[ -n "$ha_node_name" ]]; then
+        crudini --set /etc/xroad/conf.d/local.ini center ha-node-name "$ha_node_name"
+      fi
+    fi
+  fi
 fi
 
 #DEBHELPER#
-
 exit 0


### PR DESCRIPTION
When upgrading from pre-6.23 version to 6.23 or later, detect if the central server is using a HA setup with PostgreSQL BDR and configure center.ha-node-name using the BDR node name if it has not been set.