### PR TITLE
XRDDEV-1239/XRDDEV-1240

### DIFF
--- a/src/proxy-ui-api/frontend/src/locales/en.json
+++ b/src/proxy-ui-api/frontend/src/locales/en.json
@@ -261,7 +261,11 @@
     "adding_services": "Adding services:",
     "wsdl_validation_warnings": "Validation warnings:",
     "memberNameGroupDesc": "Member name / Group description",
-    "idGroupCode": "ID / Group code"
+    "idGroupCode": "ID / Group code",
+    "service_parameters_ssl_test_warnings": {
+      "internal_server_ssl_handshake_error": "TLS handshake with the upstream server failed, server certificate missing from configuration:",
+      "internal_server_ssl_error": "Checking internal server certificates failed. Is the upstream server URL correct and accessible by the Security Server?"
+    }
   },
   "endpoints": {
     "addEndpoint": "Add Endpoint",
@@ -686,8 +690,6 @@
     "sessionExpired": "Session expired"
   },
   "customValidation": {
-    "invalidRest": "REST URL is not valid",
-    "invalidWsdl": "WSDL URL is not valid",
     "invalidUrl": "URL is not valid",
     "invalidXrdIdentifier": "Identifier value contains illegal characters"
   },

--- a/src/proxy-ui-api/frontend/src/locales/en.json
+++ b/src/proxy-ui-api/frontend/src/locales/en.json
@@ -852,6 +852,7 @@
     },
     "diagnostic_request_failed": "Diagnostic request failed",
     "malformed_url": "Malformed URL",
+    "invalid_https_url": "URL does not use HTTPS",
     "weak_pin": "Weak PIN",
     "process_not_executable": "Process is not executable",
     "invalid_filename": "Invalid filename",

--- a/src/proxy-ui-api/frontend/src/plugins/vee-validate.ts
+++ b/src/proxy-ui-api/frontend/src/plugins/vee-validate.ts
@@ -35,7 +35,7 @@ extend('restUrl', {
   },
   message() {
     // You might want to generate a more complex message with this function.
-    return i18n.t('customValidation.invalidRest') as string;
+    return i18n.t('customValidation.invalidUrl') as string;
   },
 });
 
@@ -47,7 +47,7 @@ extend('wsdlUrl', {
     return false;
   },
   message() {
-    return i18n.t('customValidation.invalidWsdl') as string;
+    return i18n.t('customValidation.invalidUrl') as string;
   },
 });
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
@@ -53,6 +53,7 @@ import org.niis.xroad.restapi.service.ServiceClientService;
 import org.niis.xroad.restapi.service.ServiceDescriptionService;
 import org.niis.xroad.restapi.service.ServiceNotFoundException;
 import org.niis.xroad.restapi.service.ServiceService;
+import org.niis.xroad.restapi.service.UnhandledWarningsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -119,17 +120,21 @@ public class ServicesApiController implements ServicesApi {
         ClientId clientId = serviceConverter.parseClientId(id);
         String fullServiceCode = serviceConverter.parseFullServiceCode(id);
         Service updatedService = null;
+        boolean ignoreWarnings = serviceUpdate.getIgnoreWarnings();
         try {
             updatedService = serviceConverter.convert(
                     serviceService.updateService(clientId, fullServiceCode,
                             serviceUpdate.getUrl(), serviceUpdate.getUrlAll(),
                             serviceUpdate.getTimeout(), serviceUpdate.getTimeoutAll(),
-                            Boolean.TRUE.equals(serviceUpdate.getSslAuth()), serviceUpdate.getSslAuthAll()),
+                            Boolean.TRUE.equals(serviceUpdate.getSslAuth()), serviceUpdate.getSslAuthAll(),
+                            ignoreWarnings),
                     clientId);
         } catch (InvalidUrlException e) {
             throw new BadRequestException(e);
         } catch (ClientNotFoundException | ServiceNotFoundException e) {
             throw new ResourceNotFoundException(e);
+        } catch (UnhandledWarningsException e) {
+            throw new BadRequestException(e);
         }
         return new ResponseEntity<>(updatedService, HttpStatus.OK);
     }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
@@ -130,12 +130,10 @@ public class ServicesApiController implements ServicesApi {
                             Boolean.TRUE.equals(serviceUpdate.getSslAuth()), serviceUpdate.getSslAuthAll(),
                             ignoreWarnings),
                     clientId);
