### PR TITLE
XRDDEV-1122

### DIFF
--- a/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
@@ -143,7 +143,7 @@ export const actions: ActionTree<AddClientState, RootState> = {
     // Fetch clients from backend that can be selected
     return api
       .get(
-        '/clients?exclude_local=true&member_missing_sign_cert=true&internal_search=false&show_members=false',
+        '/clients?exclude_local=true&internal_search=false&show_members=false',
       )
       .then((res) => {
         commit('storeSelectableClients', res.data);

--- a/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
@@ -134,21 +134,20 @@ export const mutations: MutationTree<AddClientState> = {
   },
 };
 
+// Compares two Clients on member level and returns true if the
+// member ids of the clients match. Otherwise returns false.
+const memberEquals = (client: Client, other: Client): boolean =>
+  client.member_class === other.member_class &&
+  client.member_code === other.member_code &&
+  client.instance_id === other.instance_id;
+
 // Filters out clients that have local relatives.
 // If the member owning the client or another subsystem
 // of the same member is already present locally,
 // the client is excluded.
 const excludeClientsWithLocalRelatives = (clients: Client[], localClients: Client[]): Client[] => {
   return clients.filter((client: Client) => {
-    let showClient = true;
-    localClients.forEach((localClient: Client) => {
-      if (localClient.member_class === client.member_class &&
-          localClient.member_code === client.member_code &&
-          localClient.instance_id === client.instance_id) {
-        showClient = false;
-      }
-    });
-    return showClient;
+    return !localClients.some( (localClient: Client) => memberEquals(localClient, client))
   });
 }
 

--- a/src/proxy-ui-api/frontend/src/views/AddSubsystem/AddSubsystem.vue
+++ b/src/proxy-ui-api/frontend/src/views/AddSubsystem/AddSubsystem.vue
@@ -255,7 +255,7 @@ export default Vue.extend({
       // Fetch selectable subsystems
       api
         .get(
-          `/clients?instance=${this.instanceId}&member_class=${this.memberClass}&member_code=${this.memberCode}&show_members=false&exclude_local=true`,
+          `/clients?instance=${this.instanceId}&member_class=${this.memberClass}&member_code=${this.memberCode}&show_members=false&exclude_local=true&internal_search=false`,
         )
         .then((res) => {
           this.selectableSubsystems = res.data;

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/ClientUtils.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/ClientUtils.java
@@ -56,7 +56,7 @@ public final class ClientUtils {
                 log.error(ERROR_OCSP_EXTRACT_MSG + " for client: " + clientId.toString(), e);
                 return false;
             }
-            if (clientId.equals(certificateInfo.getMemberId())
+            if (clientId.memberEquals(certificateInfo.getMemberId())
                     && certificateInfo.getStatus().equals(CertificateInfo.STATUS_REGISTERED)
                     && ocspResponseStatus.equals(CertificateInfo.OCSP_RESPONSE_GOOD)) {
                 return true;


### PR DESCRIPTION
- Fix Add subsystem query
   - Add missing query parameter: `internal_search=false`
- Fix Add client query
   - Filter out all clients that have local relatives.
   - If the member owning the client or another subsystem of the same member is already present locally, the client is excluded.
- Fix bug in client search with `local_valid_sign_cert` param
  - Compare only the member part of the client identifier to member identifiers in the certificates.

JIRA issues: https://jira.niis.org/browse/XRDDEV-1122


