### PR TITLE
UI layout quickfix for content class

### DIFF
--- a/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
+++ b/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
@@ -54,7 +54,7 @@ export default Vue.extend({
   },
 });
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
 .content {
   width: 1000px;
 }

--- a/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
+++ b/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
@@ -1,4 +1,3 @@
-import { Permissions } from '@/global';
 <template>
   <div class="wrapper xrd-view-common">
     <v-tabs


### PR DESCRIPTION
There was a scss class "content" that was probably accidentally set as global. 
This caused other parts of the UI to break which were also using a class with same name.

Class is now scoped and issue fixed.