### PR TITLE
XRDDEV-812 implement client.owner true/false property

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwner.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwner.java
@@ -28,11 +28,9 @@ import ee.ria.xroad.common.identifier.ClientId;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 
 @Data
 @AllArgsConstructor
-@Slf4j
 public class SecurityServerOwner {
     private ClientId id;
 }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwner.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwner.java
@@ -1,0 +1,38 @@
+/**
+ * The MIT License
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.restapi.cache;
+
+import ee.ria.xroad.common.identifier.ClientId;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@AllArgsConstructor
+@Slf4j
+public class SecurityServerOwner {
+    private ClientId id;
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwnerConfig.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/cache/SecurityServerOwnerConfig.java
@@ -1,0 +1,47 @@
+/**
+ * The MIT License
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.restapi.cache;
+
+import ee.ria.xroad.common.identifier.ClientId;
+
+import org.niis.xroad.restapi.service.ServerConfService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import static org.springframework.context.annotation.ScopedProxyMode.TARGET_CLASS;
+import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
+
+@Configuration
+public class SecurityServerOwnerConfig {
+
+    @Bean
+    @Scope(value = SCOPE_REQUEST, proxyMode = TARGET_CLASS)
+    public SecurityServerOwner securityServerOwner(ServerConfService serverConfService) {
+        ClientId id = serverConfService.getSecurityServerOwnerId();
+        return new SecurityServerOwner(id);
+    }
+
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
@@ -30,6 +30,7 @@ import ee.ria.xroad.common.identifier.ClientId;
 
 import com.google.common.collect.Streams;
 import org.apache.commons.lang.StringUtils;
+import org.niis.xroad.restapi.cache.SecurityServerOwner;
 import org.niis.xroad.restapi.facade.GlobalConfFacade;
 import org.niis.xroad.restapi.openapi.BadRequestException;
 import org.niis.xroad.restapi.openapi.model.Client;
@@ -53,6 +54,7 @@ import static org.niis.xroad.restapi.converter.Converters.ENCODED_ID_SEPARATOR;
 public class ClientConverter {
 
     private final GlobalConfFacade globalConfFacade;
+    private final SecurityServerOwner securityServerOwner; // request scoped
 
     public static final int INSTANCE_INDEX = 0;
     public static final int MEMBER_CLASS_INDEX = 1;
@@ -60,8 +62,10 @@ public class ClientConverter {
     public static final int SUBSYSTEM_CODE_INDEX = 3;
 
     @Autowired
-    public ClientConverter(GlobalConfFacade globalConfFacade) {
+    public ClientConverter(GlobalConfFacade globalConfFacade,
+            SecurityServerOwner securityServerOwner) {
         this.globalConfFacade = globalConfFacade;
+        this.securityServerOwner = securityServerOwner;
     }
 
     /**
@@ -76,6 +80,7 @@ public class ClientConverter {
         client.setMemberCode(clientType.getIdentifier().getMemberCode());
         client.setSubsystemCode(clientType.getIdentifier().getSubsystemCode());
         client.setMemberName(globalConfFacade.getMemberName(clientType.getIdentifier()));
+        client.setOwner(clientType.getIdentifier().equals(securityServerOwner.getId()));
         Optional<ClientStatus> status = ClientStatusMapping.map(clientType.getClientStatus());
         client.setStatus(status.orElse(null));
         Optional<ConnectionType> connectionTypeEnum =

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -5,7 +5,7 @@ servers:
     url: https://virtserver.swaggerhub.com/Gofore/X-Road/1.0.0
 info:
   description: X-Road UI Based API
-  version: "1.0.21"
+  version: "1.0.22"
   title: X-Road UI Based API
   contact:
     email: lauri.koutaniemi@gofore.com
@@ -3978,6 +3978,11 @@ components:
           example: ABC
           minLength: 1
           maxLength: 255
+        owner:
+          type: boolean
+          description: if this client is the owner member of this security server
+          example: false
+          readOnly: true
         connection_type:
           $ref: '#/components/schemas/ConnectionType'
         status:

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/converter/ClientConverterTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/converter/ClientConverterTest.java
@@ -29,6 +29,7 @@ import ee.ria.xroad.common.identifier.ClientId;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.niis.xroad.restapi.cache.SecurityServerOwner;
 import org.niis.xroad.restapi.facade.GlobalConfFacade;
 import org.niis.xroad.restapi.openapi.BadRequestException;
 import org.niis.xroad.restapi.openapi.model.Client;
@@ -53,7 +54,9 @@ public class ClientConverterTest {
                 return MEMBER_NAME_PREFIX + identifier.getMemberCode();
             }
         };
-        clientConverter = new ClientConverter(globalConfFacade);
+        ClientId ownerId = ClientId.create("XRD2", "GOV", "M4");
+
+        clientConverter = new ClientConverter(globalConfFacade, new SecurityServerOwner(ownerId));
     }
 
     @Test

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/converter/LocalGroupConverterTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/converter/LocalGroupConverterTest.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.identifier.ClientId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.niis.xroad.restapi.cache.SecurityServerOwner;
 import org.niis.xroad.restapi.facade.GlobalConfFacade;
 import org.niis.xroad.restapi.openapi.model.LocalGroup;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,7 +61,9 @@ public class LocalGroupConverterTest {
                 return MEMBER_NAME_PREFIX + identifier.getMemberCode();
             }
         };
-        clientConverter = new ClientConverter(globalConfFacade);
+        ClientId ownerId = ClientId.create("XRD2", "GOV", "M4");
+
+        clientConverter = new ClientConverter(globalConfFacade, new SecurityServerOwner(ownerId));
         localGroupConverter = new LocalGroupConverter(clientConverter, globalConfFacade);
     }
 

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -74,6 +74,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -169,6 +170,19 @@ public class ClientsApiControllerIntegrationTest {
                 clientsApiController.findClients(null, null, null, null, null, true, false);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(9, response.getBody().size());
+    }
+
+    @Test
+    @WithMockUser(authorities = "VIEW_CLIENTS")
+    public void ownerMemberFlag() {
+        ResponseEntity<List<Client>> response =
+                clientsApiController.findClients(null, null, null, null, null, true, false);
+        assertEquals(9, response.getBody().size());
+        List<Client> owners = response.getBody().stream()
+                .filter(Client::getOwner)
+                .collect(Collectors.toList());
+        assertEquals(1, owners.size());
+        assertEquals("FI:GOV:M1", owners.iterator().next().getId());
     }
 
     @Test


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-812

ClientConverter populates all Client objects with owner (true/false) property which tells if the client is security server's owner member. This is based on a request scoped bean in a new `org.niis.xroad.restapi.cache` package.