### PR TITLE
Add one month ignore for node-sass low level vulnerability

### DIFF
--- a/src/proxy-ui-api/frontend/audit-resolve.json
+++ b/src/proxy-ui-api/frontend/audit-resolve.json
@@ -1,0 +1,11 @@
+{
+  "decisions": {
+    "961|node-sass": {
+      "decision": "ignore",
+      "madeAt": 1579006978204,
+      "expiresAt": 1581598965549
+    }
+  },
+  "rules": {},
+  "version": 1
+}


### PR DESCRIPTION
This adds ignore for the new node-sass vulnerability.  
It is low level and in the "devDependencies" so this is not dangerous, but it fails the build.
https://npmjs.com/advisories/961  

