### PR TITLE
XRDDEV-1132

### DIFF
--- a/src/proxy-ui-api/build.gradle
+++ b/src/proxy-ui-api/build.gradle
@@ -228,3 +228,8 @@ dependencyManagement {
         }
     }
 }
+
+test {
+    // Needed for the tests in DiagnosticsApiControllerTest class
+    systemProperty "user.timezone", "UTC"
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
@@ -31,7 +31,6 @@ import ee.ria.xroad.common.identifier.GlobalGroupId;
 import ee.ria.xroad.common.identifier.LocalGroupId;
 import ee.ria.xroad.common.identifier.XRoadId;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTimeZone;
 import org.niis.xroad.restapi.converter.Converters;
@@ -53,7 +52,6 @@ import java.util.regex.Pattern;
 /**
  * Format utils
  */
-@Slf4j
 public final class FormatUtils {
     public static final String HTTPS_PROTOCOL = "https://";
     public static final String HTTP_PROTOCOL = "http://";

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.identifier.GlobalGroupId;
 import ee.ria.xroad.common.identifier.LocalGroupId;
 import ee.ria.xroad.common.identifier.XRoadId;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTimeZone;
 import org.niis.xroad.restapi.converter.Converters;
@@ -52,6 +53,7 @@ import java.util.regex.Pattern;
 /**
  * Format utils
  */
+@Slf4j
 public final class FormatUtils {
     public static final String HTTPS_PROTOCOL = "https://";
     public static final String HTTP_PROTOCOL = "http://";
@@ -95,8 +97,8 @@ public final class FormatUtils {
     public static OffsetDateTime fromLocalTimeToOffsetDateTime(LocalTime localTime) {
         // Use joda "LocalDate.now()" to enable better testability. Joda allows setting current system
         // time using "DateTimeUtils.setCurrentMillisFixed" method.
-        return LocalDateTime.of(LocalDate.parse(org.joda.time.LocalDate.now(DateTimeZone.UTC).toString()), localTime)
-                .toInstant(ZoneOffset.UTC).atOffset(ZoneOffset.UTC);
+        return LocalDateTime.of(LocalDate.parse(org.joda.time.LocalDate.now(DateTimeZone.getDefault()).toString()),
+                localTime).toInstant(OffsetDateTime.now().getOffset()).atOffset(ZoneOffset.UTC);
     }
 
     /**
@@ -112,7 +114,10 @@ public final class FormatUtils {
     public static OffsetDateTime fromLocalTimeToOffsetDateTime(LocalTime localTime, boolean isInPast) {
         OffsetDateTime offsetDateTime = fromLocalTimeToOffsetDateTime(localTime);
         // Use joda "LocalTime.now()" to enable better testability.
-        int currentHour = org.joda.time.LocalTime.now(DateTimeZone.UTC).getHourOfDay();
+        org.joda.time.LocalTime now = org.joda.time.LocalTime.now(DateTimeZone.getDefault());
+        LocalTime localTimeNow = LocalTime.of(now.getHourOfDay(), now.getMinuteOfHour(), now.getSecondOfMinute());
+        int currentHour = fromLocalTimeToOffsetDateTime(localTimeNow).getHour();
+
         if (isInPast && currentHour < offsetDateTime.getHour()) {
             // Minus one day if localTime was yesterday
             return offsetDateTime.minusDays(1);

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/DiagnosticsApiControllerTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/DiagnosticsApiControllerTest.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.DiagnosticsStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.niis.xroad.restapi.dto.OcspResponderDiagnosticsStatus;
@@ -56,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -94,6 +96,12 @@ public class DiagnosticsApiControllerTest {
 
     @MockBean
     DiagnosticService diagnosticService;
+
+    @Before
+    public void setup() {
+        System.setProperty("user.timezone", "UTC");
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+    }
 
     @After
     public final void tearDown() {

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/util/TestUtils.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/util/TestUtils.java
@@ -42,6 +42,7 @@ import org.springframework.http.ResponseEntity;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
@@ -313,6 +314,7 @@ public final class TestUtils {
      * @return
      */
     public static Long fromDateTimeToMilliseconds(String dateTimeStr) {
-        return LocalDateTime.parse(dateTimeStr).atOffset(ZoneOffset.UTC).toInstant().toEpochMilli();
+        return LocalDateTime.parse(dateTimeStr).toInstant(OffsetDateTime.now().getOffset()).atOffset(ZoneOffset.UTC)
+                .toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION
Fix timezone issue in diagnostics timestamps:

- Convert local time returned by admin APIs to OffsetDateTime using default system timezone as source timezone.
- Set UTC timezone for tests since otherwise default timezone of JVM is used.

JIRA issue: https://jira.niis.org/browse/XRDDEV-1132