-        } catch (InvalidUrlException | InvalidHttpsUrlException e) {
+        } catch (InvalidUrlException | InvalidHttpsUrlException | UnhandledWarningsException e) {
             throw new BadRequestException(e);
         } catch (ClientNotFoundException | ServiceNotFoundException e) {
             throw new ResourceNotFoundException(e);
-        } catch (UnhandledWarningsException e) {
-            throw new BadRequestException(e);
         }
         return new ResponseEntity<>(updatedService, HttpStatus.OK);
     }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServicesApiController.java
@@ -47,6 +47,7 @@ import org.niis.xroad.restapi.service.AccessRightService;
 import org.niis.xroad.restapi.service.ClientNotFoundException;
 import org.niis.xroad.restapi.service.EndpointAlreadyExistsException;
 import org.niis.xroad.restapi.service.EndpointNotFoundException;
+import org.niis.xroad.restapi.service.InvalidHttpsUrlException;
 import org.niis.xroad.restapi.service.InvalidUrlException;
 import org.niis.xroad.restapi.service.ServiceClientNotFoundException;
 import org.niis.xroad.restapi.service.ServiceClientService;
@@ -129,7 +130,7 @@ public class ServicesApiController implements ServicesApi {
                             Boolean.TRUE.equals(serviceUpdate.getSslAuth()), serviceUpdate.getSslAuthAll(),
                             ignoreWarnings),
                     clientId);
