### PR TITLE
XRDDEV-1320: sslAuth is returned as false for services whose url starts with http://

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ServiceConverter.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ServiceConverter.java
@@ -96,7 +96,11 @@ public class ServiceConverter {
         service.setId(convertId(serviceType, clientId));
         service.setServiceCode(serviceType.getServiceCode());
         service.setFullServiceCode(FormatUtils.getServiceFullName(serviceType));
-        service.setSslAuth((boolean) ObjectUtils.defaultIfNull(serviceType.getSslAuthentication(), true));
+        if (serviceType.getUrl().startsWith(FormatUtils.HTTP_PROTOCOL)) {
+            service.setSslAuth(false);
+        } else {
+            service.setSslAuth((boolean) ObjectUtils.defaultIfNull(serviceType.getSslAuthentication(), true));
+        }
         service.setTimeout(serviceType.getTimeout());
         service.setUrl(serviceType.getUrl());
         service.setTitle(serviceType.getTitle());

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -182,7 +182,7 @@ public class ServicesApiControllerIntegrationTest extends AbstractApiControllerT
         Service updatedService = servicesApiController.updateService(TestUtils.SS1_GET_RANDOM_V1,
                 serviceUpdate).getBody();
         assertEquals(10, updatedService.getTimeout().intValue());
-        assertTrue(updatedService.getSslAuth());
+        assertEquals(false, updatedService.getSslAuth());
         assertEquals(TestUtils.URL_HTTP, updatedService.getUrl());
     }
 


### PR DESCRIPTION
On converter layer sslAuth is set false for services whose url starts with http:// 

https://jira.niis.org/browse/XRDDEV-1320