### PR TITLE
XRDDEV-776 updates from demo comments

### DIFF
--- a/src/proxy-ui-api/frontend/src/locales/en.json
+++ b/src/proxy-ui-api/frontend/src/locales/en.json
@@ -87,7 +87,7 @@
     "deleteCertConfirm": "Are you sure that you want to delete this certificate?",
     "certDeleted": "Certificate deleted",
     "activateSuccess": "Certificate has been activated",
-    "deactivateSuccess": "Certificate has been disabled"
+    "disableSuccess": "Certificate has been disabled"
   },
   "localGroups": {
     "addGroup": "Add group",

--- a/src/proxy-ui-api/frontend/src/views/CertificateDetails/CertificateDetails.vue
+++ b/src/proxy-ui-api/frontend/src/views/CertificateDetails/CertificateDetails.vue
@@ -185,9 +185,9 @@ export default Vue.extend({
     },
     deactivateCertificate(hash: string): void {
       api
-        .put(`token-certificates/${hash}/deactivate`, hash)
+        .put(`token-certificates/${hash}/disable`, hash)
         .then((res) => {
-          this.$bus.$emit('show-success', 'cert.deactivateSuccess');
+          this.$bus.$emit('show-success', 'cert.disableSuccess');
           this.fetchData(this.hash);
         })
         .catch((error) => this.$bus.$emit('show-error', error.message));

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/TokenCertificatesApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/TokenCertificatesApiController.java
@@ -90,7 +90,7 @@ public class TokenCertificatesApiController implements TokenCertificatesApi {
 
     @Override
     @PreAuthorize("hasAnyAuthority('ACTIVATE_DISABLE_AUTH_CERT','ACTIVATE_DISABLE_SIGN_CERT')")
-    public ResponseEntity<Void> deactivateCertificate(String hash) {
+    public ResponseEntity<Void> disableCertificate(String hash) {
         try {
             tokenCertificateService.deactivateCertificate(hash);
         } catch (CertificateNotFoundException e) {

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/PossibleActionsRuleEngine.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/PossibleActionsRuleEngine.java
@@ -88,7 +88,9 @@ public class PossibleActionsRuleEngine {
         boolean keyNotSupported = isKeyUnsupported(tokenInfo, keyInfo);
 
         // key.js#L26
-        if (!keyNotSupported
+        // original logic pieces preserved, could be simplified
+        if (tokenInfo.isActive()
+                && !keyNotSupported
                 && !(tokenInfo.isReadOnly() && !keyInfo.isSavedToConfiguration())
                 && (keyInfo.isSavedToConfiguration() || tokenInfo.isActive())) {
             actions.add(PossibleActionEnum.DELETE);

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -350,12 +350,12 @@ paths:
           description: request specified an invalid format
         '500':
           description: internal server error
-  /token-certificates/{hash}/deactivate:
+  /token-certificates/{hash}/disable:
     put: # ok
       tags:
         - security server
       summary: deactivate certificate
-      operationId: deactivateCertificate
+      operationId: disableCertificate
       description: Administrator deactivates selected certificate.
       parameters:
         - in: path

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/PossibleActionsRuleEngineTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/PossibleActionsRuleEngineTest.java
@@ -338,6 +338,14 @@ public class PossibleActionsRuleEngineTest {
                 createTestToken(false, true,
                         true, false));
         assertFalse(actions.contains(PossibleActionEnum.DELETE));
+
+        // cant delete if inactive
+        actions = getPossibleKeyActions(
+                createTestToken(true, false,
+                        false, false));
+        assertFalse(actions.contains(PossibleActionEnum.DELETE));
+
+
     }
 
     /**


### PR DESCRIPTION
Small updates for already-closed https://jira.niis.org/browse/XRDDEV-776, based on comments from demo:
- key delete is not a possible action if token is not active (would fail if attempted)
- certificate action is now "disable" in the API endpoint, instead of old "deactivate" (in line with other actions such as token/login which also use UI terms, and with possible action "DISABLE")