### PR TITLE
Issue #691 - improvement to build script: if docker is available, the…

### DIFF
--- a/src/BUILD.md
+++ b/src/BUILD.md
@@ -4,7 +4,10 @@ Running the X-Road software requires Linux (Ubuntu or RHEL). As a development en
 
 **Tools**
 
-*Required for building*
+*Required for building in Docker (recommended)*
+* Docker (for deb/rpm packaging)
+
+*Required for building natively (without Docker)*
 * OpenJDK / JDK version 8
 * Gradle
 * JRuby and rvm (ruby version manager)
@@ -19,7 +22,15 @@ Running the X-Road software requires Linux (Ubuntu or RHEL). As a development en
 
 The development environment should have at least 8GB of memory and 20GB of free disk space (applies to a virtual machine as well), especially if you set up a local X-Road instance.
 
-## Dependency installation and building instructions
+## Dependency installation and instructions for building in Docker
+
+* Install Docker
+
+* Build the software and installation packages:
+
+    `./build_packages.sh`
+
+## Dependency installation and instructions for building natively (without Docker)
 
 * Requires Ubuntu >=16.04, 18.04 is recommended.
 

--- a/src/build_packages.sh
+++ b/src/build_packages.sh
@@ -2,18 +2,27 @@
 set -e
 export XROAD=$(cd "$(dirname "$0")"; pwd)
 
-./compile_code.sh "$@"
+errorExit() {
+	echo "*** $*" 1>&2
+	exit 1
+}
 
 if command -v docker &>/dev/null; then
-    docker build -q -t xroad-deb-bionic $XROAD/packages/docker/deb-bionic
-    docker build -q -t xroad-rpm $XROAD/packages/docker/rpm
-    docker build -q -t xroad-rpm-el8 $XROAD/packages/docker/rpm-el8
+    docker build -q -t xroad-build --build-arg uid=$(id -u) --build-arg gid=$(id -g) $XROAD/packages/docker-compile || errorExit "Error building build image."
+    docker build -q -t xroad-deb-bionic $XROAD/packages/docker/deb-bionic || errorExit "Error building pkg deb image."
+    docker build -q -t xroad-rpm $XROAD/packages/docker/rpm || errorExit "Error building pkg rpm image."
+    docker build -q -t xroad-rpm-el8 $XROAD/packages/docker/rpm-el8 || errorExit "Error building pkg el8-rpm image."
 
-    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-deb-bionic /workspace/src/packages/build-deb.sh bionic
-    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-rpm /workspace/src/packages/build-rpm.sh
-    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-rpm-el8 /workspace/src/packages/build-rpm.sh
-else
+    docker run --rm -v $XROAD/..:/workspace -w /workspace/src -u builder xroad-build  bash -c "./update_ruby_dependencies.sh && ./compile_code.sh -nodaemon" || errorExit "Error running build of binaries."
+    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-deb-bionic /workspace/src/packages/build-deb.sh bionic || errorExit "Error building deb"
+    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-rpm /workspace/src/packages/build-rpm.sh || errorExit "Error building rpm"
+    docker run --rm -v $XROAD/..:/workspace -u $(id -u):$(id -g) -e HOME=/workspace/src/packages xroad-rpm-el8 /workspace/src/packages/build-rpm.sh || errorExit "Error building el8-rpm"
+elif command -v dpkg-buildpackage && [ -r ~/.rvm ]; then
     echo "Docker not installed, building only .deb packages for this distribution"
-    cd $XROAD/packages
-    ./build-deb.sh $(lsb_release -sc)
+    cd $XROAD || errorExit "Error 'cd $XROAD'."
+    ./compile_code.sh "$@" || errorExit "Error running build of binaries."
+    cd $XROAD/packages || errorExit "Error 'cd $XROAD/packages'."
+    ./build-deb.sh $(lsb_release -sc) || errorExit "Error building '.deb' packages."
+else
+    errorExit "I cannot build (yet) on your platform. Please consult the file 'BUILD.md' for build requirements."
 fi


### PR DESCRIPTION
Changes to the build script and the build instructions:

- if docker is available, the whole process is performed in docker containers, no need to install further build dependencies on the build host
- if docker is not available, perform some minimal checking on the build dependencies on the host
- implement early fail error handling
- changed the build instructions accordingly

This PR should not make any changes to existing build environments necessary.
