### PR TITLE
XRDDEV-1271: Avoid GlobalConf update during backup restore

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/scheduling/GlobalConfChecker.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/scheduling/GlobalConfChecker.java
@@ -39,7 +39,9 @@ import ee.ria.xroad.signer.protocol.message.GetAuthKey;
 import lombok.extern.slf4j.Slf4j;
 import org.niis.xroad.restapi.facade.GlobalConfFacade;
 import org.niis.xroad.restapi.facade.SignerProxyFacade;
+import org.niis.xroad.restapi.service.BackupRestoreEvent;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,14 +56,14 @@ import static ee.ria.xroad.common.util.CryptoUtils.readCertificate;
  * Job that checks whether globalconf has changed.
  */
 @Component
-@Transactional
 @Slf4j
 public class GlobalConfChecker {
     public static final int JOB_REPEAT_INTERVAL_MS = 30000;
     public static final int INITIAL_DELAY_MS = 30000;
-    private GlobalConfCheckerHelper globalConfCheckerHelper;
-    private GlobalConfFacade globalConfFacade;
-    private SignerProxyFacade signerProxyFacade;
+    private final GlobalConfCheckerHelper globalConfCheckerHelper;
+    private final GlobalConfFacade globalConfFacade;
+    private final SignerProxyFacade signerProxyFacade;
+    private volatile boolean restoreInProgress = false;
 
     @Autowired
     public GlobalConfChecker(GlobalConfCheckerHelper globalConfCheckerHelper, GlobalConfFacade globalConfFacade,
@@ -82,10 +84,15 @@ public class GlobalConfChecker {
      * @throws Exception
      */
     @Scheduled(fixedRate = JOB_REPEAT_INTERVAL_MS, initialDelay = INITIAL_DELAY_MS)
-    public void updateServerConf() throws Exception {
+    @Transactional
+    public void updateServerConf() {
         // In clustered setup slave nodes may skip globalconf updates
         if (SLAVE.equals(SystemProperties.getServerNodeType())) {
             log.debug("This is a slave node - skip globalconf updates");
+            return;
+        }
+
+        if (restoreInProgress) {
             return;
         }
 
@@ -96,6 +103,11 @@ public class GlobalConfChecker {
             log.error("Checking globalconf for updates failed", e);
             throw e;
         }
+    }
+
+    @EventListener
+    protected void onEvent(BackupRestoreEvent e) {
+        restoreInProgress = BackupRestoreEvent.START.equals(e);
     }
 
     private void checkGlobalConf() {
@@ -173,7 +185,7 @@ public class GlobalConfChecker {
     }
 
     private void updateClientStatuses(ServerConfType serverConf,
-                                      SecurityServerId securityServerId) throws Exception {
+            SecurityServerId securityServerId) throws Exception {
         log.debug("Updating client statuses");
 
         for (ClientType client : serverConf.getClient()) {
@@ -229,7 +241,7 @@ public class GlobalConfChecker {
     }
 
     private void updateCertStatus(SecurityServerId securityServerId,
-                                  CertificateInfo certInfo) throws Exception {
+            CertificateInfo certInfo) throws Exception {
         X509Certificate cert =
                 readCertificate(certInfo.getCertificateBytes());
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/scheduling/GlobalConfChecker.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/scheduling/GlobalConfChecker.java
@@ -93,6 +93,7 @@ public class GlobalConfChecker {
         }
 
         if (restoreInProgress) {
+            log.debug("Backup restore in progress - skipping globalconf update");
             return;
         }
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/BackupRestoreEvent.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/BackupRestoreEvent.java
@@ -1,6 +1,5 @@
 /**
  * The MIT License
- * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
@@ -25,32 +24,6 @@
  */
 package org.niis.xroad.restapi.service;
 
-import lombok.extern.slf4j.Slf4j;
-import org.niis.xroad.restapi.util.PersistenceUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-/**
- * evict connections from CP (transactional wrapper for PersistenceUtils method)
- */
-@Slf4j
-@Service
-@Transactional
-@PreAuthorize("isAuthenticated()")
-public class EvictConnectionsService {
-
-    @Autowired
-    private PersistenceUtils persistenceUtils;
-
-    /**
-     * To prevent "relation serverconf does not exist" problems that come from broken connections/statements
-     * that did not like the DB restart
-     * @throws InterruptedException if interrupted
-     */
-    public void evict() throws InterruptedException {
-        persistenceUtils.evictPoolConnections();
-    }
-
+public enum BackupRestoreEvent {
+    START, END;
 }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/NotificationService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/NotificationService.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.niis.xroad.restapi.dto.AlertStatus;
 import org.niis.xroad.restapi.facade.GlobalConfFacade;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
@@ -146,5 +147,14 @@ public class NotificationService {
      */
     public synchronized void setBackupRestoreRunningSince() {
         backupRestoreRunningSince = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    @EventListener
+    protected void onEvent(BackupRestoreEvent e) {
+        if (BackupRestoreEvent.START.equals(e)) {
+            setBackupRestoreRunningSince();
+        } else {
+            resetBackupRestoreRunningSince();
+        }
     }
 }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/RestoreService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/RestoreService.java
@@ -33,8 +33,10 @@ import org.niis.xroad.restapi.cache.CurrentSecurityServerId;
 import org.niis.xroad.restapi.config.audit.AuditDataHelper;
 import org.niis.xroad.restapi.repository.BackupRepository;
 import org.niis.xroad.restapi.util.FormatUtils;
+import org.niis.xroad.restapi.util.PersistenceUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
@@ -55,27 +57,27 @@ public class RestoreService {
     private final ExternalProcessRunner externalProcessRunner;
     private final CurrentSecurityServerId currentSecurityServerId;
     private final BackupRepository backupRepository;
-    private final NotificationService notificationService;
     private final ApiKeyService apiKeyService;
     private final AuditDataHelper auditDataHelper;
-    private final EvictConnectionsService evictConnectionsService;
+    private final PersistenceUtils persistenceUtils;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Autowired
     public RestoreService(ExternalProcessRunner externalProcessRunner,
             @Value("${script.restore-configuration.path}") String configurationRestoreScriptPath,
             @Value("${script.restore-configuration.args}") String configurationRestoreScriptArgs,
             CurrentSecurityServerId currentSecurityServerId, BackupRepository backupRepository,
-            NotificationService notificationService, ApiKeyService apiKeyService,
-            AuditDataHelper auditDataHelper, EvictConnectionsService evictConnectionsService) {
+            ApiKeyService apiKeyService, AuditDataHelper auditDataHelper, PersistenceUtils persistenceUtils,
+            ApplicationEventPublisher publisher) {
         this.externalProcessRunner = externalProcessRunner;
         this.configurationRestoreScriptPath = configurationRestoreScriptPath;
         this.configurationRestoreScriptArgs = configurationRestoreScriptArgs;
         this.currentSecurityServerId = currentSecurityServerId;
         this.backupRepository = backupRepository;
-        this.notificationService = notificationService;
         this.apiKeyService = apiKeyService;
         this.auditDataHelper = auditDataHelper;
-        this.evictConnectionsService = evictConnectionsService;
+        this.persistenceUtils = persistenceUtils;
+        this.eventPublisher = publisher;
     }
 
     /**
@@ -83,17 +85,12 @@ public class RestoreService {
      * out by the current restore script.
      * @param fileName name of the backup file
      * @throws BackupFileNotFoundException
-     * @throws InterruptedException execution of the restore script was interrupted
+     * @throws InterruptedException          execution of the restore script was interrupted
      * @throws RestoreProcessFailedException if the restore script fails or does not execute
      */
     public synchronized void restoreFromBackup(String fileName) throws BackupFileNotFoundException,
             InterruptedException, RestoreProcessFailedException {
         auditDataHelper.putBackupFilename(backupRepository.getFilePath(fileName));
-        if (notificationService.getBackupRestoreRunningSince() != null) {
-            // should not happen because the method is synchronized
-            throw new RuntimeException("There is a restore (started at "
-                    + notificationService.getBackupRestoreRunningSince() + ") already in progress");
-        }
         String configurationBackupPath = backupRepository.getConfigurationBackupPath();
         String backupFilePath = configurationBackupPath + fileName;
         File backupFile = new File(backupFilePath);
@@ -102,27 +99,29 @@ public class RestoreService {
         }
         String[] arguments = buildArguments(backupFilePath);
         try {
-            notificationService.setBackupRestoreRunningSince();
+            eventPublisher.publishEvent(BackupRestoreEvent.START);
             ExternalProcessRunner.ProcessResult processResult = externalProcessRunner
                     .executeAndThrowOnFailure(configurationRestoreScriptPath, arguments);
 
             int exitCode = processResult.getExitCode();
 
-            String restoreFinishedLogMsg = String.format("Restoring configuration finished with exit status %s",
-                    exitCode);
-            log.info(restoreFinishedLogMsg);
-            log.info(" --- Restore script console output - START --- ");
-            log.info(ExternalProcessRunner.processOutputToString(processResult.getProcessOutput()));
-            log.info(" --- Restore script console output - END --- ");
+            if (log.isInfoEnabled()) {
+                String restoreFinishedLogMsg =
+                        String.format("Restoring configuration finished with exit status %s", exitCode);
+                log.info(restoreFinishedLogMsg);
+                log.info(" --- Restore script console output - START --- ");
+                log.info(ExternalProcessRunner.processOutputToString(processResult.getProcessOutput()));
+                log.info(" --- Restore script console output - END --- ");
+            }
 
-            evictConnectionsService.evict();
+            persistenceUtils.evictPoolConnections();
 
         } catch (ProcessFailedException | ProcessNotExecutableException e) {
             throw new RestoreProcessFailedException(e, "restoring from a backup failed");
         } finally {
-            notificationService.resetBackupRestoreRunningSince();
+            eventPublisher.publishEvent(BackupRestoreEvent.END);
             apiKeyService.clearApiKeyCaches();
-            log.info("Cleared api key caches");
+            log.debug("Cleared api key caches");
         }
     }
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/PersistenceUtils.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/PersistenceUtils.java
@@ -62,7 +62,7 @@ public final class PersistenceUtils {
     public void evictPoolConnections() {
         try {
             if (dataSource.isWrapperFor(HikariDataSource.class)) {
-                log.info("Evicting hikari datasource connection pool connections");
+                log.debug("Evicting connection pool connections");
                 dataSource.unwrap(HikariDataSource.class)
                         .getHikariPoolMXBean()
                         .softEvictConnections();


### PR DESCRIPTION
* Refactor RestoreService to publish an restore start/stop event,
  decoupling it from listeners (GlobalConfChecker, NotificationService).
* Clean up EvictConnectionsService (no need for a transaction when
  evicting connections)