### PR TITLE
XRDDEV-856: Update dependencies

### DIFF
--- a/src/addons/wsdlvalidator/build.gradle
+++ b/src/addons/wsdlvalidator/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.apache.cxf:cxf-tools-validator:3.2.6"
+    compile "org.apache.cxf:cxf-tools-validator:3.2.12"
 }
 
 shadowJar {

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
     id 'org.sonarqube' version '2.7.1'
     id 'com.github.hierynomus.license' version '0.15.0'
-    id 'org.owasp.dependencycheck' version '5.2.2'
+    id 'org.owasp.dependencycheck' version '5.3.0'
     id 'jacoco'
     id 'idea'
 }

--- a/src/common-util/build.gradle
+++ b/src/common-util/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     compile 'ch.qos.logback:logback-classic:1.2.3'
 
-    compile ('org.quartz-scheduler:quartz:2.3.1') {
+    compile ('org.quartz-scheduler:quartz:2.3.2') {
         exclude module: 'c3p0'
     }
 
@@ -43,7 +43,7 @@ dependencies {
     compile "com.typesafe.akka:akka-remote_2.11:$akkaVersion"
     compile "com.typesafe.akka:akka-slf4j_2.11:$akkaVersion"
 
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.10.1'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.10.2'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'com.google.guava:guava:28.0-jre'
 


### PR DESCRIPTION
Updates include fixes to the following vulnerabilities in dependencies:
* Quarz scheduler 2.3.1 to 2.3.2 (CVE-2019-13990)
* Apache CXF wsdlvalidator 3.2.6 to 3.2.12 (CVE-2019-12491)
* FasterXML jackson-databind 2.9.10.1 to 2.9.20.2 (CVE-2019-20330)