### PR TITLE
XRDDEV-972: Refactor security server db migrations

### DIFF
--- a/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf-changelog.xml
+++ b/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf-changelog.xml
@@ -6,5 +6,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
   <include file="serverconf/000-baseline.xml"/>
+  <include file="serverconf/001-apikeys.xml"/>
 
 </databaseChangeLog>

--- a/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf-legacy-changelog.xml
+++ b/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf-legacy-changelog.xml
@@ -22,6 +22,5 @@
   <include file="serverconf/8-restauthorization.xml" />
   <include file="serverconf/9-rest-auth-refactoring.xml" />
   <include file="serverconf/10-rest-service-type-rename.xml" />
-  <include file="serverconf/11-apikeys.xml" />
   <!-- legacy changelog, do not edit -->
 </databaseChangeLog>

--- a/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf/001-apikeys.xml
+++ b/src/packages/src/xroad/common/proxy/usr/share/xroad/db/serverconf/001-apikeys.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <changeSet author="jm" id="11-apikey-tables">
+    <changeSet author="niis" id="001-apikeys">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="APIKEY"/></not>
+            <not><tableExists tableName="APIKEY_ROLES"/></not>
+        </preConditions>
+
         <createTable tableName="APIKEY">
             <column name="ID" type="BIGINT">
                 <constraints nullable="false"/>
@@ -10,6 +15,7 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
+
         <createTable tableName="APIKEY_ROLES">
             <column name="ID" type="BIGINT" autoIncrement="true">
                 <constraints nullable="false"/>
@@ -21,49 +27,34 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
+
         <addPrimaryKey columnNames="ID" constraintName="APIKEYPK" tableName="APIKEY"/>
         <addPrimaryKey columnNames="ID" constraintName="APIKEY_ROLESPK" tableName="APIKEY_ROLES"/>
         <addForeignKeyConstraint baseColumnNames="APIKEY_ID" baseTableName="APIKEY_ROLES" constraintName="FK_APIKEY_ROLES_APIKEY_ID" deferrable="false" initiallyDeferred="false" referencedColumnNames="ID" referencedTableName="APIKEY"/>
         <addUniqueConstraint columnNames="apikey_id, role" constraintName="UNIQUE_APIKEY_ROLE" tableName="APIKEY_ROLES" />
-    </changeSet>
 
-    <changeSet author="jm" id="11-unique-constraint">
-        <sql splitStatements="false">
-            alter table APIKEY_ROLES ADD CONSTRAINT VALID_ROLE
-            CHECK (
-            ROLE IN ('XROAD_SECURITY_OFFICER',
-            'XROAD_REGISTRATION_OFFICER',
-            'XROAD_SERVICE_ADMINISTRATOR',
-            'XROAD_SYSTEM_ADMINISTRATOR',
-            'XROAD_SECURITYSERVER_OBSERVER')
-            )
-        </sql>
-
-        <rollback>
-            alter table APIKEY_ROLES DROP CONSTRAINT VALID_ROLE
-        </rollback>
-    </changeSet>
-
-
-    <changeSet author="jm" id="11-history">
         <sql splitStatements="false">
             <![CDATA[
+            ALTER TABLE APIKEY_ROLES ADD CONSTRAINT VALID_ROLE
+                CHECK (ROLE IN (
+                    'XROAD_SECURITY_OFFICER',
+                    'XROAD_REGISTRATION_OFFICER',
+                    'XROAD_SERVICE_ADMINISTRATOR',
+                    'XROAD_SYSTEM_ADMINISTRATOR',
+                    'XROAD_SECURITYSERVER_OBSERVER')
+                );
             DROP TRIGGER IF EXISTS update_history ON apikey;
             CREATE TRIGGER update_history AFTER INSERT OR UPDATE OR DELETE ON apikey
-            FOR EACH ROW EXECUTE PROCEDURE add_history_rows();
+                FOR EACH ROW EXECUTE PROCEDURE add_history_rows();
 
             DROP TRIGGER IF EXISTS update_history ON apikey_roles;
             CREATE TRIGGER update_history AFTER INSERT OR UPDATE OR DELETE ON apikey_roles
-            FOR EACH ROW EXECUTE PROCEDURE add_history_rows();
-]]>
+                FOR EACH ROW EXECUTE PROCEDURE add_history_rows();
+            ]]>
         </sql>
-
         <rollback>
-            <![CDATA[
-DROP TRIGGER IF EXISTS update_history ON apikey;
-DROP TRIGGER IF EXISTS update_history ON apikey_roles;
-]]>
+          <dropTable tableName="APIKEY" cascadeConstraints="true"/>
+          <dropTable tableName="APIKEY_ROLES" cascadeConstraints="true"/>
         </rollback>
-
     </changeSet>
 </databaseChangeLog>

--- a/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
+++ b/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
@@ -137,6 +137,7 @@ EOF
       cd /usr/share/xroad/db/
       /usr/share/xroad/db/liquibase.sh --classpath=/usr/share/xroad/jlib/proxy.jar --url="jdbc:postgresql://$db_host/$db_database?dialect=ee.ria.xroad.common.db.CustomPostgreSQLDialect" --changeLogFile=/usr/share/xroad/db/serverconf-legacy-changelog.xml --password="${db_password}" --username="${db_user}" update || die "Connection to database has failed, please check database availability and configuration in ${db_properties} file"
         psql_master --single-transaction -d "$db_database" <<EOF || die "Renaming public schema to '$db_schema' failed."
+\set STOP_ON_ERROR on
 ALTER DATABASE "${db_database}" OWNER TO "${db_master_user}";
 REVOKE ALL ON DATABASE "${db_database}" FROM PUBLIC;
 GRANT CREATE,TEMPORARY,CONNECT ON DATABASE "${db_database}" TO "${db_user}";

--- a/src/packages/src/xroad/ubuntu/generic/xroad-proxy.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-proxy.postinst
@@ -132,6 +132,7 @@ EOF
       cd /usr/share/xroad/db/
       /usr/share/xroad/db/liquibase.sh --classpath=/usr/share/xroad/jlib/proxy.jar --url="jdbc:postgresql://$db_host/$db_database?dialect=ee.ria.xroad.common.db.CustomPostgreSQLDialect" --changeLogFile=/usr/share/xroad/db/serverconf-legacy-changelog.xml --password="${db_password}" --username="${db_user}" update || die "Connection to database has failed, please check database availability and configuration in ${db_properties} file"
         psql_master --single-transaction -d "$db_database" <<EOF || die "Renaming public schema to '$db_schema' failed."
+\set STOP_ON_ERROR on
 ALTER DATABASE "${db_database}" OWNER TO "${db_master_user}";
 REVOKE ALL ON DATABASE "${db_database}" FROM PUBLIC;
 GRANT CREATE,TEMPORARY,CONNECT ON DATABASE "${db_database}" TO "${db_user}";


### PR DESCRIPTION
Make it simpler to manually fix a security server install in case migration
fails due to insufficient database rights.