### PR TITLE
XRDDEV-1254 

### DIFF
--- a/src/packages/src/xroad/redhat/SOURCES/proxy-ui-api/xroad-proxy-ui-api-setup.sh
+++ b/src/packages/src/xroad/redhat/SOURCES/proxy-ui-api/xroad-proxy-ui-api-setup.sh
@@ -34,5 +34,5 @@ if [[ ! -r /etc/xroad/ssl/proxy-ui-api.crt || ! -r /etc/xroad/ssl/proxy-ui-api.k
 then
     echo "Generating new proxy-ui-api.[crt|key|p12] files "
     rm -f /etc/xroad/ssl/proxy-ui-api.crt /etc/xroad/ssl/proxy-ui-api.key /etc/xroad/ssl/proxy-ui-api.p12
-    /usr/share/xroad/scripts/generate_certificate.sh  -n proxy-ui-api -s "/CN=$HOST" -a "$ALT" -p 2> /tmp/cert.err || handle_error
+    /usr/share/xroad/scripts/generate_certificate.sh  -n proxy-ui-api -s "/CN=$HOST" -a "$ALT" -p 2> /tmp/cert.err || echo "generate_certificate failed, see /tmp/cert.err!"
 fi

--- a/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
+++ b/src/packages/src/xroad/redhat/SOURCES/proxy/xroad-proxy-setup.sh
@@ -17,7 +17,7 @@ if [[ ! -r /etc/xroad/ssl/internal.crt || ! -r /etc/xroad/ssl/internal.key  || !
 then
     echo "Generating new internal.[crt|key|p12] files "
     rm -f /etc/xroad/ssl/internal.crt /etc/xroad/ssl/internal.key /etc/xroad/ssl/internal.p12
-    /usr/share/xroad/scripts/generate_certificate.sh  -n internal -s "/CN=$HOST" -a "$ALT" -p 2> /tmp/cert.err || handle_error
+    /usr/share/xroad/scripts/generate_certificate.sh  -n internal -s "/CN=$HOST" -a "$ALT" -p 2> /tmp/cert.err || echo "generate_certificate failed, see /tmp/cert.err!"
 fi
 
 mkdir -p /var/spool/xroad; chown xroad:xroad /var/spool/xroad

--- a/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
@@ -19,7 +19,7 @@ Requires:  systemd
 Requires:  rlwrap
 %endif
 Requires:  jre-1.8.0-headless >= 1.8.0.51
-Requires:  crudini, hostname, sudo
+Requires:  crudini, hostname, sudo, openssl
 
 %define src %{_topdir}/..
 

--- a/src/packages/src/xroad/ubuntu/generic/control
+++ b/src/packages/src/xroad/ubuntu/generic/control
@@ -30,7 +30,7 @@ Description: X-Road central server
 Package: xroad-base
 Architecture: amd64
 Pre-depends: dpkg (>= 1.15.7.2)
-Depends: ${misc:Depends}, openjdk-8-jre-headless, rlwrap, ca-certificates-java, crudini, adduser, net-tools, iproute2, sudo
+Depends: ${misc:Depends}, openjdk-8-jre-headless, rlwrap, ca-certificates-java, crudini, adduser, net-tools, iproute2, sudo, openssl
 Replaces: xroad-proxy (<< 6.8.9), xroad-common (<= 6.17.0-0.20171018082348git2ecf68ed)
 Breaks: xroad-common (<= 6.17.0-0.20171018082348git2ecf68ed)
 Description: X-Road base components


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-1254

- fix broken installation on systems without openssl
- improve error handling when generate_certificates fails