### PR TITLE
Fix status icons with a shared component

### DIFF
--- a/src/proxy-ui-api/frontend/src/components/ui/StatusIcon.vue
+++ b/src/proxy-ui-api/frontend/src/components/ui/StatusIcon.vue
@@ -1,0 +1,84 @@
+<template>
+  <div :class="status"></div>
+</template>
+
+<script lang="ts">
+/**
+ * General purpose component for status icon with color
+ */
+import Vue from 'vue';
+import { Client, ClientStatus } from '@/types';
+
+export default Vue.extend({
+  props: {
+    status: {
+      type: String,
+      validator: (val) =>
+        [
+          'green',
+          'green-ring',
+          'orange',
+          'orange-ring',
+          'red-ring',
+          'red',
+        ].includes(val),
+    },
+  },
+});
+</script>
+
+
+<style lang="scss" scoped>
+.status-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+%status-icon-shared {
+  height: 8px;
+  width: 8px;
+  min-height: 8px;
+  min-width: 8px;
+  border-radius: 50%;
+  margin-right: 16px;
+}
+
+%status-ring-icon-shared {
+  height: 10px;
+  width: 10px;
+  border-radius: 50%;
+  margin-right: 16px;
+  border: 2px solid;
+}
+
+.red {
+  @extend %status-icon-shared;
+  background: #d0021b;
+}
+
+.red-ring {
+  @extend %status-ring-icon-shared;
+  border-color: #d0021b;
+}
+
+.green {
+  @extend %status-icon-shared;
+  background: #7ed321;
+}
+
+.green-ring {
+  @extend %status-ring-icon-shared;
+  border-color: #7ed321;
+}
+
+.orange {
+  @extend %status-icon-shared;
+  border-color: #f5a623;
+}
+
+.orange-ring {
+  @extend %status-ring-icon-shared;
+  border-color: #f5a623;
+}
+</style>

--- a/src/proxy-ui-api/frontend/src/global.ts
+++ b/src/proxy-ui-api/frontend/src/global.ts
@@ -127,6 +127,15 @@ export enum PossibleActions {
   GENERATE_SIGN_CSR = 'GENERATE_SIGN_CSR',
 }
 
