### PR TITLE
Disable message body logging for the Icelandic Instance

### DIFF
--- a/src/packages/src/xroad/default-configuration/override-securityserver-is.ini
+++ b/src/packages/src/xroad/default-configuration/override-securityserver-is.ini
@@ -2,4 +2,3 @@
 
 [message-log]
 message-body-logging=false
-acceptable-timestamp-failure-period=18000

--- a/src/packages/src/xroad/default-configuration/override-securityserver-is.ini
+++ b/src/packages/src/xroad/default-configuration/override-securityserver-is.ini
@@ -1,0 +1,5 @@
+; IS security server configuration overrides
+
+[message-log]
+message-body-logging=false
+acceptable-timestamp-failure-period=18000


### PR DESCRIPTION
As per request from Icelandic X-Road, message body logging will be disabled on all security servers.