### PR TITLE
Fix to #378 (Package 'wget' missing in docker image for packaging rpm)

### DIFF
--- a/src/packages/docker/rpm/Dockerfile
+++ b/src/packages/docker/rpm/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-RUN yum -y install sudo git rpm-build java-1.8.0-openjdk-headless
+RUN yum -y install sudo git rpm-build java-1.8.0-openjdk-headless wget
 RUN yum clean all
 RUN sed -i 's/requiretty/!requiretty/' /etc/sudoers
 WORKDIR /workspace


### PR DESCRIPTION
Adds install of 'wget' to the build of the rpm packaging docker image. 