### PR TITLE
XRDDEV-1206 & XRDDEV-1196 Snackbar error modifications

### DIFF
--- a/src/proxy-ui-api/frontend/src/components/ui/Snackbar.vue
+++ b/src/proxy-ui-api/frontend/src/components/ui/Snackbar.vue
@@ -1,41 +1,5 @@
 <template>
   <div>
-    <!-- Error: raw text  -->
-    <v-snackbar
-      data-test="error-snackbar"
-      v-model="showErrorRaw"
-      color="error"
-      :timeout="timeout"
-    >
-      {{ errorMessageRaw }}
-      <v-btn
-        icon
-        color="white"
-        data-test="close-snackbar"
-        @click="closeError()"
-      >
-        <v-icon dark>mdi-close-circle</v-icon>
-      </v-btn>
-    </v-snackbar>
-
-    <!-- Error: localization code. Doesn't close automatically  -->
-    <v-snackbar
-      data-test="error-snackbar"
-      v-model="showErrorCode"
-      color="error"
-      :timeout="forever"
-    >
-      {{ $t(errorMessageCode) }}
-      <v-btn
-        icon
-        color="white"
-        data-test="close-snackbar"
-        @click="closeError()"
-      >
-        <v-icon dark>mdi-close-circle</v-icon>
-      </v-btn>
-    </v-snackbar>
-
     <!-- Success: localization code -->
     <v-snackbar
       data-test="success-snackbar"
@@ -62,41 +26,56 @@
       }}</v-btn>
     </v-snackbar>
 
-    <!-- Error: Object. Doesn't close automatically -->
+    <!-- Error -->
     <v-snackbar
       data-test="indefinite-snackbar"
-      v-if="errorObject"
-      v-model="showError"
-      :timeout="forever"
+      v-for="notification in notifications"
+      :key="notification.timeAdded"
+      :timeout="notification.timeout"
+      v-model="notification.show"
       color="error"
       multi-line
+      @input="closeError(notification.timeAdded)"
     >
       <div class="row-wrapper scrollable">
-        <div v-if="errorCode">
-          {{ $t('error_code.' + errorCode) }}
+        <!-- Show localised text by id -->
+        <div v-if="notification.errorMessageCode">
+          {{ $t(notification.errorMessageCode) }}
         </div>
-        <div v-else="">
-          {{ errorObject }}
+
+        <!-- Show raw text -->
+        <div v-else-if="notification.errorMessageRaw">
+          {{ notification.errorMessageRaw }}
+        </div>
+
+        <!-- Show localised text by id from error object -->
+        <div v-else-if="notification.errorObject && errorCode(notification)">
+          {{ $t('error_code.' + errorCode(notification)) }}
+        </div>
+
+        <!-- If error doesn't have a text or localisation key then just print the error object -->
+        <div v-else-if="notification.errorObject">
+          {{ notification.errorObject }}
         </div>
 
         <!-- Show the error metadata if it exists -->
-        <div v-for="meta in errorMetadata" :key="meta">
+        <div v-for="meta in errorMetadata(notification)" :key="meta">
           {{ meta }}
         </div>
 
         <!-- Error ID -->
-        <div v-if="errorId">
+        <div v-if="errorId(notification)">
           {{ $t('id') }}:
-          {{ errorId }}
+          {{ errorId(notification) }}
         </div>
       </div>
 
-      <template v-if="errorId">
+      <template v-if="errorId(notification)">
         <v-btn
           outlined
           color="white"
           data-test="copy-id-button"
-          @click.prevent="copyId"
+          @click.prevent="copyId(notification)"
           >{{ $t('action.copyId') }}
         </v-btn>
       </template>
@@ -105,7 +84,7 @@
         icon
         color="white"
         data-test="close-snackbar"
-        @click="closeError()"
+        @click="closeError(notification.timeAdded)"
       >
         <v-icon dark>mdi-close-circle</v-icon>
       </v-btn>
