### PR TITLE
XRDDEV-1158

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
@@ -945,10 +945,11 @@ public class ServiceDescriptionService {
                 serviceDescriptionType.getService(),
                 newServices);
 
-        // On refresh the service url should not change so they are reset to original values
-        if (serviceDescriptionType.getUrl().equals(url)) {
-            resetServiceUrls(serviceDescriptionType, newServices);
-        }
+        // On refresh the service properties (URL, timeout, SSL authentication) should not change
+        // so the existing values must be kept. This applies to a case when 1) the WSDL URL remains the same
+        // and 2) the WSDL URL is changed. When the WSDL URL is changed (2), the service properties must keep
+        // the same values in case the WSDL fetched from the new URL contains services with the same service code.
+        updateServicePoperties(serviceDescriptionType, newServices);
 
         wsdlAuditData.put(SERVICES_ADDED, serviceChanges.getAddedFullServiceCodes());
         wsdlAuditData.put(SERVICES_DELETED, serviceChanges.getRemovedFullServiceCodes());
@@ -1000,9 +1001,9 @@ public class ServiceDescriptionService {
     }
 
     /**
-     * Reset the urls of each service to match its value before it was refreshed.
+     * Update the url, timeout and SSL authentication of each service to match its value before it was refreshed.
      */
-    private List<ServiceType> resetServiceUrls(ServiceDescriptionType serviceDescriptionType,
+    private List<ServiceType> updateServicePoperties(ServiceDescriptionType serviceDescriptionType,
             List<ServiceType> newServices) {
         return newServices.stream()
                 .map(newService -> {
@@ -1010,6 +1011,8 @@ public class ServiceDescriptionService {
                     serviceDescriptionType.getService().forEach(s -> {
                         if (newServiceFullName.equals(FormatUtils.getServiceFullName(s))) {
                             newService.setUrl(s.getUrl());
+                            newService.setTimeout(s.getTimeout());
+                            newService.setSslAuthentication(s.getSslAuthentication());
                         }
                     });
                     return newService;

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
@@ -751,13 +751,10 @@ public class ServiceDescriptionService {
         updateServiceCodes(restServiceCode, newRestServiceCode, serviceDescription);
 
         // Parse openapi definition and handle updating endpoints and acls
-        if (!serviceDescription.getUrl().equals(url)) {
-            parseOpenApi3ToServiceDescription(url, newRestServiceCode, ignoreWarnings, serviceDescription);
-        }
+        parseOpenApi3ToServiceDescription(url, newRestServiceCode, ignoreWarnings, serviceDescription);
 
         serviceDescription.setRefreshedDate(new Date());
         serviceDescription.setUrl(url);
-        serviceDescription.getService().get(0).setUrl(url);
 
         checkDuplicateServiceCodes(serviceDescription);
         checkDuplicateUrl(serviceDescription);
@@ -786,9 +783,6 @@ public class ServiceDescriptionService {
                     result.getWarnings());
             throw new UnhandledWarningsException(Arrays.asList(openapiParserWarnings));
         }
-
-        // Update url
-        updateServiceDescriptionUrl(serviceDescription, serviceCode, url);
 
         // Create endpoints from parsed results
         List<EndpointType> parsedEndpoints = result.getOperations().stream()
@@ -846,24 +840,6 @@ public class ServiceDescriptionService {
                 .orElseThrow(() -> new DeviationAwareRuntimeException("Service with servicecode: " + serviceCode
                         + " wasn't found from servicedescription with id: " + serviceDescriptiontype.getId()));
         service.setServiceCode(newserviceCode);
-    }
-
-    /**
-     * Updates the url of the given ServiceDescription and service attached to it with matching ServiceCode to one given
-     *
-     * @param serviceDescriptionType
-     * @param serviceCode
-     * @param url
-     */
-    private void updateServiceDescriptionUrl(ServiceDescriptionType serviceDescriptionType, String serviceCode,
-            String url) {
-        serviceDescriptionType.setUrl(url);
-        ServiceType service = serviceDescriptionType.getService().stream()
-                .filter(s -> serviceCode.equals(s.getServiceCode()))
-                .findFirst()
-                .orElseThrow(() -> new DeviationAwareRuntimeException("Service with servicecode: " + serviceCode
-                        + " wasn't found from servicedescription with id: " + serviceDescriptionType.getId()));
-        service.setUrl(url);
     }
 
     /**


### PR DESCRIPTION
Bug fixes for refresh and update WSDL and OpenAPI3 features:

- Do no overwrite timeout and SSL authentication values when WSDL is refreshed or updated.
- Do not overwrite service URL value when OpenAPI3 service description is refreshed or updated.
- Reload and parse OpenAPI3 service description on update so that implementation is consistent with WSDLs.

JIRA issue: https://jira.niis.org/browse/XRDDEV-1158