### PR TITLE
XRDDEV-952: fixed issue with footer covering elements if the page needs to scroll

### DIFF
--- a/src/proxy-ui-api/frontend/src/App.vue
+++ b/src/proxy-ui-api/frontend/src/App.vue
@@ -1,11 +1,13 @@
 <template>
   <v-app class="xrd-app">
-    <div>
+    <app-toolbar />
+    <v-content app>
       <transition name="fade" mode="out-in">
         <router-view />
       </transition>
-    </div>
+    </v-content>
     <snackbar ref="snackbar"></snackbar>
+    <app-footer />
   </v-app>
 </template>
 
@@ -14,10 +16,16 @@ import Vue from 'vue';
 import axios from 'axios';
 import SnackbarMixin from '@/components/ui/SnackbarMixin.vue';
 import { RouteName } from '@/global';
+import AppFooter from '@/components/layout/AppFooter.vue';
+import AppToolbar from '@/components/layout/AppToolbar.vue';
 
 export default Vue.extend({
   name: 'App',
   mixins: [SnackbarMixin],
+  components: {
+    AppToolbar,
+    AppFooter,
+  },
   created() {
     // Add a response interceptor
     axios.interceptors.response.use(

--- a/src/proxy-ui-api/frontend/src/components/layout/AppFooter.vue
+++ b/src/proxy-ui-api/frontend/src/components/layout/AppFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer absolute color="grey lighten-3">
+  <v-footer color="grey lighten-3">
     <v-layout align-center justify-center>
       <v-row class="xrd-tab-max-width">
         <v-col cols="6" sm="3" class="pt-2">
@@ -61,7 +61,7 @@ import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
 export default Vue.extend({
-  name: 'footer',
+  name: 'app-footer',
   computed: {
     ...mapGetters(['securityServerVersion']),
   },

--- a/src/proxy-ui-api/frontend/src/components/layout/AppToolbar.vue
+++ b/src/proxy-ui-api/frontend/src/components/layout/AppToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-toolbar dark color="#202020" class="elevation-2">
+  <v-app-bar app dark color="#202020" elevation="2">
     <v-img
       :src="require('../../assets/xroad_logo_64.png')"
       height="64"
@@ -29,7 +29,7 @@
         </v-list-item>
       </v-list>
     </v-menu>
-  </v-toolbar>
+  </v-app-bar>
 </template>
 
 <script lang="ts">

--- a/src/proxy-ui-api/frontend/src/views/AppBase.vue
+++ b/src/proxy-ui-api/frontend/src/views/AppBase.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <toolbar />
     <router-view name="top" />
     <v-layout align-center justify-center>
       <v-layout mt-5 align-center justify-center class="base-full-width frame">
@@ -28,22 +27,15 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <app-footer/>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
 import { RouteName } from '@/global';
 import * as api from '@/util/api';
-import Toolbar from '../components/layout/AppToolbar.vue';
-import AppFooter from '@/components/layout/AppFooter.vue';
+
 export default Vue.extend({
-  components: {
-    Toolbar,
-    AppFooter,
-  },
   data() {
     return {
       interval: 0,


### PR DESCRIPTION
This fix involved changing the layout structure. In summary:
- The components app-toolbar and app-footer were moved from AppBase.vue to App.vue so they can be immediately under v-app (seems to be required for vuetify-s structure to work correctly)
- Changed the wrapper div around content under App.vue to be v-content instead (again, seems to be a requirement for vuetify-s layout)
- Changed AppToolbar.vue to use v-app-bar instead of v-toolbar (was recommended under console)
- Removed the "absolute" attribute from AppFooter.vue v-footer component

I manually tested as much as I knew how to and there seem to be no side-effects to these changes.