### PR TITLE
XRDDEV-1017: Make SignerClient more robust

### DIFF
--- a/src/autologin/source/common/xroad-autologin-retry.sh
+++ b/src/autologin/source/common/xroad-autologin-retry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-echo "looping starts"
+# allow signer to start up
+sleep 3
 return_value=-1
 while [ $return_value -ne 0 ]
 do
@@ -12,5 +12,5 @@ do
         echo "wrong PIN, or PIN not available and should not retry"
         break
     fi
-    sleep 1
+    sleep 3
 done

--- a/src/common-util/src/main/resources/akka-global.conf
+++ b/src/common-util/src/main/resources/akka-global.conf
@@ -1,40 +1,55 @@
 akka {
-    stdout-loglevel = "OFF"
-    loggers = ["akka.event.slf4j.Slf4jLogger"]
-    loglevel = "DEBUG"
-    logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  stdout-loglevel = "OFF"
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
-    actor {
-        # for now, using java serialization
-        allow-java-serialization = true
-        warn-about-java-serializer-usage = false
+  actor {
+    # for now, using java serialization
+    allow-java-serialization = true
+    warn-about-java-serializer-usage = false
+  }
+
+  remote {
+    artery {
+      transport = tcp
+
+      canonical {
+        port = 0
+        hostname = "127.0.0.1"
+      }
+
+      advanced {
+        # Maximum serialized message size, including header data.
+        maximum-frame-size = 256 KiB
+
+        # Disable compression:
+        #   Most actors are temporary (often used only once), but
+        #   the compression cache seems to keep mappings also to those
+        #   and use lot of memory.
+        #   All communications are over the loopback interface, compression
+        #   effect on performance is small.
+        compression {
+          actor-refs {
+            max = "off"
+          }
+          manifests {
+            max = "off"
+          }
+        }
+      }
     }
 
-    remote {
-        artery {
-            transport = tcp
+    # for now, using remoting directly instead of a cluster
+    warn-about-direct-use = off
 
-            canonical {
-                port = 0
-                hostname = "127.0.0.1"
-            }
+    # allow remote watch
+    use-unsafe-remote-features-outside-cluster = on
 
-            advanced {
-                # Maximum serialized message size, including header data.
-                maximum-frame-size = 256 KiB
-            }
-        }
-
-        # for now, using remoting directly instead of a cluster
-        warn-about-direct-use = off
-
-        # allow remote watch
-        use-unsafe-remote-features-outside-cluster = on
-
-        # but disable remote deployment
-        deployment {
-            enable-whitelist = on
-            whitelist = []
-        }
+    # but disable remote deployment
+    deployment {
+      enable-whitelist = on
+      whitelist = []
     }
+  }
 }

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -7,7 +7,7 @@ xroadVersion=6.24.0
 xroadBuildType=SNAPSHOT
 
 // common dependency versions
-akkaVersion=2.13:2.6.6
+akkaVersion=2.13:2.6.7
 metricsVersion=3.2.2
 jettyVersion=9.4.20.v20190813
 jaxbVersion=2.2.11

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -7,7 +7,7 @@ xroadVersion=6.24.0
 xroadBuildType=SNAPSHOT
 
 // common dependency versions
-akkaVersion=2.13:2.6.1
+akkaVersion=2.13:2.6.6
 metricsVersion=3.2.2
 jettyVersion=9.4.20.v20190813
 jaxbVersion=2.2.11

--- a/src/packages/src/xroad/default-configuration/signer.ini
+++ b/src/packages/src/xroad/default-configuration/signer.ini
@@ -9,7 +9,7 @@ device-configuration-file=/etc/xroad/devices.ini
 key-configuration-file=/etc/xroad/signer/keyconf.xml
 
 ; Timeout in milliseconds of the signer client
-client-timeout=60000
+client-timeout=50000
 
 ; Port number of Signer
 port=5558

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/config/StartStopListener.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/config/StartStopListener.java
@@ -54,6 +54,7 @@ public class StartStopListener implements ApplicationListener {
 
         if (uiApiActorSystem != null) {
             uiApiActorSystem.stop();
+            uiApiActorSystem = null;
         }
     }
 
@@ -69,9 +70,8 @@ public class StartStopListener implements ApplicationListener {
         log.debug("start");
         if (uiApiActorSystem == null) {
             uiApiActorSystem = new UIServices("ProxyUIApi", "proxyuiapi");
+            SignerClient.init(uiApiActorSystem.getActorSystem(), signerIp);
         }
-
-        SignerClient.init(uiApiActorSystem.getActorSystem(), signerIp);
     }
 
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/config/StartStopListener.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/config/StartStopListener.java
@@ -45,11 +45,11 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 //@Configuration
-public class StartStopListener implements ApplicationListener {
+public class StartStopListener implements ApplicationListener<ApplicationEvent> {
 
-    private static UIServices uiApiActorSystem;
+    private UIServices uiApiActorSystem;
 
-    private void stop() throws Exception {
+    private synchronized void stop() throws Exception {
         log.debug("stop");
 
         if (uiApiActorSystem != null) {
@@ -66,7 +66,7 @@ public class StartStopListener implements ApplicationListener {
      * Maybe be called multiple times since ContextRefreshedEvent can happen multiple times
      * @throws Exception
      */
-    private void start() throws Exception {
+    private synchronized void start() {
         log.debug("start");
         if (uiApiActorSystem == null) {
             uiApiActorSystem = new UIServices("ProxyUIApi", "proxyuiapi");

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
@@ -28,20 +28,30 @@ package ee.ria.xroad.signer.protocol;
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.SystemProperties;
 
+import akka.actor.ActorIdentity;
 import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
+import akka.actor.Identify;
+import akka.actor.Props;
+import akka.actor.Terminated;
+import akka.actor.UntypedAbstractActor;
 import akka.pattern.Patterns;
 import akka.util.Timeout;
 import lombok.extern.slf4j.Slf4j;
 import scala.concurrent.Await;
 
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static ee.ria.xroad.common.ErrorCodes.X_HTTP_ERROR;
+import static ee.ria.xroad.common.ErrorCodes.X_INTERNAL_ERROR;
 import static ee.ria.xroad.signer.protocol.ComponentNames.REQUEST_PROCESSOR;
 import static ee.ria.xroad.signer.protocol.ComponentNames.SIGNER;
+import static ee.ria.xroad.signer.protocol.SignerClient.SignerWatcher.signerRef;
 
 /**
  * Signer client is used to send messages to signer from other components
@@ -50,12 +60,9 @@ import static ee.ria.xroad.signer.protocol.ComponentNames.SIGNER;
 @Slf4j
 public final class SignerClient {
 
-    private static final int TIMEOUT_MILLIS =
-            SystemProperties.getSignerClientTimeout();
+    private static final Timeout TIMEOUT =
+            Timeout.apply(SystemProperties.getSignerClientTimeout(), TimeUnit.MILLISECONDS);
     public static final String LOCALHOST_IP = "127.0.0.1";
-
-    private static ActorSystem actorSystem;
-    private static ActorSelection requestProcessor;
 
     private SignerClient() {
     }
@@ -65,63 +72,50 @@ public final class SignerClient {
      * @param system the actor system
      * @throws Exception if an error occurs
      */
-    public static void init(ActorSystem system) throws Exception {
+    public static void init(ActorSystem system) {
         init(system, LOCALHOST_IP);
     }
 
     /**
      * Initializes the client with the provided actor system.
-     * @param system the actor system
+     * @param system          the actor system
      * @param signerIpAddress IP address for remote signer
-     *                         or 127.0.0.1 for local signer
+     *                        or 127.0.0.1 for local signer
      * @throws Exception if an error occurs
      */
-    public static void init(ActorSystem system,
-                            String signerIpAddress) throws Exception {
-        log.trace("init()");
-
-        if (SignerClient.actorSystem == null) {
-            SignerClient.actorSystem = system;
-
-            requestProcessor = system.actorSelection(
-                    getSignerPath(signerIpAddress) + "/user/" + REQUEST_PROCESSOR);
-
-        }
+    public static void init(ActorSystem system, String signerIpAddress) {
+        SignerWatcher.init(system, signerIpAddress);
     }
 
     /**
      * Forwards a message to the signer.
-     * @param message the message
+     * @param message  the message
      * @param receiver the receiver actor
      */
     public static void execute(Object message, ActorRef receiver) {
-        verifyInitialized();
-        requestProcessor.tell(message, receiver);
+        signerRef().tell(message, receiver);
     }
 
     /**
      * Sends a message and waits for a response, returning it. If the response
      * is an exception, throws it.
-     * @param <T> the type of result
+     * @param <T>     the type of result
      * @param message the message
      * @return the response
      * @throws Exception if the response is an exception
      */
     public static <T> T execute(Object message) throws Exception {
-        verifyInitialized();
-
-        final Timeout timeout = Timeout.apply(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         try {
-            return result(Await.result(Patterns.ask(requestProcessor, message, timeout), timeout.duration()));
-        } catch (TimeoutException te) {
-            throw connectionTimeoutException(te);
+            return result(Await.result(Patterns.ask(signerRef(), message, TIMEOUT), TIMEOUT.duration()));
+        } catch (TimeoutException e) {
+            throw new CodedException(X_INTERNAL_ERROR, e, "Request to Signer timed out");
         }
     }
 
     /**
      * Returns the object as the instance or throws exception, if the object
      * is throwable.
-     * @param <T> the type of result
+     * @param <T>    the type of result
      * @param result the result object
      * @return result
      * @throws Exception if the object is throwable
@@ -129,31 +123,130 @@ public final class SignerClient {
     @SuppressWarnings("unchecked")
     public static <T> T result(Object result) throws Exception {
         if (result instanceof Throwable) {
-            throw (Exception) result;
+            throw (Exception)result;
         } else {
-            return (T) result;
+            return (T)result;
         }
     }
 
-    private static String getSignerPath() {
-        return getSignerPath("127.0.0.1");
-    }
+    static class SignerWatcher extends UntypedAbstractActor {
 
-    private static String getSignerPath(String signerIpAddress) {
-        return "akka://" + SIGNER + "@" + signerIpAddress + ":"
-                + SystemProperties.getSignerPort();
-    }
+        // Implementation note. The requestProcessor future will be completed by the internally used
+        // SignerWatcher actor, and replaced with a new one in case the Signer is restarted. The purpose is to avoid
+        // long request timeouts when the signer is not (yet) available, and to detect restarts.
+        private static volatile CompletableFuture<ActorRef> requestProcessor = null;
+        private static final Duration WATCH_DELAY = Duration.ofSeconds(1);
+        private static final int REF_GET_TIMEOUT = 7;
 
-    private static void verifyInitialized() {
-        if (actorSystem == null) {
-            throw new IllegalStateException("SignerClient is not initialized");
+        static ActorRef signerRef() {
+            final CompletableFuture<ActorRef> processor = requestProcessor;
+            if (processor == null) {
+                throw new IllegalStateException("SignerClient is not initialized");
+            }
+            try {
+                return processor.get(REF_GET_TIMEOUT, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException | CancellationException e) {
+                throw new CodedException(X_INTERNAL_ERROR, e, "Signer is not available");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CodedException(X_INTERNAL_ERROR, e, "Request to signer was interrupted");
+            }
+        }
+
+        static synchronized void init(ActorSystem system, String signerIpAddress) {
+            if (requestProcessor == null) {
+                requestProcessor = new CompletableFuture<>();
+                system.actorOf(Props.create(SignerWatcher.class, signerIpAddress));
+            }
+        }
+
+        private long correlationId = 0;
+        private ActorRef signerRef;
+        private ActorSelection signer;
+        private final String signerIpAddress;
+
+        interface Watch {
+        }
+
+        SignerWatcher(String signerIpAddress) {
+            this.signerIpAddress = signerIpAddress;
+        }
+
+        @Override
+        public void preStart() {
+            signer = context().actorSelection(getSignerPath() + "/user/" + REQUEST_PROCESSOR);
+            self().tell(Watch.class, self());
+        }
+
+        @Override
+        public void postStop() {
+            if (signerRef != null) {
+                context().unwatch(signerRef);
+            }
+            requestProcessor.cancel(true);
+            requestProcessor = null;
+        }
+
+        @Override
+        public void onReceive(final Object message) {
+            if (Watch.class == message) {
+                if (signerRef == null) {
+                    identifyAgent();
+                    scheduleWatch();
+                }
+            } else if (message instanceof ActorIdentity) {
+                attachSigner((ActorIdentity)message);
+            } else if (message instanceof Terminated) {
+                detachSigner((Terminated)message);
+                scheduleWatch();
+            } else {
+                unhandled(message);
+            }
+        }
+
+        private void scheduleWatch() {
+            context().system().scheduler()
+                    .scheduleOnce(WATCH_DELAY, self(), Watch.class, context().system().dispatcher(), self());
+        }
+
+        private void detachSigner(final Terminated message) {
+            if (signerRef != null) {
+                log.warn("Signer detached");
+                context().unwatch(signerRef);
+                signerRef = null;
+            }
+            requestProcessor.cancel(true);
+            requestProcessor = new CompletableFuture<>();
+        }
+
+        private void attachSigner(final ActorIdentity message) {
+            if (message.correlationId().equals(correlationId)) {
+                if (signerRef != null) {
+                    context().unwatch(signerRef);
+                }
+                signerRef = message.getActorRef().orElse(null);
+                if (signerRef != null) {
+                    context().watch(signerRef);
+                    if (!requestProcessor.complete(signerRef)) {
+                        requestProcessor.cancel(true);
+                        requestProcessor = CompletableFuture.completedFuture(signerRef);
+                    }
+                    log.info("Signer attached");
+                } else {
+                    requestProcessor.cancel(true);
+                    requestProcessor = new CompletableFuture<>();
+                    log.debug("Signer not available");
+                }
+            }
+        }
+
+        private void identifyAgent() {
+            correlationId++;
+            signer.tell(new Identify(correlationId), self());
+        }
+
+        private String getSignerPath() {
+            return "akka://" + SIGNER + "@" + signerIpAddress + ":" + SystemProperties.getSignerPort();
         }
     }
-
-    private static CodedException connectionTimeoutException(Exception e) {
-        return new CodedException(X_HTTP_ERROR, e,
-                "Connection to Signer (port %s) timed out",
-                SystemProperties.getSignerPort());
-    }
-
 }

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
@@ -166,7 +166,7 @@ public final class SignerClient {
         }
 
         private static synchronized void resetRequestProcessor(CompletableFuture<ActorRef> processor) {
-            if (requestProcessor != null) {
+            if (requestProcessor != null && !requestProcessor.isDone()) {
                 requestProcessor.cancel(true);
             }
             requestProcessor = processor;
@@ -243,7 +243,9 @@ public final class SignerClient {
                     log.info("Signer attached");
                 } else {
                     log.debug("Signer is unreachable");
-                    resetRequestProcessor(new CompletableFuture<>());
+                    if (requestProcessor.isDone()) {
+                        resetRequestProcessor(new CompletableFuture<>());
+                    }
                 }
             }
         }

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/AbstractRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/AbstractRequestHandler.java
@@ -59,7 +59,8 @@ public abstract class AbstractRequestHandler<T> extends UntypedAbstractActor {
                 if (result instanceof Exception) {
                     handleError(translateException((Exception) result));
                 } else if (hasSender()) {
-                    getSender().tell(result, getSelf());
+                    //use parent as sender (avoids leaking the temp request handler ref)
+                    getSender().tell(result, context().parent());
                 }
             }
         } catch (ClassCastException e) {
@@ -91,7 +92,8 @@ public abstract class AbstractRequestHandler<T> extends UntypedAbstractActor {
         log.error("Error in request handler", e);
 
         if (hasSender()) {
-            getSender().tell(e.withPrefix(SIGNER_X), getSelf());
+            //use parent as sender (avoids leaking the temp request handler ref)
+            getSender().tell(e.withPrefix(SIGNER_X), context().parent());
         }
     }
 

--- a/src/signer/src/main/resources/application.conf
+++ b/src/signer/src/main/resources/application.conf
@@ -11,8 +11,6 @@ signer-main {
                     hostname = "127.0.0.1"
                     port = 2552 // will be overridden by application
                 }
-                untrusted-mode = on
-                trusted-selection-paths = ["/user/RequestProcessor"]
             }
         }
 


### PR DESCRIPTION
In certain conditions, SignerClient can observe timeout when Signer is restarted while a request is being made. Make SignerClient
to watch Signer's RequestProcessor actor, and in case of termination, try to re-establish connection as soon as possible. Alter the Signer startup to remove unnecessary delays.

Also update Akka to the latest patch version (2.6.6).