### PR TITLE
XRDDEV-1028 Remove references to allow-get-wsdl-request property

### DIFF
--- a/src/packages/src/xroad/default-configuration/proxy.ini
+++ b/src/packages/src/xroad/default-configuration/proxy.ini
@@ -88,9 +88,6 @@ jetty-clientproxy-configuration-file=/etc/xroad/jetty/clientproxy.xml
 ; File name of the OCSP Responder Jetty server configuration XML
 jetty-ocsp-responder-configuration-file=/etc/xroad/jetty/ocsp-responder.xml
 
-; Whether to allow getWsdl metaservice to be called with GET
-allow-get-wsdl-request=false
-
 ; The time period in seconds how long the fastest provider's URI is cached
 ; To disable the URI cache set this value to 0
 client-fastest-connecting-ssl-uri-cache-period=3600

--- a/src/packages/src/xroad/redhat/SPECS/xroad-proxy.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-proxy.spec
@@ -172,21 +172,6 @@ fi
 
 if [ $1 -gt 1 ] ; then
     # upgrade
-    # allow-get-wsdl-request for upgrade installations
-    proxy_ini=/etc/xroad/conf.d/proxy.ini
-    local_ini=/etc/xroad/conf.d/local.ini
-    present_in_proxy_ini=$(crudini --get ${proxy_ini} proxy allow-get-wsdl-request 2>/dev/null)
-    if [[ -n "$present_in_proxy_ini" ]];
-      then
-        echo "allow-get-wsdl-request already present in proxy.ini, do not update local.ini"
-      else
-        echo "allow-get-wsdl-request not present in proxy.ini, update local.ini"
-        crudini --set ${local_ini} proxy allow-get-wsdl-request true
-      fi
-fi
-
-if [ $1 -gt 1 ] ; then
-    # upgrade
     # migrate from client-fastest-connecting-ssl-use-uri-cache to client-fastest-connecting-ssl-uri-cache-period
     local_ini=/etc/xroad/conf.d/local.ini
     local_ini_value=$(crudini --get ${local_ini} proxy client-fastest-connecting-ssl-use-uri-cache 2>/dev/null)

--- a/src/packages/src/xroad/ubuntu/generic/xroad-proxy.preinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-proxy.preinst
@@ -11,21 +11,6 @@ fi
 
 if [ "$1" = "upgrade" ];
   then
-    # allow-get-wsdl-request for upgrade installations
-    proxy_ini=/etc/xroad/conf.d/proxy.ini
-    local_ini=/etc/xroad/conf.d/local.ini
-    present_in_proxy_ini=$(crudini --get ${proxy_ini} proxy allow-get-wsdl-request 2>/dev/null)
-    if [[ -n "$present_in_proxy_ini" ]];
-      then
-        echo "allow-get-wsdl-request already present in proxy.ini, do not update local.ini"
-      else
-        echo "allow-get-wsdl-request not present in proxy.ini, update local.ini"
-        crudini --set ${local_ini} proxy allow-get-wsdl-request true
-      fi
-fi
-
-if [ "$1" = "upgrade" ];
-  then
     # migrate from client-fastest-connecting-ssl-use-uri-cache to client-fastest-connecting-ssl-uri-cache-period
     local_ini=/etc/xroad/conf.d/local.ini
     local_ini_value=$(crudini --get ${local_ini} proxy client-fastest-connecting-ssl-use-uri-cache 2>/dev/null)


### PR DESCRIPTION
- Remove `allow-get-wsdl-request` from `proxy.ini`.
- Remove refences to `allow-get-wsdl-request` from Ubuntu and RHEL installation scripts.