### PR TITLE
XRDDEV-408 Validate wsdl service urls

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ClientsApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ClientsApiController.java
@@ -80,6 +80,7 @@ import org.niis.xroad.restapi.service.CertificateNotFoundException;
 import org.niis.xroad.restapi.service.ClientNotFoundException;
 import org.niis.xroad.restapi.service.ClientService;
 import org.niis.xroad.restapi.service.GlobalConfOutdatedException;
+import org.niis.xroad.restapi.service.InvalidServiceUrlException;
 import org.niis.xroad.restapi.service.InvalidUrlException;
 import org.niis.xroad.restapi.service.LocalGroupService;
 import org.niis.xroad.restapi.service.MissingParameterException;
@@ -407,8 +408,8 @@ public class ClientsApiController implements ClientsApi {
             try {
                 addedServiceDescriptionType = serviceDescriptionService.addWsdlServiceDescription(
                         clientId, url, ignoreWarnings);
-            } catch (WsdlParser.WsdlNotFoundException | UnhandledWarningsException
-                    | InvalidUrlException | InvalidWsdlException e) {
+            } catch (WsdlParser.WsdlNotFoundException | UnhandledWarningsException | InvalidUrlException
+                    | InvalidWsdlException | InvalidServiceUrlException e) {
                 // deviation data (errorcode + warnings) copied
                 throw new BadRequestException(e);
             } catch (ClientNotFoundException e) {

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServiceDescriptionsApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServiceDescriptionsApiController.java
@@ -41,6 +41,7 @@ import org.niis.xroad.restapi.openapi.model.ServiceDescriptionDisabledNotice;
 import org.niis.xroad.restapi.openapi.model.ServiceDescriptionUpdate;
 import org.niis.xroad.restapi.openapi.model.ServiceType;
 import org.niis.xroad.restapi.openapi.validator.ServiceDescriptionUpdateValidator;
+import org.niis.xroad.restapi.service.InvalidServiceUrlException;
 import org.niis.xroad.restapi.service.InvalidUrlException;
 import org.niis.xroad.restapi.service.ServiceDescriptionNotFoundException;
 import org.niis.xroad.restapi.service.ServiceDescriptionService;
@@ -187,8 +188,8 @@ public class ServiceDescriptionsApiController implements ServiceDescriptionsApi 
             }
 
         } catch (WsdlParser.WsdlNotFoundException | OpenApiParser.ParsingException | UnhandledWarningsException
-                | InvalidUrlException | InvalidWsdlException
-                | ServiceDescriptionService.WrongServiceDescriptionTypeException e) {
+                | InvalidUrlException | ServiceDescriptionService.WrongServiceDescriptionTypeException
+                | InvalidWsdlException | InvalidServiceUrlException e) {
             throw new BadRequestException(e);
         } catch (ServiceDescriptionService.ServiceAlreadyExistsException
                 | ServiceDescriptionService.WsdlUrlAlreadyExistsException e) {
@@ -216,10 +217,9 @@ public class ServiceDescriptionsApiController implements ServiceDescriptionsApi 
             serviceDescription = serviceDescriptionConverter.convert(
                     serviceDescriptionService.refreshServiceDescription(serviceDescriptionId,
                             ignoreWarnings.getIgnoreWarnings()));
-        } catch (WsdlParser.WsdlNotFoundException | UnhandledWarningsException
-                | InvalidUrlException | InvalidWsdlException
-                | ServiceDescriptionService.WrongServiceDescriptionTypeException
-                | OpenApiParser.ParsingException e) {
+        } catch (WsdlParser.WsdlNotFoundException | UnhandledWarningsException | InvalidUrlException
+                | InvalidWsdlException | ServiceDescriptionService.WrongServiceDescriptionTypeException
+                | OpenApiParser.ParsingException | InvalidServiceUrlException e) {
             throw new BadRequestException(e);
         } catch (ServiceDescriptionService.ServiceAlreadyExistsException
                 | ServiceDescriptionService.WsdlUrlAlreadyExistsException e) {

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InvalidServiceUrlException.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/InvalidServiceUrlException.java
@@ -1,0 +1,39 @@
+/**
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.restapi.service;
+
+import org.niis.xroad.restapi.exceptions.ErrorDeviation;
+
+import java.util.List;
+
+public class InvalidServiceUrlException extends ServiceException {
+
+    public static final String ERROR_INVALID_SERVICE_URL = "invalid_service_url";
+
+    public InvalidServiceUrlException(List<String> metadata) {
+        super(new ErrorDeviation(ERROR_INVALID_SERVICE_URL, metadata));
+    }
+}

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/ServiceDescriptionService.java
@@ -236,6 +236,7 @@ public class ServiceDescriptionService {
      * @throws InvalidWsdlException if WSDL at the url was invalid
      * @throws UnhandledWarningsException if there were warnings that were not ignored
      * @throws InvalidUrlException if url was empty or invalid
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
      * @throws WsdlUrlAlreadyExistsException conflict: another service description has same url
      * @throws ServiceAlreadyExistsException conflict: same service exists in another SD
      * @throws InterruptedException if the thread running the WSDL validator is interrupted. <b>The
@@ -249,7 +250,7 @@ public class ServiceDescriptionService {
             UnhandledWarningsException,
             ServiceAlreadyExistsException,
             InvalidUrlException,
-            WsdlUrlAlreadyExistsException, InterruptedException {
+            WsdlUrlAlreadyExistsException, InterruptedException, InvalidServiceUrlException {
         ClientType client = clientService.getLocalClient(clientId);
         if (client == null) {
             throw new ClientNotFoundException(CLIENT_WITH_ID + " " + clientId.toShortString() + " not found");
@@ -512,6 +513,7 @@ public class ServiceDescriptionService {
      * @throws InvalidWsdlException if WSDL at the url was invalid
      * @throws UnhandledWarningsException if there were warnings that were not ignored
      * @throws InvalidUrlException if url was empty or invalid
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
      * @throws WsdlUrlAlreadyExistsException conflict: another service description has same url
      * @throws ServiceAlreadyExistsException conflict: same service exists in another SD
      * @throws InterruptedException if the thread running the WSDL validator is interrupted. <b>The
@@ -525,7 +527,7 @@ public class ServiceDescriptionService {
             UnhandledWarningsException,
             InvalidUrlException,
             ServiceAlreadyExistsException,
-            WsdlUrlAlreadyExistsException, InterruptedException {
+            WsdlUrlAlreadyExistsException, InterruptedException, InvalidServiceUrlException {
         ServiceDescriptionType serviceDescriptionType = getServiceDescriptiontype(id);
         if (serviceDescriptionType == null) {
             throw createServiceDescriptionNotFoundException(id);
@@ -545,6 +547,7 @@ public class ServiceDescriptionService {
      * @throws WrongServiceDescriptionTypeException wrong type of service description
      * @throws UnhandledWarningsException Unhandledwarnings in openapi3 or wsdl description
      * @throws InvalidUrlException invalid url
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
      * @throws ServiceAlreadyExistsException service code already exists if refreshing wsdl
      * @throws WsdlUrlAlreadyExistsException url is already in use by this client
      * @throws OpenApiParser.ParsingException openapi3 description parsing fails
@@ -553,7 +556,8 @@ public class ServiceDescriptionService {
             throws WsdlParser.WsdlNotFoundException, InvalidWsdlException,
             ServiceDescriptionNotFoundException, WrongServiceDescriptionTypeException,
             UnhandledWarningsException, InvalidUrlException, ServiceAlreadyExistsException,
-            WsdlUrlAlreadyExistsException, OpenApiParser.ParsingException, InterruptedException {
+            WsdlUrlAlreadyExistsException, OpenApiParser.ParsingException, InterruptedException,
+            InvalidServiceUrlException {
 
         ServiceDescriptionType serviceDescriptionType = getServiceDescriptiontype(id);
         if (serviceDescriptionType == null) {
@@ -584,6 +588,7 @@ public class ServiceDescriptionService {
      * @throws InvalidWsdlException if WSDL at the url was invalid
      * @throws UnhandledWarningsException if there were warnings that were not ignored
      * @throws InvalidUrlException if url was empty or invalid
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
      * @throws WsdlUrlAlreadyExistsException conflict: another service description has same url
      * @throws ServiceAlreadyExistsException conflict: same service exists in another SD
      * @throws InterruptedException if the thread running the WSDL validator is interrupted. <b>The
@@ -596,7 +601,7 @@ public class ServiceDescriptionService {
             throws WsdlParser.WsdlNotFoundException, InvalidWsdlException,
             WrongServiceDescriptionTypeException,
             UnhandledWarningsException, InvalidUrlException, ServiceAlreadyExistsException,
-            WsdlUrlAlreadyExistsException, InterruptedException {
+            WsdlUrlAlreadyExistsException, InterruptedException, InvalidServiceUrlException {
 
         if (!serviceDescriptionType.getType().equals(DescriptionType.WSDL)) {
             throw new WrongServiceDescriptionTypeException("Expected description type WSDL");
@@ -904,12 +909,24 @@ public class ServiceDescriptionService {
      * @param serviceDescriptionType
      * @param url                    the new url
      * @return ServiceDescriptionType
+     * @throws WsdlParser.WsdlNotFoundException if a wsdl was not found at the url
+     * @throws WrongServiceDescriptionTypeException if SD with given id was not a WSDL based one
+     * @throws InvalidWsdlException if WSDL at the url was invalid
+     * @throws UnhandledWarningsException if there were warnings that were not ignored
+     * @throws InvalidUrlException if url was empty or invalid
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
+     * @throws WsdlUrlAlreadyExistsException conflict: another service description has same url
+     * @throws ServiceAlreadyExistsException conflict: same service exists in another SD
+     * @throws InterruptedException if the thread running the WSDL validator is interrupted. <b>The
+     * interrupted thread has already been handled with so you can choose to ignore this exception if you so
+     * please.</b>
      */
     private ServiceDescriptionType updateWsdlUrl(ServiceDescriptionType serviceDescriptionType, String url,
             boolean ignoreWarnings)
             throws InvalidWsdlException, WsdlParser.WsdlNotFoundException,
             WrongServiceDescriptionTypeException, UnhandledWarningsException,
-            ServiceAlreadyExistsException, InvalidUrlException, WsdlUrlAlreadyExistsException, InterruptedException {
+            ServiceAlreadyExistsException, InvalidUrlException, WsdlUrlAlreadyExistsException, InterruptedException,
+            InvalidServiceUrlException {
 
         auditDataHelper.put(serviceDescriptionType.getClient().getIdentifier());
         Map<RestApiAuditProperty, Object> wsdlAuditData = auditDataHelper.putMap(WSDL);
@@ -1086,7 +1103,7 @@ public class ServiceDescriptionService {
     }
 
     private Collection<WsdlParser.ServiceInfo> parseWsdl(String url) throws WsdlParser.WsdlNotFoundException,
-            WsdlParser.WsdlParseException {
+            WsdlParser.WsdlParseException, InvalidServiceUrlException {
         Collection<WsdlParser.ServiceInfo> parsedServices;
         parsedServices = WsdlParser.parseWSDL(url);
         return parsedServices;
@@ -1170,6 +1187,7 @@ public class ServiceDescriptionService {
      * @throws WsdlParser.WsdlNotFoundException if a wsdl was not found at the url
      * @throws InvalidUrlException if url was empty or invalid
      * @throws InvalidWsdlException if wsdl was invalid (either parsing or validation)
+     * @throws InvalidServiceUrlException if the WSDL has services with invalid urls
      * @throws WsdlUrlAlreadyExistsException conflict: another service description has same url
      * @throws ServiceAlreadyExistsException conflict: same service exists in another SD
      */
@@ -1179,7 +1197,7 @@ public class ServiceDescriptionService {
             InvalidWsdlException,
             InvalidUrlException,
             WsdlUrlAlreadyExistsException,
-            ServiceAlreadyExistsException, InterruptedException {
+            ServiceAlreadyExistsException, InterruptedException, InvalidServiceUrlException {
 
         WsdlProcessingResult result = new WsdlProcessingResult();
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/wsdl/WsdlParser.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/wsdl/WsdlParser.java
@@ -28,6 +28,7 @@ package org.niis.xroad.restapi.wsdl;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.niis.xroad.restapi.exceptions.ErrorDeviation;
+import org.niis.xroad.restapi.service.InvalidServiceUrlException;
 import org.niis.xroad.restapi.service.ServiceException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -63,11 +64,15 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.niis.xroad.restapi.util.FormatUtils.HTTPS_PROTOCOL;
+import static org.niis.xroad.restapi.util.FormatUtils.HTTP_PROTOCOL;
 
 /**
  * Utils for WSDL parsing
@@ -106,13 +111,17 @@ public final class WsdlParser {
      * @throws WsdlNotFoundException if a WSDL was not found at given URL
      * @throws WsdlParseException if anything else than WsdlNotFoundException went wrong in parsing (e.g. document
      * size exceeds the limit defined by {@link #MAX_DESCRIPTION_SIZE})
+     * @throws InvalidServiceUrlException if a service in the WSDL has a URL that doesn't start with HTTP or HTTPS
      */
-    public static Collection<ServiceInfo> parseWSDL(String wsdlUrl) throws WsdlNotFoundException, WsdlParseException {
+    public static Collection<ServiceInfo> parseWSDL(String wsdlUrl) throws WsdlNotFoundException, WsdlParseException,
+            InvalidServiceUrlException {
         try {
             return internalParseWSDL(wsdlUrl);
         } catch (PrivateWsdlNotFoundException e) {
             log.error("Reading WSDL from {} failed", wsdlUrl, e);
             throw new WsdlNotFoundException(e);
+        } catch (InvalidServiceUrlException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Reading WSDL from {} failed", wsdlUrl, e);
             throw new WsdlParseException(clarifyWsdlParsingException(e));
@@ -150,7 +159,7 @@ public final class WsdlParser {
         Collection<Service> services = definition.getServices().values();
 
         Map<String, ServiceInfo> result = new HashMap<>();
-
+        final List<String> invalidUrls = new ArrayList<>();
         for (Service service : services) {
             for (Port port : (Collection<Port>) service.getPorts().values()) {
                 if (!hasSoapOverHttpBinding(port)) {
@@ -158,6 +167,9 @@ public final class WsdlParser {
                 }
 
                 String url = getUrl(port);
+                if (url != null && !url.startsWith(HTTP_PROTOCOL) && !url.startsWith(HTTPS_PROTOCOL)) {
+                    invalidUrls.add(url);
+                }
                 for (BindingOperation operation : (List<BindingOperation>) port.getBinding().getBindingOperations()) {
                     String title = getChildValue("title",
                             operation.getOperation().getDocumentationElement());
@@ -168,6 +180,9 @@ public final class WsdlParser {
                             operation.getName(), title, url, version));
                 }
             }
+        }
+        if (!invalidUrls.isEmpty()) {
+            throw new InvalidServiceUrlException(invalidUrls);
         }
 
         return result.values();

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -89,6 +89,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.niis.xroad.restapi.service.InvalidServiceUrlException.ERROR_INVALID_SERVICE_URL;
 import static org.niis.xroad.restapi.service.ServiceDescriptionService.ServiceAlreadyExistsException.ERROR_SERVICE_EXISTS;
 import static org.niis.xroad.restapi.service.ServiceDescriptionService.WARNING_WSDL_VALIDATION_WARNINGS;
 import static org.niis.xroad.restapi.service.ServiceDescriptionService.WsdlUrlAlreadyExistsException.ERROR_WSDL_EXISTS;
@@ -718,6 +719,22 @@ public class ClientsApiControllerIntegrationTest extends AbstractApiControllerTe
             fail("should have thrown BadRequestException");
         } catch (BadRequestException expected) {
             assertEquals(ERROR_INVALID_WSDL, expected.getErrorDeviation().getCode());
+        }
+    }
+
+    @Test
+    @WithMockUser(authorities = { "ADD_WSDL" })
+    public void addWsdlServiceDescriptionBadServiceUrl() {
+        ServiceDescriptionAdd serviceDescription =
+                new ServiceDescriptionAdd().url("file:src/test/resources/wsdl/invalid-serviceurl.wsdl");
+        serviceDescription.setType(ServiceType.WSDL);
+        try {
+            serviceDescription.setIgnoreWarnings(true);
+            clientsApiController.addClientServiceDescription(TestUtils.CLIENT_ID_SS1, serviceDescription);
+            fail("should have thrown BadRequestException");
+        } catch (BadRequestException expected) {
+            assertEquals(ERROR_INVALID_SERVICE_URL, expected.getErrorDeviation().getCode());
+            assertFalse(expected.getErrorDeviation().getMetadata().isEmpty());
         }
     }
 

--- a/src/proxy-ui-api/src/test/resources/wsdl/invalid-serviceurl.wsdl
+++ b/src/proxy-ui-api/src/test/resources/wsdl/invalid-serviceurl.wsdl
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:xrd="http://x-road.ee/xsd/x-road.xsd"
+  xmlns:tns="http://xroad-andmekogu.x-road.ee/producer"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  name="xroadGetRandom"
+  targetNamespace="http://xroad-andmekogu.x-road.ee/producer">
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://xroad-andmekogu.x-road.ee/producer">
+      <xsd:import namespace="http://x-road.ee/xsd/x-road.xsd" schemaLocation="http://x-road.ee/xsd/x-road.xsd"/>
+      <xsd:element name="xroadGetRandom">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="request">
+              <xsd:complexType>
+                <xsd:sequence>
+                  <xsd:element name="in" type="xsd:string">
+                    <xsd:annotation>
+                      <xsd:appinfo>
+                        <xrd:title>Random input</xrd:title>
+                      </xsd:appinfo>
+                    </xsd:annotation>
+                  </xsd:element>
+                </xsd:sequence>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="xroadGetRandomResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="response" type="xsd:string">
+              <xsd:annotation>
+                <xsd:appinfo>
+                  <xrd:title>Random response</xrd:title>
+                </xsd:appinfo>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="standardheader">
+    <wsdl:part name="consumer" element="xrd:consumer"/>
+    <wsdl:part name="producer" element="xrd:producer"/>
+    <wsdl:part name="userId" element="xrd:userId"/>
+    <wsdl:part name="service" element="xrd:service"/>
+    <wsdl:part name="id" element="xrd:id"/>
+  </wsdl:message>
+
+  <wsdl:message name="xroadGetRandom">
+    <wsdl:part name="body"  element="tns:xroadGetRandom" />
+  </wsdl:message>
+  <wsdl:message name="xroadGetRandomResponse">
+    <wsdl:part name="body"  element="tns:xroadGetRandomResponse" />
+  </wsdl:message>
+
+  <wsdl:portType name="xroadGetRandom">
+    <wsdl:operation name="xroadGetRandom">
+      <wsdl:documentation>
+        <xrd:title>Suvaline sisend document/literal stiilis</xrd:title>
+        <xrd:notes>Suvalisele sisendile tuleb ka suvaline vastus.</xrd:notes>
+      </wsdl:documentation>
+      <wsdl:input message="tns:xroadGetRandom"/>
+      <wsdl:output message="tns:xroadGetRandomResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="xroadGetRandomSOAP" type="tns:xroadGetRandom">
+    <soap:binding style="document"
+                  transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="xroadGetRandom">
+      <soap:operation soapAction="" style="document"/>
+      <xrd:version>v1</xrd:version>
+      <wsdl:input>
+        <soap:body parts="body" use="literal"/>
+        <soap:header message="tns:standardheader" part="consumer" use="literal"/>
+        <soap:header message="tns:standardheader" part="producer" use="literal"/>
+        <soap:header message="tns:standardheader" part="userId" use="literal"/>
+        <soap:header message="tns:standardheader" part="id" use="literal"/>
+        <soap:header message="tns:standardheader" part="service" use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body parts="body" use="literal"/>
+        <soap:header message="tns:standardheader" part="consumer" use="literal"/>
+        <soap:header message="tns:standardheader" part="producer" use="literal"/>
+        <soap:header message="tns:standardheader" part="userId" use="literal"/>
+        <soap:header message="tns:standardheader" part="id" use="literal"/>
+        <soap:header message="tns:standardheader" part="service" use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="xroad-andmekoguService">
+    <wsdl:port binding="tns:xroadGetRandomSOAP" name="xroadGetRandomSOAP">
+      <soap:address location="sftp://iks2-testhost:8080/testservice-0.1/xroad"/>
+      <xrd:address producer="xroad-andmekogu"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Adds a validation for WSDL service URLs when adding a new WSDL. Forces the service URLs to start with `http://` or `https://`. The faulty URLs will be returned in the error response's metadata field

JIRA: https://jira.niis.org/browse/XRDDEV-408