+
+export enum CertificateStatus {
+  SAVED = 'SAVED',
+  REGISTRATION_IN_PROGRESS = 'REGISTRATION_IN_PROGRESS',
+  REGISTERED = 'REGISTERED',
+  DELETION_IN_PROGRESS = 'DELETION_IN_PROGRESS',
+  GLOBAL_ERROR = 'GLOBAL_ERROR',
+}
+
 export const mainTabs = [
   {
     to: { name: RouteName.Clients },

--- a/src/proxy-ui-api/frontend/src/views/Clients/ClientStatus.vue
+++ b/src/proxy-ui-api/frontend/src/views/Clients/ClientStatus.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="status-wrapper">
-    <div :class="getStatusIconClass(status)"></div>
+    <StatusIcon :status="statusIconType" />
     <div class="status-text">{{getStatusText(status)}}</div>
   </div>
 </template>
@@ -8,36 +8,55 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Client, ClientStatus } from '@/types';
+import StatusIcon from '@/components/ui/StatusIcon.vue';
 
 export default Vue.extend({
+  components: {
+    StatusIcon,
+  },
   props: {
     status: {
       type: String,
     },
   },
-  data() {
-    return {
-      tab: null,
-    };
+
+  computed: {
+    statusIconType(): string {
+      switch (this.status.toLowerCase()) {
+        case 'registered':
+          return 'green';
+        case 'registration_in_progress':
+          return 'green-ring';
+        case 'saved':
+          return 'orange-ring';
+        case 'deletion_in_progress':
+          return 'red-ring';
+        case 'global_error':
+          return 'red';
+        default:
+          return 'red';
+      }
+    },
   },
+
   methods: {
-    getStatusIconClass(status: string): string {
+    getStatusIconType(status: string): string {
       if (!status) {
         return '';
       }
       switch (status.toLowerCase()) {
         case 'registered':
-          return 'status-green';
+          return 'green';
         case 'registration_in_progress':
-          return 'status-green-ring';
+          return 'green-ring';
         case 'saved':
-          return 'status-orange-ring';
+          return 'orange-ring';
         case 'deletion_in_progress':
-          return 'status-red-ring';
+          return 'red-ring';
         case 'global_error':
-          return 'status-red';
+          return 'red';
         default:
-          return '';
+          return 'red';
       }
     },
     getStatusText(status: string): string {
@@ -69,45 +88,5 @@ export default Vue.extend({
   display: flex;
   flex-direction: row;
   align-items: center;
-}
-
-%status-icon-shared {
-  height: 8px;
-  width: 8px;
-  border-radius: 50%;
-  margin-right: 16px;
-}
-
-%status-ring-icon-shared {
-  height: 10px;
-  width: 10px;
-  border-radius: 50%;
-  margin-right: 16px;
-  border: 2px solid;
-}
-
-.status-red {
-  @extend %status-icon-shared;
-  background: #d0021b;
-}
-
-.status-red-ring {
-  @extend %status-ring-icon-shared;
-  border-color: #d0021b;
-}
-
-.status-green {
-  @extend %status-icon-shared;
-  background: #7ed321;
-}
-
-.status-green-ring {
-  @extend %status-ring-icon-shared;
-  border-color: #7ed321;
-}
-
-.status-orange-ring {
-  @extend %status-ring-icon-shared;
-  border-color: #f5a623;
 }
 </style>

--- a/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/SignAndAuthKeys/CertificateStatus.vue
+++ b/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/SignAndAuthKeys/CertificateStatus.vue
@@ -1,14 +1,19 @@
 <template>
   <div class="row-wrap">
-    <div :class="iconClass"></div>
+    <StatusIcon :status="statusIconType" />
     <div>{{$t(status)}}</div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { CertificateStatus } from '@/global';
+import StatusIcon from '@/components/ui/StatusIcon.vue';
 
 export default Vue.extend({
+  components: {
+    StatusIcon,
+  },
   props: {
     certificate: {
       type: Object,
@@ -21,19 +26,19 @@ export default Vue.extend({
   computed: {
     status() {
       switch (this.certificate.status) {
-        case 'SAVED':
+        case CertificateStatus.SAVED:
           return 'keys.certStatus.saved';
           break;
-        case 'REGISTRATION_IN_PROGRESS':
+        case CertificateStatus.REGISTRATION_IN_PROGRESS:
           return 'keys.certStatus.registration';
           break;
-        case 'REGISTERED':
+        case CertificateStatus.REGISTERED:
           return 'keys.certStatus.registered';
           break;
-        case 'DELETION_IN_PROGRESS':
+        case CertificateStatus.DELETION_IN_PROGRESS:
           return 'keys.certStatus.deletion';
           break;
-        case 'GLOBAL_ERROR':
+        case CertificateStatus.GLOBAL_ERROR:
           return 'keys.certStatus.globalError';
           break;
         default:
@@ -41,13 +46,25 @@ export default Vue.extend({
           break;
       }
     },
-    iconClass() {
+    statusIconType() {
       switch (this.certificate.status) {
-        case 'SAVED':
-          return 'status-green';
+        case CertificateStatus.SAVED:
+          return 'orange-ring';
+          break;
+        case CertificateStatus.REGISTRATION_IN_PROGRESS:
+          return 'orange';
+          break;
+        case CertificateStatus.REGISTERED:
+          return 'green';
+          break;
+        case CertificateStatus.DELETION_IN_PROGRESS:
+          return 'red';
+          break;
+        case CertificateStatus.GLOBAL_ERROR:
+          return 'red-ring';
           break;
         default:
-          return 'status-red';
+          return 'red-ring';
           break;
       }
     },
@@ -62,22 +79,5 @@ export default Vue.extend({
   display: flex;
   flex-direction: row;
   align-items: baseline;
-}
-
-%status-icon-shared {
-  height: 8px;
-  width: 8px;
-  border-radius: 50%;
-  margin-right: 16px;
-}
-
-.status-red {
-  @extend %status-icon-shared;
-  background: #d0021b;
-}
-
-.status-green {
-  @extend %status-icon-shared;
-  background: #7ed321;
 }
 </style>


### PR DESCRIPTION
A small update
- Status icon of sign & auth keys table is now functional in all cases
- Added a new shared "icon component" that also replaces the old implementation in clients list