-        } catch (InvalidUrlException e) {
+        } catch (InvalidUrlException | InvalidHttpsUrlException e) {
             throw new BadRequestException(e);
         } catch (ClientNotFoundException | ServiceNotFoundException e) {
             throw new ResourceNotFoundException(e);

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InternalServerTestService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InternalServerTestService.java
@@ -1,0 +1,193 @@
+/**
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.restapi.service;
+
+import ee.ria.xroad.common.conf.InternalSSLKey;
+import ee.ria.xroad.common.conf.serverconf.ServerConf;
+import ee.ria.xroad.common.conf.serverconf.model.CertificateType;
+import ee.ria.xroad.common.util.CryptoUtils;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.niis.xroad.restapi.wsdl.HostnameVerifiers;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.net.Socket;
+import java.net.URL;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service class for testing internal server connections
+ */
+@Slf4j
+@Service
+@Transactional
+@PreAuthorize("isAuthenticated()")
+public class InternalServerTestService {
+    /**
+     * Tests if a HTTPS connection can be established to the given URL using
+     * the specified certificates.
+     * @param trustedCerts certificates used for authentication
+     * @param url the URL for opening the connection
+     * @throws Exception in case connection fails
+     */
+    public void testHttpsConnection(
+            List<CertificateType> trustedCerts, String url) throws Exception {
+
+        List<X509Certificate> trustedX509Certs = new ArrayList<>();
+        for (CertificateType trustedCert : trustedCerts) {
+            trustedX509Certs.add(CryptoUtils.readCertificate(trustedCert.getData()));
+        }
+
+        SSLContext ctx = SSLContext.getInstance(CryptoUtils.SSL_PROTOCOL);
+        ctx.init(createServiceKeyManager(),
+                new TrustManager[] {new ServiceTrustManager(trustedX509Certs)},
+                new SecureRandom());
+
+        HttpsURLConnection con = (HttpsURLConnection)(new URL(url).openConnection());
+
+        con.setSSLSocketFactory(ctx.getSocketFactory());
+        con.setHostnameVerifier(HostnameVerifiers.ACCEPT_ALL);
+
+        con.connect();
+    }
+
+    private KeyManager[] createServiceKeyManager() throws Exception {
+        InternalSSLKey key = ServerConf.getSSLKey();
+
+        if (key != null) {
+            return new KeyManager[] {new ServiceKeyManager(key)};
+        }
+
+        return null;
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+    private class ServiceKeyManager extends X509ExtendedKeyManager {
+
+        private static final String ALIAS = "AuthKeyManager";
+
+        private final InternalSSLKey sslKey;
+
+        @Override
+        public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+            return ALIAS;
+        }
+
+        @Override
+        public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+            return ALIAS;
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            return ALIAS;
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return ALIAS;
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            log.trace("getCertificateChain: {}", (Object)sslKey.getCertChain());
+            return sslKey.getCertChain();
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            log.trace("getPrivateKey: {}", sslKey.getKey());
+            return sslKey.getKey();
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+    }
+
+    private class ServiceTrustManager implements X509TrustManager {
+
+        private List<X509Certificate> trustedCerts;
+
+        ServiceTrustManager(List<X509Certificate> trustedCerts) {
+            this.trustedCerts = trustedCerts;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            log.trace("checkClientTrusted()");
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+
+            if (chain == null || chain.length == 0) {
+                throw new IllegalArgumentException(
+                        "Server certificate chain is empty");
+            }
+
+            if (trustedCerts.contains(chain[0])) {
+                log.trace("Found matching IS certificate");
+                return;
+            }
+
+            log.error("Could not find matching IS certificate");
+            throw new CertificateException("Server certificate is not trusted");
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            log.trace("getAcceptedIssuers()");
+            return new X509Certificate[] {};
+        }
+    }
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InvalidHttpsUrlException.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InvalidHttpsUrlException.java
@@ -1,0 +1,44 @@
+/**
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.restapi.service;
+
+import org.niis.xroad.restapi.exceptions.ErrorDeviation;
+
+public class InvalidHttpsUrlException extends ServiceException {
+    public static final String ERROR_INVALID_HTTPS_URL = "invalid_https_url";
+
+    public InvalidHttpsUrlException() {
+        super(createError());
+    }
+
+    public InvalidHttpsUrlException(String s) {
+        super(s, createError());
+    }
+
+    private static ErrorDeviation createError() {
+        return new ErrorDeviation(ERROR_INVALID_HTTPS_URL);
+    }
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceService.java
@@ -67,8 +67,8 @@ import static org.niis.xroad.restapi.config.audit.RestApiAuditProperty.URL;
 @PreAuthorize("isAuthenticated()")
 public class ServiceService {
 
+    public static final String WARNING_INTERNAL_SERVER_SSL_HANDSHAKE_ERROR = "internal_server_ssl_handshake_error";
     public static final String WARNING_INTERNAL_SERVER_SSL_ERROR = "internal_server_ssl_error";
-    public static final String WARNING_INTERNAL_SERVER_SSL_FAILURE = "internal_server_ssl_failure";
 
     private final ClientRepository clientRepository;
     private final ServiceDescriptionRepository serviceDescriptionRepository;
@@ -171,9 +171,10 @@ public class ServiceService {
             try {
                 internalServerTestService.testHttpsConnection(client.getIsCert(), url);
             } catch (SSLHandshakeException she) {
-                throw new UnhandledWarningsException(new WarningDeviation(WARNING_INTERNAL_SERVER_SSL_ERROR, url));
+                throw new UnhandledWarningsException(
+                        new WarningDeviation(WARNING_INTERNAL_SERVER_SSL_HANDSHAKE_ERROR, url));
             } catch (Exception e) {
-                throw new UnhandledWarningsException(new WarningDeviation(WARNING_INTERNAL_SERVER_SSL_FAILURE, url));
+                throw new UnhandledWarningsException(new WarningDeviation(WARNING_INTERNAL_SERVER_SSL_ERROR, url));
             }
         }
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceService.java
@@ -141,6 +141,7 @@ public class ServiceService {
      * @param sslAuthAll
      * @return ServiceType
      * @throws InvalidUrlException if given url was not valid
+     * @throws InvalidHttpsUrlException if given url does not use https and https is required
      * @throws ServiceNotFoundException if service with given fullServicecode was not found
      * @throws ClientNotFoundException if client with given id was not found
      * @throws UnhandledWarningsException if SSL auth is enabled and verification of the SSL connection between the
@@ -149,7 +150,7 @@ public class ServiceService {
     public ServiceType updateService(ClientId clientId, String fullServiceCode,
             String url, boolean urlAll, Integer timeout, boolean timeoutAll,
             boolean sslAuth, boolean sslAuthAll, boolean ignoreWarnings) throws InvalidUrlException,
-            ServiceNotFoundException, ClientNotFoundException, UnhandledWarningsException {
+            ServiceNotFoundException, ClientNotFoundException, UnhandledWarningsException, InvalidHttpsUrlException {
 
         auditDataHelper.put(clientId);
 
@@ -157,7 +158,7 @@ public class ServiceService {
             throw new InvalidUrlException("URL is not valid: " + url);
         }
         if (sslAuth && !FormatUtils.isHttpsUrl(url)) {
-            throw new InvalidUrlException("HTTPS must be used when SSL authentication is enabled");
+            throw new InvalidHttpsUrlException("HTTPS must be used when SSL authentication is enabled");
         }
 
         ServiceType serviceType = getService(clientId, fullServiceCode);

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -5602,6 +5602,11 @@ components:
           type: boolean
           example: false
           default: false
+        ignore_warnings:
+          type: boolean
+          default: false
+          description: if true, any ignorable warnings are ignored. if false (or missing),
+            any warnings cause request to fail
     Endpoint:
       type: object
       description: Endpoint for a service

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/AbstractApiControllerTestContext.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/AbstractApiControllerTestContext.java
@@ -38,6 +38,7 @@ import org.niis.xroad.restapi.service.CertificateAuthorityService;
 import org.niis.xroad.restapi.service.DiagnosticService;
 import org.niis.xroad.restapi.service.GlobalConfService;
 import org.niis.xroad.restapi.service.InitializationService;
+import org.niis.xroad.restapi.service.InternalServerTestService;
 import org.niis.xroad.restapi.service.KeyService;
 import org.niis.xroad.restapi.service.NotificationService;
 import org.niis.xroad.restapi.service.PossibleActionsRuleEngine;
@@ -97,6 +98,8 @@ public abstract class AbstractApiControllerTestContext extends AbstractFacadeMoc
     InternalTlsCertificateRepository mockRepository;
     @MockBean
     VersionService versionService;
+    @MockBean
+    InternalServerTestService internalServerTestService;
     // temporarily public accessor, I have plan to merge restapi.controller and restapi.openapi packages
     @MockBean
     public NotificationService notificationService;

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -42,6 +42,8 @@ import org.niis.xroad.restapi.util.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -53,10 +55,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.niis.xroad.restapi.service.AccessRightService.AccessRightNotFoundException.ERROR_ACCESSRIGHT_NOT_FOUND;
 import static org.niis.xroad.restapi.service.ClientNotFoundException.ERROR_CLIENT_NOT_FOUND;
+import static org.niis.xroad.restapi.service.InvalidUrlException.ERROR_MALFORMED_URL;
 import static org.niis.xroad.restapi.service.ServiceNotFoundException.ERROR_SERVICE_NOT_FOUND;
+import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_ERROR;
+import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_FAILURE;
 
 /**
  * Test ServicesApiController
@@ -125,13 +131,52 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
 
     @Test
     @WithMockUser(authorities = { "VIEW_CLIENT_SERVICES", "EDIT_SERVICE_PARAMS" })
+    public void updateServiceHttpsVerifySslAuth() throws Exception {
+        doThrow(new SSLHandshakeException("")).when(internalServerTestService).testHttpsConnection(any(), any());
+
+        Service service = servicesApiController.getService(TestUtils.SS1_GET_RANDOM_V1).getBody();
+        assertEquals(60, service.getTimeout().intValue());
+
+        ServiceUpdate serviceUpdate = new ServiceUpdate();
+        serviceUpdate.setTimeout(10);
+        serviceUpdate.setSslAuth(true);
+        serviceUpdate.setUrl(TestUtils.URL_HTTPS);
+
+        try {
+            servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
+            fail("should throw BadRequestException");
+        } catch (BadRequestException expected) {
+            assertEquals(WARNING_INTERNAL_SERVER_SSL_ERROR,
+                    expected.getWarningDeviations().iterator().next().getCode());
+        }
+
+        doThrow(new Exception("")).when(internalServerTestService).testHttpsConnection(any(), any());
+        try {
+            servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
+            fail("should throw BadRequestException");
+        } catch (BadRequestException expected) {
+            assertEquals(WARNING_INTERNAL_SERVER_SSL_FAILURE,
+                    expected.getWarningDeviations().iterator().next().getCode());
+        }
+
+        serviceUpdate.setIgnoreWarnings(true);
+
+        Service updatedService = servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1,
+                serviceUpdate).getBody();
+        assertEquals(10, updatedService.getTimeout().intValue());
+        assertEquals(true, updatedService.getSslAuth());
+        assertEquals(TestUtils.URL_HTTPS, updatedService.getUrl());
+    }
+
+    @Test
+    @WithMockUser(authorities = { "VIEW_CLIENT_SERVICES", "EDIT_SERVICE_PARAMS" })
     public void updateServiceHttp() {
         Service service = servicesApiController.getService(TestUtils.SS1_GET_RANDOM_V1).getBody();
         assertEquals(60, service.getTimeout().intValue());
 
         ServiceUpdate serviceUpdate = new ServiceUpdate();
         serviceUpdate.setTimeout(10);
-        serviceUpdate.setSslAuth(true); // value does not matter if http - will aways be set to null
+        serviceUpdate.setSslAuth(false); // value will be set to null if http
         serviceUpdate.setUrl(TestUtils.URL_HTTP);
 
         Service updatedService = servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1,
@@ -139,6 +184,26 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
         assertEquals(10, updatedService.getTimeout().intValue());
         assertTrue(updatedService.getSslAuth());
         assertEquals(TestUtils.URL_HTTP, updatedService.getUrl());
+    }
+
+    @Test
+    @WithMockUser(authorities = { "VIEW_CLIENT_SERVICES", "EDIT_SERVICE_PARAMS" })
+    public void updateServiceHttpVerifySslAuth() {
+        when(backupService.getBackupFiles()).thenThrow(new RuntimeException());
+        Service service = servicesApiController.getService(TestUtils.SS1_GET_RANDOM_V1).getBody();
+        assertEquals(60, service.getTimeout().intValue());
+
+        ServiceUpdate serviceUpdate = new ServiceUpdate();
+        serviceUpdate.setTimeout(10);
+        serviceUpdate.setSslAuth(true); // value will be set to null if http
+        serviceUpdate.setUrl(TestUtils.URL_HTTP);
+
+        try {
+            servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
+            fail("should throw BadRequestException");
+        } catch (BadRequestException expected) {
+            assertEquals(ERROR_MALFORMED_URL, expected.getErrorDeviation().getCode());
+        }
     }
 
     @Test
@@ -177,6 +242,7 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
         serviceUpdate.setTimeout(10);
         serviceUpdate.setSslAuth(true);
         serviceUpdate.setUrl(TestUtils.URL_HTTPS);
+        serviceUpdate.setIgnoreWarnings(true);
 
         Service updatedService = servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1,
                 serviceUpdate).getBody();

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.niis.xroad.restapi.service.AccessRightService.AccessRightNotFoundException.ERROR_ACCESSRIGHT_NOT_FOUND;
 import static org.niis.xroad.restapi.service.ClientNotFoundException.ERROR_CLIENT_NOT_FOUND;
-import static org.niis.xroad.restapi.service.InvalidUrlException.ERROR_MALFORMED_URL;
+import static org.niis.xroad.restapi.service.InvalidHttpsUrlException.ERROR_INVALID_HTTPS_URL;
 import static org.niis.xroad.restapi.service.ServiceNotFoundException.ERROR_SERVICE_NOT_FOUND;
 import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_ERROR;
 import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_HANDSHAKE_ERROR;
@@ -202,7 +202,7 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
             servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
             fail("should throw BadRequestException");
         } catch (BadRequestException expected) {
-            assertEquals(ERROR_MALFORMED_URL, expected.getErrorDeviation().getCode());
+            assertEquals(ERROR_INVALID_HTTPS_URL, expected.getErrorDeviation().getCode());
         }
     }
 

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -62,7 +62,7 @@ import static org.niis.xroad.restapi.service.ClientNotFoundException.ERROR_CLIEN
 import static org.niis.xroad.restapi.service.InvalidUrlException.ERROR_MALFORMED_URL;
 import static org.niis.xroad.restapi.service.ServiceNotFoundException.ERROR_SERVICE_NOT_FOUND;
 import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_ERROR;
-import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_FAILURE;
+import static org.niis.xroad.restapi.service.ServiceService.WARNING_INTERNAL_SERVER_SSL_HANDSHAKE_ERROR;
 
 /**
  * Test ServicesApiController
@@ -146,7 +146,7 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
             servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
             fail("should throw BadRequestException");
         } catch (BadRequestException expected) {
-            assertEquals(WARNING_INTERNAL_SERVER_SSL_ERROR,
+            assertEquals(WARNING_INTERNAL_SERVER_SSL_HANDSHAKE_ERROR,
                     expected.getWarningDeviations().iterator().next().getCode());
         }
 
@@ -155,7 +155,7 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
             servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1, serviceUpdate);
             fail("should throw BadRequestException");
         } catch (BadRequestException expected) {
-            assertEquals(WARNING_INTERNAL_SERVER_SSL_FAILURE,
+            assertEquals(WARNING_INTERNAL_SERVER_SSL_ERROR,
                     expected.getWarningDeviations().iterator().next().getCode());
         }
 


### PR DESCRIPTION
Verify SSL auth on service update and show a warning dialog to the user:

- Verify SSL authentication with IS when service is updated and `sslAuth` is true.
- Show warning dialog if verification of SSL auth with IS fails on service update.
- Validate that URL is HTTPS when `sslAuth` is true.
- Add `ignoreWarnings` param to `updateService` endpoint.
- Copy `InternalServerTestService` implementation from the old UI module.
  - The old UI module (`proxy-ui`) code will be removed at a later point.
- Update OpenAPI description.
- Update unit tests and new tests for the additions.

JIRA issues:
- https://jira.niis.org/browse/XRDDEV-1239 (backend)
- https://jira.niis.org/browse/XRDDEV-1240 (frontend)
