### PR TITLE
XRDDEV-1027 adding duplicate access rights for a localgroup is prevented.

### DIFF
--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -516,13 +516,13 @@ public class ServicesApiControllerIntegrationTest {
         // try adding two identical localgroups -> no exception, only one added
         List<ServiceClient> itemsBefore =
                 servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
-        ServiceClient localGroup = new ServiceClient().id(TestUtils.DB_LOCAL_GROUP_ID_1).serviceClientType(
+        ServiceClient localGroup = new ServiceClient().id(TestUtils.DB_LOCAL_GROUP_ID_2).serviceClientType(
                 ServiceClientType.LOCALGROUP);
         ServiceClients duplicateLocalGroups = new ServiceClients().addItemsItem(localGroup).addItemsItem(localGroup);
         servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, duplicateLocalGroups);
         List<ServiceClient> itemsAfter =
                 servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
-        assertEquals(itemsBefore.size(), itemsAfter.size());
+        assertEquals(itemsBefore.size() + 1, itemsAfter.size());
     }
 
     @Test(expected = BadRequestException.class)

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -484,6 +484,7 @@ public class ServicesApiControllerIntegrationTest {
         assertEquals(calculatePrimeClientsBefore + 3, updatedServiceClients.size());
     }
 
+    @Test
     @WithMockUser(authorities = { "VIEW_SERVICE_ACL", "EDIT_SERVICE_ACL" })
     public void addDuplicateAccessRight() throws Exception {
         when(globalConfService.clientsExist(any())).thenReturn(true);
@@ -500,7 +501,7 @@ public class ServicesApiControllerIntegrationTest {
                         ServiceClientType.SUBSYSTEM));
         try {
             servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, clientsToAdd);
-            throw new Exception("Should throw Conflict exception in stead of this");
+            fail("Should throw Conflict exception in stead of this");
         } catch (ConflictException e) { }
 
         // try adding duplicate local group
@@ -509,20 +510,20 @@ public class ServicesApiControllerIntegrationTest {
                         ServiceClientType.LOCALGROUP));
         try {
             servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, existingLocalGroup);
-            throw new Exception("Should throw Conflict exception in stead of this");
+            fail("Should throw Conflict exception in stead of this");
         } catch (ConflictException e) { }
 
 
-        // try adding two identical localgroups -> no exception, only one added
+        // try adding two identical localgroups
         List<ServiceClient> itemsBefore =
                 servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
         ServiceClient localGroup = new ServiceClient().id(TestUtils.DB_LOCAL_GROUP_ID_2).serviceClientType(
                 ServiceClientType.LOCALGROUP);
         ServiceClients duplicateLocalGroups = new ServiceClients().addItemsItem(localGroup).addItemsItem(localGroup);
-        servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, duplicateLocalGroups);
-        List<ServiceClient> itemsAfter =
-                servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
-        assertEquals(itemsBefore.size() + 1, itemsAfter.size());
+        try {
+            servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, duplicateLocalGroups);
+            fail("Should throw Conflict exception in stead of this");
+        } catch (ConflictException e) { }
     }
 
     @Test(expected = BadRequestException.class)

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -513,13 +513,16 @@ public class ServicesApiControllerIntegrationTest {
         } catch (ConflictException e) { }
 
 
-        // try adding two identical localgroups
+        // try adding two identical localgroups -> no exception, only one added
+        List<ServiceClient> itemsBefore =
+                servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
         ServiceClient localGroup = new ServiceClient().id(TestUtils.DB_LOCAL_GROUP_ID_1).serviceClientType(
                 ServiceClientType.LOCALGROUP);
         ServiceClients duplicateLocalGroups = new ServiceClients().addItemsItem(localGroup).addItemsItem(localGroup);
-        try {
-            servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, duplicateLocalGroups);
-        } catch (ConflictException e) { }
+        servicesApiController.addServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1, duplicateLocalGroups);
+        List<ServiceClient> itemsAfter =
+                servicesApiController.getServiceServiceClients(TestUtils.SS1_GET_RANDOM_V1).getBody();
+        assertEquals(itemsBefore.size(), itemsAfter.size());
     }
 
     @Test(expected = BadRequestException.class)

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/ServiceDescriptionServiceIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/ServiceDescriptionServiceIntegrationTest.java
@@ -586,10 +586,10 @@ public class ServiceDescriptionServiceIntegrationTest {
     @WithMockUser(authorities = "ADD_OPENAPI3")
     public void addRestEndpointServiceDescriptionSuccess() throws Exception {
         ClientType client = clientService.getLocalClient(CLIENT_ID_SS1);
-        assertEquals(6, client.getEndpoint().size());
+        assertEquals(7, client.getEndpoint().size());
         serviceDescriptionService.addRestEndpointServiceDescription(CLIENT_ID_SS1, "http://testurl.com", "testcode");
         client = clientService.getLocalClient(CLIENT_ID_SS1);
-        assertEquals(7, client.getEndpoint().size());
+        assertEquals(8, client.getEndpoint().size());
         assertTrue(client.getEndpoint().stream()
                 .map(EndpointType::getServiceCode)
                 .collect(Collectors.toList())


### PR DESCRIPTION
This was actually done already in a refactoring, but I added a couple of tests just for this.

https://jira.niis.org/browse/XRDDEV-1027