### PR TITLE
XRDDEV-1171 Fix service tab permission bug

### DIFF
--- a/src/proxy-ui-api/frontend/src/components/ui/Snackbar.vue
+++ b/src/proxy-ui-api/frontend/src/components/ui/Snackbar.vue
@@ -219,5 +219,4 @@ export default Vue.extend({
   overflow-y: auto;
   max-height: 300px;
 }
-
 </style>

--- a/src/proxy-ui-api/frontend/src/global.ts
+++ b/src/proxy-ui-api/frontend/src/global.ts
@@ -1,3 +1,5 @@
+import { Tab } from '@/ui-types';
+
 // A "single source of truth" for route names
 export enum RouteName {
   Keys = 'keys',
@@ -147,29 +149,33 @@ export enum CertificateStatus {
   GLOBAL_ERROR = 'GLOBAL_ERROR',
 }
 
-export const mainTabs = [
+export const mainTabs: Tab[] = [
   {
     to: { name: RouteName.Clients },
     key: 'clients',
     name: 'tab.main.clients',
-    permission: Permissions.VIEW_CLIENTS,
+    permissions: [Permissions.VIEW_CLIENTS],
   },
   {
     to: { name: RouteName.SignAndAuthKeys },
     key: 'keys',
     name: 'tab.main.keys',
-    permission: Permissions.VIEW_KEYS,
+    permissions: [Permissions.VIEW_KEYS],
   },
   {
     to: { name: RouteName.Diagnostics },
     key: 'diagnostics',
     name: 'tab.main.diagnostics',
-    permission: Permissions.DIAGNOSTICS,
+    permissions: [Permissions.DIAGNOSTICS],
   },
   {
     to: { name: RouteName.SystemParameters },
     key: 'settings',
     name: 'tab.main.settings',
+    permissions: [
+      Permissions.VIEW_SYS_PARAMS,
+      Permissions.BACKUP_CONFIGURATION,
+    ],
   },
 ];
 

--- a/src/proxy-ui-api/frontend/src/store/modules/user.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/user.ts
@@ -39,10 +39,14 @@ export const userGetters: GetterTree<UserState, RootState> = {
   getAllowedTabs: (state, getters) => (tabs: Tab[]) => {
     // returns filtered array of objects based on the 'permission' attribute
     const filteredTabs = tabs.filter((tab: Tab) => {
-      if (!tab.permission) {
+      if (!tab.permissions || tab.permissions.length === 0) {
+        // No permission needed for this tab
         return true;
       }
-      if (getters.hasPermission(tab.permission)) {
+      if (
+        tab.permissions.some((permission) => getters.hasPermission(permission))
+      ) {
+        // Return true if the user has at least one of the tabs permissions
         return true;
       }
       return false;

--- a/src/proxy-ui-api/frontend/src/ui-types.ts
+++ b/src/proxy-ui-api/frontend/src/ui-types.ts
@@ -14,7 +14,7 @@ export interface Tab {
       id?: string;
     };
   };
-  permission?: string;
+  permissions?: string[];
 }
 
 // Extension for Client

--- a/src/proxy-ui-api/frontend/src/views/Clients/Client.vue
+++ b/src/proxy-ui-api/frontend/src/views/Clients/Client.vue
@@ -98,7 +98,7 @@ export default Vue.extend({
     },
 
     tabs(): Tab[] {
-      const allTabs = [
+      const allTabs: Tab[] = [
         {
           key: 'details',
           name: 'tab.client.details',
@@ -114,7 +114,7 @@ export default Vue.extend({
             name: RouteName.MemberServers,
             params: { id: this.id },
           },
-          permission: Permissions.VIEW_CLIENT_INTERNAL_CERTS,
+          permissions: [Permissions.VIEW_CLIENT_INTERNAL_CERTS],
         },
       ];
 

--- a/src/proxy-ui-api/frontend/src/views/Clients/Subsystem.vue
+++ b/src/proxy-ui-api/frontend/src/views/Clients/Subsystem.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
             name: RouteName.SubsystemServiceClients,
             params: { id: this.id },
           },
-          permission: Permissions.VIEW_CLIENT_ACL_SUBJECTS,
+          permissions: [Permissions.VIEW_CLIENT_ACL_SUBJECTS],
         },
         {
           key: 'services',
@@ -106,7 +106,7 @@ export default Vue.extend({
             name: RouteName.SubsystemServices,
             params: { id: this.id },
           },
-          permission: Permissions.VIEW_CLIENT_SERVICES,
+          permissions: [Permissions.VIEW_CLIENT_SERVICES],
         },
         {
           key: 'internalServers',
@@ -115,7 +115,7 @@ export default Vue.extend({
             name: RouteName.SubsystemServers,
             params: { id: this.id },
           },
-          permission: Permissions.VIEW_CLIENT_INTERNAL_CERTS,
+          permissions: [Permissions.VIEW_CLIENT_INTERNAL_CERTS],
         },
         {
           key: 'localGroups',
@@ -124,7 +124,7 @@ export default Vue.extend({
             name: RouteName.SubsystemLocalGroups,
             params: { id: this.id },
           },
-          permission: Permissions.VIEW_CLIENT_LOCAL_GROUPS,
+          permissions: [Permissions.VIEW_CLIENT_LOCAL_GROUPS],
         },
       ];
 

--- a/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/KeysAndCertificates.vue
+++ b/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/KeysAndCertificates.vue
@@ -76,7 +76,7 @@ export default Vue.extend({
           to: {
             name: RouteName.ApiKey,
           },
-          permission: Permissions.VIEW_CLIENT_ACL_SUBJECTS,
+          permissions: [Permissions.VIEW_CLIENT_ACL_SUBJECTS],
           helpImage: 'api_keys.png',
           helpTitle: 'keys.helpTitleApi',
           helpText: 'keys.helpTextApi',
@@ -87,7 +87,7 @@ export default Vue.extend({
           to: {
             name: RouteName.SSTlsCertificate,
           },
-          permission: Permissions.VIEW_CLIENT_SERVICES,
+          permissions: [Permissions.VIEW_CLIENT_SERVICES],
           helpImage: 'tls_certificate.png',
           helpTitle: 'keys.helpTitleSS',
           helpText: 'keys.helpTextSS',

--- a/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
+++ b/src/proxy-ui-api/frontend/src/views/Settings/Settings.vue
@@ -31,14 +31,14 @@ export default Vue.extend({
   },
   computed: {
     tabs(): Tab[] {
-      const allTabs = [
+      const allTabs: Tab[] = [
         {
           key: 'system',
           name: 'tab.settings.systemParameters',
           to: {
             name: RouteName.SystemParameters,
           },
-          permission: Permissions.VIEW_SYS_PARAMS,
+          permissions: [Permissions.VIEW_SYS_PARAMS],
         },
         {
           key: 'backup',
@@ -46,7 +46,7 @@ export default Vue.extend({
           to: {
             name: RouteName.BackupAndRestore,
           },
-          permission: Permissions.BACKUP_CONFIGURATION,
+          permissions: [Permissions.BACKUP_CONFIGURATION],
         },
       ];
       return this.$store.getters.getAllowedTabs(allTabs);


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-1171

Changed the tab interface so that it has a permissions array instead of a permission string. Now a tab can have multiple permissions and if even one of them exists the tab visible. This fixes the "problem" that the Settings view doesn't have its own permission.