### PR TITLE
Fix npm audit build issue

### DIFF
--- a/src/proxy-ui-api/frontend/audit-resolve.json
+++ b/src/proxy-ui-api/frontend/audit-resolve.json
@@ -4,6 +4,26 @@
       "decision": "ignore",
       "madeAt": 1588058362447,
       "expiresAt": 1590650328259
+    },
+    "1500|@vue/cli-plugin-unit-jest>ts-jest>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1588578292034,
+      "expiresAt": 1591170276771
+    },
+    "1500|@vue/cli-service>webpack-dev-server>yargs>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1588578292034,
+      "expiresAt": 1591170276771
+    },
+    "1500|node-sass>sass-graph>yargs>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1588578292034,
+      "expiresAt": 1591170276771
+    },
+    "1500|npm-audit-resolver>audit-resolve-core>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1588578292034,
+      "expiresAt": 1591170276771
     }
   },
   "rules": {},

--- a/src/proxy-ui-api/frontend/audit-resolve.json
+++ b/src/proxy-ui-api/frontend/audit-resolve.json
@@ -1,10 +1,5 @@
 {
   "decisions": {
-    "1179|@vue/cli-plugin-e2e-nightwatch>nightwatch>optimist>minimist": {
-      "decision": "ignore",
-      "madeAt": 1588058362447,
-      "expiresAt": 1590650328259
-    },
     "1500|@vue/cli-plugin-unit-jest>ts-jest>yargs-parser": {
       "decision": "ignore",
       "madeAt": 1588578292034,

--- a/src/proxy-ui-api/frontend/package-lock.json
+++ b/src/proxy-ui-api/frontend/package-lock.json
@@ -6660,6 +6660,12 @@
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
       "dev": true
     },
+    "envinfo": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
+      "integrity": "sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ==",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -12962,27 +12968,28 @@
       "dev": true
     },
     "nightwatch": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-1.3.4.tgz",
-      "integrity": "sha512-27zWPjmBsHu3IDKc6QTQdRKbTWx4WuTUXbCOT1Wa8Ovxbv+3TZ7GCd9Dt9wm14ElO9Db9/PKVk8JIWThkqGRZA==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-1.3.5.tgz",
+      "integrity": "sha512-Wb1oLwIhF/44B4NcpDzjNnXu4YIs51AgfMYHsjUssg+n5qZLqty4Wg3uF7G4jT9g4S5IAEYw1D7/Yt+XFxdQtg==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "chai-nightwatch": "^0.4.0",
+        "ci-info": "^2.0.0",
         "dotenv": "7.0.0",
-        "ejs": "^2.5.9",
-        "is-ci": "^2.0.0",
+        "ejs": "^2.7.4",
+        "envinfo": "^7.5.1",
         "lodash.clone": "3.0.3",
         "lodash.defaultsdeep": "^4.6.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "3.0.4",
+        "minimist": "^1.2.5",
         "mkpath": "1.0.0",
         "mocha": "^6.2.2",
-        "optimist": "^0.6.1",
-        "ora": "^4.0.2",
+        "ora": "^4.0.3",
         "proxy-agent": "^3.1.1",
-        "request": "^2.88.0",
-        "request-promise": "^4.2.4",
+        "request": "^2.88.2",
+        "request-promise": "^4.2.5",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -13700,24 +13707,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -19075,12 +19064,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {


### PR DESCRIPTION
Adds yargs-parser to accepted vulnerabilities for one month.
Removes minimalist which has been fixed.

Updated the confluence accordingly
https://confluence.niis.org/display/XRDDEV/Accepted+npm+audit+vulnerabilities