### PR TITLE
XRDDEV-1210: key label can't be null, as this causes a NPE in HardwareTokenWorker

### DIFF
--- a/src/proxy-ui-api/frontend/src/store/modules/certificateSignRequest.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/certificateSignRequest.ts
@@ -7,6 +7,7 @@ import {
   CertificateAuthority,
   CsrSubjectFieldDescription,
   KeyWithCertificateSigningRequestId,
+  KeyLabelWithCsrGenerate,
 } from '@/openapi-types';
 import * as api from '@/util/api';
 import { UsageTypes, CsrFormatTypes } from '@/global';
@@ -236,8 +237,8 @@ export const actions: ActionTree<CsrState, RootState> = {
   generateKeyAndCsr({ getters }, tokenId: string) {
     const crtObject = getters.csrRequestBody;
 
-    const body = {
-      key_label: undefined,
+    const body: KeyLabelWithCsrGenerate = {
+      key_label: '',
       csr_generate_request: crtObject,
     };
 

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -5295,13 +5295,14 @@ components:
     KeyLabelWithCsrGenerate: # ok
       type: object
       required:
+        - key_label
         - csr_generate_request
       properties:
         key_label:
           type: string
           format: text
           description: label for the new key
-          minLength: 1
+          minLength: 0
           maxLength: 255
           example: My new key
         csr_generate_request:


### PR DESCRIPTION
The old UI used an empty string, so we will allow the same to keep it optional.

JIRA issue: https://jira.niis.org/browse/XRDDEV-1210