### PR TITLE
Parametrize proxy ui api proxy address

### DIFF
--- a/src/proxy-ui-api/frontend/vue.config.js
+++ b/src/proxy-ui-api/frontend/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   devServer: {
-    proxy: 'https://docker-rest-ui-ss.local:4000', // this needs to be parametrized (address where backend runs)
+    proxy: process.env.PROXY_ADDRESS || 'https://localhost:4100',
     https: true
   },
 


### PR DESCRIPTION
Parameterize proxy-ui-api frontend devServer proxy address so that developers don't need to customize it in order to get frontend working