@@ -117,17 +96,12 @@
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 import { toClipboard } from '@/util/helpers';
+import { Notification } from '@/ui-types';
 
 export default Vue.extend({
   // Component for snackbar notifications
   computed: {
-    ...mapGetters([
-      'successMessageCode',
-      'successMessageRaw',
-      'errorMessageRaw',
-      'errorMessageCode',
-      'errorObject',
-    ]),
+    ...mapGetters(['successMessageCode', 'successMessageRaw', 'notifications']),
 
     showSuccessCode: {
       get(): string {
@@ -145,51 +119,6 @@ export default Vue.extend({
         this.$store.commit('setSuccessRawVisible', value);
       },
     },
-    showError: {
-      get(): string {
-        return this.$store.getters.showErrorObject;
-      },
-      set(value: string) {
-        this.$store.commit('setErrorObjectVisible', value);
-      },
-    },
-    showErrorRaw: {
-      get(): string {
-        return this.$store.getters.showErrorRaw;
-      },
-      set(value: string) {
-        this.$store.commit('setErrorRawVisible', value);
-      },
-    },
-    showErrorCode: {
-      get(): string {
-        return this.$store.getters.showErrorCode;
-      },
-      set(value: string) {
-        this.$store.commit('setErrorCodeVisible', value);
-      },
-    },
-    errorCode(): string | undefined {
-      if (this.errorObject?.response?.data?.error?.code) {
-        return this.errorObject.response.data.error.code;
-      }
-
-      return undefined;
-    },
-    errorId(): string | undefined {
-      if (this.errorObject?.response?.headers['x-road-ui-correlation-id']) {
-        return this.errorObject.response.headers['x-road-ui-correlation-id'];
-      }
-
-      return undefined;
-    },
-    errorMetadata(): string[] {
-      if (this.errorObject?.response?.data?.error?.metadata) {
-        return this.errorObject.response.data.error.metadata;
-      }
-
-      return [];
-    },
   },
 
   data() {
@@ -199,18 +128,45 @@ export default Vue.extend({
     };
   },
   methods: {
+    errorCode(notification: Notification): string | undefined {
+      if (notification.errorObject?.response?.data?.error?.code) {
+        return notification.errorObject.response.data.error.code;
+      }
+
+      return undefined;
+    },
+
+    errorMetadata(notification: Notification): string[] {
+      if (notification.errorObject?.response?.data?.error?.metadata) {
+        return notification.errorObject.response.data.error.metadata;
+      }
+
+      return [];
+    },
+
+    errorId(notification: Notification): string | undefined {
+      if (
+        notification.errorObject?.response?.headers['x-road-ui-correlation-id']
+      ) {
+        return notification.errorObject.response.headers[
+          'x-road-ui-correlation-id'
+        ];
+      }
+
+      return undefined;
+    },
+
     closeSuccess(): void {
       this.$store.commit('setSuccessRawVisible', false);
       this.$store.commit('setSuccessCodeVisible', false);
     },
-    closeError(): void {
-      this.$store.commit('setErrorRawVisible', false);
-      this.$store.commit('setErrorCodeVisible', false);
-      this.$store.commit('setErrorObjectVisible', false);
+    closeError(id: number): void {
+      this.$store.commit('deleteNotification', id);
     },
-    copyId(): void {
-      if (this.errorId) {
-        toClipboard(this.errorId);
+    copyId(notification: Notification): void {
+      const id = this.errorId(notification);
+      if (id) {
+        toClipboard(id);
       }
     },
   },

--- a/src/proxy-ui-api/frontend/src/store/modules/notifications.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/notifications.ts
@@ -1,18 +1,13 @@
 import { ActionTree, GetterTree, Module, MutationTree } from 'vuex';
 import { RootState } from '../types';
+import { Notification } from '@/ui-types';
 
 export interface NotificationsState {
   successMessageCode: string;
   successMessageRaw: string;
   showSuccessCode: boolean;
   showSuccessRaw: boolean;
-  errorMessageCode: string;
-  errorMessageRaw: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  errorObject: any;
-  showErrorObject: boolean;
-  showErrorRaw: boolean;
-  showErrorCode: boolean;
+  notifications: Notification[];
 }
 
 const getDefaultState = () => {
@@ -21,12 +16,7 @@ const getDefaultState = () => {
     successMessageRaw: '',
     showSuccessCode: false,
     showSuccessRaw: false,
-    errorMessageCode: '',
-    errorMessageRaw: '',
-    showErrorObject: false,
-    showErrorCode: false,
-    showErrorRaw: false,
-    errorObject: undefined,
+    notifications: [],
   };
 };
 
@@ -46,24 +36,8 @@ export const getters: GetterTree<NotificationsState, RootState> = {
   successMessageRaw(state: NotificationsState): string {
     return state.successMessageRaw;
   },
-  showErrorObject(state: NotificationsState): boolean {
-    return state.showErrorObject;
-  },
-  showErrorRaw(state: NotificationsState): boolean {
-    return state.showErrorRaw;
-  },
-  showErrorCode(state: NotificationsState): boolean {
-    return state.showErrorCode;
-  },
-  errorMessageRaw(state: NotificationsState): string {
-    return state.errorMessageRaw;
-  },
-  errorMessageCode(state: NotificationsState): string {
-    return state.errorMessageCode;
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  errorObject(state: NotificationsState): any {
-    return state.errorObject;
+  notifications(state: NotificationsState): Notification[] {
+    return state.notifications;
   },
 };
 
@@ -80,17 +54,35 @@ export const mutations: MutationTree<NotificationsState> = {
     state.showSuccessRaw = true;
   },
   setErrorMessageCode(state: NotificationsState, val: string): void {
-    state.errorMessageCode = val;
-    state.showErrorCode = true;
+    const temp: Notification = {
+      timeout: 0,
+      errorMessageCode: val,
+      timeAdded: Date.now(),
+      show: true,
+    };
+
+    state.notifications.push(temp);
   },
   setErrorMessageRaw(state: NotificationsState, val: string): void {
-    state.errorMessageRaw = val;
-    state.showErrorRaw = true;
+    const temp: Notification = {
+      timeout: 2000,
+      errorMessageRaw: val,
+      timeAdded: Date.now(),
+      show: true,
+    };
+
+    state.notifications.push(temp);
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setErrorObject(state: NotificationsState, errorObject: any): void {
-    state.errorObject = errorObject;
-    state.showErrorObject = true;
+    const temp: Notification = {
+      timeout: 0,
+      errorObject: errorObject,
+      timeAdded: Date.now(), // Simple id solution
+      show: true,
+    };
+
+    state.notifications.push(temp);
   },
   setSuccessRawVisible(state: NotificationsState, val: boolean): void {
     state.showSuccessRaw = val;
@@ -98,14 +90,10 @@ export const mutations: MutationTree<NotificationsState> = {
   setSuccessCodeVisible(state: NotificationsState, val: boolean): void {
     state.showSuccessCode = val;
   },
-  setErrorRawVisible(state: NotificationsState, val: boolean): void {
-    state.showErrorRaw = val;
-  },
-  setErrorCodeVisible(state: NotificationsState, val: boolean): void {
-    state.showErrorCode = val;
-  },
-  setErrorObjectVisible(state: NotificationsState, val: boolean): void {
-    state.showErrorObject = val;
+  deleteNotification(state: NotificationsState, id: number): void {
+    state.notifications = state.notifications.filter(
+      (item: Notification) => item.timeAdded !== id,
+    );
   },
 };
 

--- a/src/proxy-ui-api/frontend/src/ui-types.ts
+++ b/src/proxy-ui-api/frontend/src/ui-types.ts
@@ -33,3 +33,16 @@ export type FileUploadResult = {
   buffer: ArrayBuffer;
   file: File;
 };
+
+// Data for snackbar notification
+export interface Notification {
+  timeAdded: number;
+  timeout: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errorObject?: any;
+  errorMessageCode?: string;
+  errorMessageRaw?: string;
+  successMessageCode?: string;
+  successMessageRaw?: string;
+  show: boolean;
+}


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-1206
https://jira.niis.org/browse/XRDDEV-1196

- Errors are now stored in an array
- Snackbars open on top of each other, but the user can see all the errors by closing the topmost
- Not a perfect solution because in some cases the errors can accumulate. How to handle that should be decided later.