### PR TITLE
XRDDEV-1159

### DIFF
--- a/doc/EnvironmentalMonitoring/Monitoring-architecture.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-architecture.md
@@ -1,6 +1,6 @@
 # X-Road: Environmental Monitoring Architecture
 
-Version: 1.7  
+Version: 1.8  
 Doc. ID: ARC-ENVMON
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -13,6 +13,7 @@ Doc. ID: ARC-ENVMON
 | 18.10.2017 | 1.5      |  | Joni Laurila |
 | 02.03.2018 | 1.6      | Added numbering, terms document references, removed unnecessary anchors | Tatu Repo
 | 20.01.2020 | 1.7      | Update XroadProcessLister description | Jarkko Hyöty
+| 25.06.2020 | 1.8      | Add chapter [2.2.1 JMX interface](#221-jmx-interface)| Petteri Kivimäki
 
 
 # Table of Contents
@@ -25,6 +26,7 @@ Doc. ID: ARC-ENVMON
 - [2 Components](#2-components)
   * [2.1 Monitoring metaservice (proxymonitor add-on)](#21-monitoring-metaservice-proxymonitor-add-on)
   * [2.2 Monitoring service (xroad-monitor)](#22-monitoring-service-xroad-monitor)
+      * [2.2.1 JMX interface](#221-jmx-interface)
   * [2.3 Central monitoring client](#23-central-monitoring-client)
   * [2.4 Central monitoring data collector](#24-central-monitoring-data-collector)
   * [2.5 Central server admin user interface](#25-central-server-admin-user-interface)
@@ -126,9 +128,23 @@ The following sensors produce monitoring data:
 
 Monitoring service is installed as a separate package, with name `xroad-monitor`. It runs in a separate process.
 
-The service also publishes the monitoring data via JMX. Local monitoring agents can use this as an alternative way to fetch monitoring data. With default configuration, JMX access is only allowed from localhost.
+#### 2.2.1 JMX interface
+
+The service also publishes the monitoring data via JMX. Local monitoring agents can use this as an alternative way to fetch monitoring data. With the default configuration, JMX is disabled.
 
 ![monitoring JMX agent](img/monitoring-jmx.png)
+
+JMX is enabled by adding the required configuration in `/etc/xroad/services/local.conf` file. The file is opened for editing and changes are made on the `PROXY_PARAMS` variable value. After the `PROXY_PARAMS` variable value has been updated, the `xroad-monitor` service must be restarted.
+
+The example configuration below enables JMX, binds it to port `9999` on any available interface with SSL and password authentication enabled:
+
+```
+MONITOR_PARAMS="$MONITOR_PARAMS \
+-Djava.rmi.server.hostname=0.0.0.0 \
+-Dcom.sun.management.jmxremote.port=9999 \
+-Dcom.sun.management.jmxremote.authenticate=true \
+-Dcom.sun.management.jmxremote.ssl=true "
+```
 
 ### 2.3 Central monitoring client
 

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 6**
 
-Version: 2.23  
+Version: 2.24  
 Doc. ID: IG-SS
 
 ---
@@ -48,7 +48,8 @@ Doc. ID: IG-SS
  29.04.2020 | 2.21    | Add instructions how to use remote database located in Microsoft Azure | Ilkka Seppälä
  12.06.2020 | 2.22    | Update reference data regarding JMX listening ports | Petteri Kivimäki
  24.06.2020 | 2.23    | Add repository sign key details in section [2.2 Reference data](#22-reference-data) | Petteri Kivimäki
-    
+ 24.06.2020 | 2.24    | Remove environmental and operational monitoring daemon JMX listening ports from section [2.2 Reference data](#22-reference-data) | Petteri Kivimäki
+     
 ## Table of Contents <!-- omit in toc -->
 
 <!-- toc -->
@@ -144,8 +145,6 @@ The software can be installed both on physical and virtualized hardware (of the 
  1.6  | TCP 4000                                  | User interface (local network)
  1.7  | TCP 80                                    | Information system access points (in the local network)<br> Connections from information systems
  &nbsp; | TCP 443                                 | Information system access points (in the local network)<br> Connections from information systems
- &nbsp; | TCP 9011                                | Port for inbound connections (from the local network to the security server)<br> Operational data monitoring daemon JMX listening port
- &nbsp; | TCP 9999                                | Port for inbound connections (from the local network to the security server)<br> Environmental monitoring daemon JMX listening port
  1.8  |                                           | Security server internal IP address(es) and hostname(s)
  1.9  |                                           | Security server public IP address, NAT address
  1.10 | &lt;by default, the server’s IP addresses and names are added to the certificate’s Distinguished Name (DN) field&gt; | Information about the user interface TLS certificate

--- a/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide_for_rhel7.md
+++ b/doc/Manuals/ig-ss_x-road_v6_security_server_installation_guide_for_rhel7.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 6**
 
-Version: 1.8  
+Version: 1.9  
 Doc. ID: IG-SS-RHEL7
 
 ---
@@ -25,6 +25,7 @@ Doc. ID: IG-SS-RHEL7
  30.04.2020 | 1.6     | Add instructions how to use remote database located in Microsoft Azure        | Ilkka Seppälä
  12.06.2020 | 1.7     | Update reference data regarding JMX listening ports | Petteri Kivimäki
  24.06.2020 | 1.8    | Add repository sign key details in section [2.2 Reference data](#22-reference-data) | Petteri Kivimäki
+ 24.06.2020 | 1.9    | Remove environmental and operational monitoring daemon JMX listening ports from section [2.2 Reference data](#22-reference-data) | Petteri Kivimäki
  
 ## Table of Contents <!-- omit in toc -->
 
@@ -112,8 +113,6 @@ The software can be installed both on physical and virtualized hardware (of the 
 | 1.6     | TCP 4000                 | User interface (local network)
 | 1.7     | TCP 8080 (or TCP 80)     | Information system access points (in the local network)<br>Connections from information systems
 |         | TCP 8443 (or TCP 443)    | Information system access points (in the local network)<br>Connections from information systems
-|         | TCP 9011                 | Port for inbound connections (from the local network to the security server)<br>Operational data monitoring daemon JMX listening port
-|         | TCP 9999                 | Port for inbound connections (from the local network to the security server)<br>Environmental monitoring daemon JMX listening port
 | 1.8     |                          | Security server internal IP address(es) and hostname(s)
 | 1.9     |                          | Security server public IP address, NAT address
 

--- a/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
+++ b/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 6**
 
-Version: 2.42
+Version: 2.43
 Doc. ID: UG-SS
 
 ---
@@ -75,7 +75,8 @@ Doc. ID: UG-SS
  01.04.2020 | 2.40    | Added notes about IP whitelists for APIs | Janne Mattila
  03.06.2020 | 2.41    | Updated audit logging description | Janne Mattila
  05.06.2020 | 2.42    | Added chapter about validation errors [19.4](#194-validation-errors) | Caro Hautamäki
-
+ 25.06.2020 | 2.43    | Update environmental and operational monitoring JMXMP details | Petteri Kivimäki
+ 
 ## Table of Contents <!-- omit in toc -->
 
 <!-- toc -->
@@ -1832,7 +1833,7 @@ The configuration anchor (renamed as `configuration-anchor.xml`) file must be ma
 
 The operational monitoring daemon makes health data available over the JMXMP protocol. The Zabbix monitoring software can be configured to gather that data periodically, using its built in JMX interface type.
 
-By default, the operational monitoring daemon exposes health data over JMXMP on localhost, port 9011, with no authentication configured and TLS enabled (see `/etc/xroad/services/opmonitor.conf`). This configuration has to be customized for external tools such as Zabbix to be able to access the data. Please refer to the documentation at \[[JMX](#Ref_JMX)\] for instructions on configuring access to the JMX interface of the operational monitoring daemon.
+By default, the operational monitoring daemon JMXMP is disabled. JMXMP must be enabled for external tools such as Zabbix to be able to access the data. Please refer to the documentation at \[[JMX](#Ref_JMX)\] for instructions on configuring access to the JMX interface of the operational monitoring daemon.
 
 For Zabbix to be able to gather data over JMX, the Zabbix Java gateway must be installed. See \[[ZABBIX-GATEWAY](#Ref_ZABBIX-GATEWAY)\] for instructions.
 
@@ -1859,7 +1860,7 @@ Monitoring extension schema is defined in \[[MONITORING_XSD](#Ref_MONITORING_XSD
 
 Environmental monitoring provides also a standard JMX endpoint which can be accessed with any JMX client (for example Java's jconsole application). See \[[ARC-ENVMON](#Ref_ARC-ENVMON)\] for details.
 
-JMX is disabled on default. JMX is enabled by adding standard JMX-related options to the executable java process as in example by \[[ZABBIX-JMX](#Ref_ZABBIX-JMX)\]. Monitor process options are defined in security server's path `/etc/xroad/services/monitor.conf`.
+JMX is disabled on default. JMX is enabled by adding standard JMX-related options to the executable java process as in example by \[[ZABBIX-JMX](#Ref_ZABBIX-JMX)\].
 
 ### 16.3 Limiting environmental monitoring remote data set
 

--- a/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
+++ b/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
@@ -4,7 +4,7 @@
 
 # X-Road: Operational Monitoring Daemon Architecture <!-- omit in toc -->
 
-Version: 1.0  
+Version: 1.1  
 Document ID: ARC-OPMOND
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -15,6 +15,7 @@ Document ID: ARC-OPMOND
 | 05.03.2018 | 0.8       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo   |
 | 18.02.2019 | 0.9       | New optional field: xRequestId (string) | Caro Hautamäki   |
 | 12.12.2019 | 1.0       | Update appendix A.2 with the updated fields | Ilkka Seppälä   |
+| 25.06.2020 | 1.1       | Update section 3.3 with the instructions how to enable JMX | Petteri Kivimäki   |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -133,6 +134,18 @@ The monitoring of the security servers is not the main functionality of the X-Ro
 ### 3.3 Operational Monitoring JMX
 
 This interface is used by a local monitoring system (e.g. Zabbix) to gather local operational health data of the security server via JMXMP. The interface is described in more detail in [[PR-OPMONJMX]](#PR-OPMONJMX).
+
+With the default configuration, JMX is disabled. JMX is enabled by adding the required configuration in `/etc/xroad/services/local.conf` file. The file is opened for editing and changes are made on the `OPMON_PARAMS` variable value. After the `OPMON_PARAMS` variable value has been updated, the `xroad-opmonitor` service must be restarted.
+                                                 
+The example configuration below enables JMX, binds it to port `9011` on any available interface with SSL and password authentication enabled:
+ 
+ ```
+OPMON_PARAMS="$OPMON_PARAMS \
+ -Djava.rmi.server.hostname=0.0.0.0 \
+ -Dcom.sun.management.jmxremote.port=9011 \
+ -Dcom.sun.management.jmxremote.authenticate=true \
+ -Dcom.sun.management.jmxremote.ssl=true "
+ ```
 
 The monitoring of the security servers is not the main functionality of the X-Road system, therefore the availability and responsiveness of this service is not paramount.
 

--- a/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
@@ -6,7 +6,7 @@
 
 **Technical Specification**
 
-Version: 1.0  
+Version: 1.1  
 Doc. ID: PR-OPMONJMX
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -15,6 +15,7 @@ Doc. ID: PR-OPMONJMX
 | 23.01.2017 | 0.3       | Added license text, table of contents and version history | Sami Kallio |
 | 05.03.2018 | 0.4       | Added terms and abbreviations reference and moved terms to term doc | Tatu Repo |
 | 12.12.2019 | 1.0       | Add description of serviceType gauges | Ilkka Seppälä |
+| 25.06.2020 | 1.1       | Add note about JMX being disabled by default | Petteri Kivimäki |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -50,6 +51,8 @@ All the sections of this specification contain normative information. All the re
 
 This specification does not include option for partially implementing the protocol – the conformant implementation must implement the entire specification.
 
+**By default, operational monitoring JMX interface is disabled. Enabling the JMX interface is explained in \[[ARC-OPMOND](#Ref_ARC-OPMOND)\].**
+
 ## 1.1 Terms and Abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
@@ -62,6 +65,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="Ref_METRICS"></a>**METRICS** -- GitHub - dropwizard/metrics: Capturing JVM- and application-level metrics. So you know what's going on, https://github.com/dropwizard/metrics  
 <a name="Ref_ZABBIX"></a>**ZABBIX** -- Zabbix Documentation 3.0 - JMX monitoring, https://www.zabbix.com/documentation/3.0/manual/config/items/itemtypes/jmx_monitoring  
 <a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
+<a name="Ref_ARC-OPMOND"></a>**ARC-OPMOND** -- X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md). 
 
 <a name="section_2"></a>
 # 2 Encoding X-Road Service Identifiers in Object Names

--- a/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
@@ -64,8 +64,8 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="Ref_JMXMP"></a>**JMXMP** -- Using JMX Connectors to Manage Resources Remotely, http://docs.oracle.com/javase/8/docs/technotes/guides/jmx/overview/connectors.html  
 <a name="Ref_METRICS"></a>**METRICS** -- GitHub - dropwizard/metrics: Capturing JVM- and application-level metrics. So you know what's going on, https://github.com/dropwizard/metrics  
 <a name="Ref_ZABBIX"></a>**ZABBIX** -- Zabbix Documentation 3.0 - JMX monitoring, https://www.zabbix.com/documentation/3.0/manual/config/items/itemtypes/jmx_monitoring  
-<a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
-<a name="Ref_ARC-OPMOND"></a>**ARC-OPMOND** -- X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md). 
+<a name="Ref_TERMS"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).<br />
+<a name="Ref_ARC-OPMOND"></a>**ARC-OPMOND** -- X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).
 
 <a name="section_2"></a>
 # 2 Encoding X-Road Service Identifiers in Object Names

--- a/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
+++ b/doc/OperationalMonitoring/Testing/test-opmon_x-road_operational_monitoring_testing_plan_Y-1104-2.md
@@ -4,7 +4,7 @@
 
 # X-Road: Operational Monitoring Testing Plan
 
-Version: 0.8  
+Version: 0.9  
 Doc ID: TEST-OPMON
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -13,6 +13,7 @@ Doc ID: TEST-OPMON
 | 23.01.2017 | 0.6       | Added license text, table of contents and version history | Sami Kallio |
 | 05.03.2018 | 0.7       | Added terms and abbreviations reference and moved terms to term doc. | Tatu Repo |
 | 05.02.2020 | 0.8       | Update information about the test suites. | Ilkka Seppälä |
+| 25.06.2020 | 0.9       | Update information about the JMX interface. | Petteri Kivimäki |
 
 ## Table of Contents
 <!-- toc -->
@@ -166,11 +167,10 @@ Direct observation of JMX metrics in `jconsole` is described in the following se
 
 ### 6.1 Testing the JMXMP Interface Using jconsole
 
-By default, the JMX interface of the operational monitoring daemon has been configured to listen on localhost, with authentication disabled and TLS enabled. In order to conveniently access this interface from a remote host, either directly or through an SSH tunnel, the following configuration must be used in `/etc/xroad/services/local.conf`, effectively overriding the value of the variable OPMON_PARAMS:
+By default, the JMX interface of the operational monitoring daemon is disabled. In order to conveniently access this interface from a remote host, either directly or through an SSH tunnel, the following configuration must be used in `/etc/xroad/services/local.conf`, effectively making changes on the `OPMON_PARAMS` parameter value:
 
 ```bash
-OPMON_PARAMS=" -javaagent:$METRICS_BUGFIX_AGENT -Xms50m -Xmx256m -XX:MaxMetaspaceSize=70m \
--Dlogback.configurationFile=/etc/xroad/conf.d/op-monitor-logback.xml \
+OPMON_PARAMS="OPMON_PARAMS \
 -Djava.rmi.server.hostname=<address> \
 -Dcom.sun.management.jmxremote \
 -Dcom.sun.management.jmxremote.port=<port> \

--- a/src/packages/src/xroad/common/op-monitor/etc/xroad/services/opmonitor.conf
+++ b/src/packages/src/xroad/common/op-monitor/etc/xroad/services/opmonitor.conf
@@ -6,11 +6,7 @@
 CP="/usr/share/xroad/jlib/op-monitor-daemon-1.0.jar"
 
 OPMON_PARAMS=" -Xms50m -Xmx256m -XX:MaxMetaspaceSize=80m \
--Dlogback.configurationFile=/etc/xroad/conf.d/op-monitor-logback.xml \
--Djava.rmi.server.hostname=127.0.0.1 \
--Dcom.sun.management.jmxremote.port=9011 \
--Dcom.sun.management.jmxremote.authenticate=false \
--Dcom.sun.management.jmxremote.ssl=true "
+-Dlogback.configurationFile=/etc/xroad/conf.d/op-monitor-logback.xml "
 
 # include local modifications
 . /etc/xroad/services/local.conf


### PR DESCRIPTION
- Disable operational monitoring JMX interface by default
- Update documentation
- Add instructions how to enable environmental and operational monitoring JMX interfaces