### PR TITLE
Issue #691 - improvement to build script: if docker is available, the…

### DIFF
--- a/src/BUILD.md
+++ b/src/BUILD.md
@@ -1,10 +1,13 @@
 # Building X-Road
 
-Running the X-Road software requires Linux (Ubuntu or RHEL). As a development environment,  only Ubuntu (>=16.04, 20.04 recommended) is currently supported. It should be possible to use some other Linux distribution for development, but the instructions and helper scripts assume Ubuntu. If you are using some other operating system (e.g. Windows or macOS), the easiest option is to first install Ubuntu into a virtual machine.
+Running the X-Road software requires Linux (Ubuntu or RHEL). As a development environment, only Ubuntu (>=16.04, 20.04 recommended) is currently supported. It should be possible to use some other Linux distribution for development, but the instructions and helper scripts assume Ubuntu. Alternatively the software can be built entirely inside docker containers (see below) making the build host distribution agnostic but also a bit slower. If you are using some other operating system (e.g. Windows or macOS), the easiest option is to first install Ubuntu into a virtual machine.
 
 **Tools**
 
-*Required for building*
+*Required for deb/rpm packaging and/or building in Docker*
+* Docker
+
+*Required for building natively (without Docker)*
 * OpenJDK / JDK version 8
 * Gradle
 * JRuby and rvm (ruby version manager)
@@ -19,7 +22,18 @@ Running the X-Road software requires Linux (Ubuntu or RHEL). As a development en
 
 The development environment should have at least 8GB of memory and 20GB of free disk space (applies to a virtual machine as well), especially if you set up a local X-Road instance.
 
-## Dependency installation and building instructions
+## Dependency installation and instructions for building in Docker
+
+* Install Docker
+
+* Build the software and installation packages:
+
+    `./build_packages.sh -d`
+
+    Note that the `build_package.sh` script's behaviour is controlled by its first command line argument.
+    All subsequent arguments will simply be passed to whatever build script it calls to perform the actual build.
+
+## Dependency installation and instructions for building natively (without Docker)
 
 * Requires Ubuntu >=16.04, 20.04 is recommended.
 

--- a/src/build_packages.sh
+++ b/src/build_packages.sh
@@ -2,27 +2,69 @@
 set -e
 export XROAD=$(cd "$(dirname "$0")"; pwd)
 
-if [[ ! " $* " =~ " --packageonly " ]]; then
-  ./compile_code.sh "$@"
-fi
+HAS_DOCKER=""
+
+errorExit() {
+    echo "*** $*" 1>&2
+    exit 1
+}
+
+usage () {
+    echo "Usage: $0 [option for $0...] [other options]"
+    echo "Options for $0:"
+    echo " -p, --package-only    Skip compilation, just build packages'"
+    echo " -d, --docker-compile  Compile in docker container instead of native gradle build"
+    echo " -h, --help            This help text."
+    echo "The option for $0, if present, must come fist, before other options."
+    echo "Other options are passed on to compile_code.sh"
+    test -z "$1" || exit "$1"
+}
+
+buildInDocker() {
+    test -n "$HAS_DOCKER" || errorExit "Error, docker is not installed/running."
+    echo "Building in docker..."
+    # check if running attached to terminal
+    # makes it possible to stop build with Ctrl+C
+    if [ -t 1 ]; then OPT="-it"; fi
+
+    docker build -q -t xroad-build --build-arg uid=$(id -u) --build-arg gid=$(id -g) $XROAD/packages/docker-compile || errorExit "Error building build image."
+    docker run --rm -v $XROAD/..:/workspace -w /workspace/src -u builder ${OPT} xroad-build  bash -c "./update_ruby_dependencies.sh && ./compile_code.sh -nodaemon" || errorExit "Error running build of binaries."
+}
+
+buildLocally() {
+    echo "Building locally..."
+    cd $XROAD || errorExit "Error 'cd $XROAD'."
+    ./compile_code.sh "$@" || errorExit "Error running build of binaries."
+}
 
 if command -v docker &>/dev/null; then
-    docker build -q -t xroad-deb-bionic "$XROAD/packages/docker/deb-bionic"
-    docker build -q -t xroad-deb-focal "$XROAD/packages/docker/deb-focal"
-    docker build -q -t xroad-rpm "$XROAD/packages/docker/rpm"
-    docker build -q -t xroad-rpm-el8 "$XROAD/packages/docker/rpm-el8"
+    HAS_DOCKER=true
+fi
+
+case "$1" in
+    --package-only|-p) shift;;
+    --docker-compile|-d) shift; buildInDocker "$@";;
+    --help|-h) usage 0;;
+    *) buildLocally "$@";;
+esac
+
+if [ -n "$HAS_DOCKER" ]; then
+    docker build -q -t xroad-deb-bionic "$XROAD/packages/docker/deb-bionic" || errorExit "Error building deb-bionic image."
+    docker build -q -t xroad-deb-focal "$XROAD/packages/docker/deb-focal" || errorExit "Error building deb-focal image."
+    docker build -q -t xroad-rpm "$XROAD/packages/docker/rpm" || errorExit "Error building rpm image."
+    docker build -q -t xroad-rpm-el8 "$XROAD/packages/docker/rpm-el8" || errorExit "Error building rpm-el8 image."
 
     OPTS=("--rm" "-v" "$XROAD/..:/workspace" "-u" "$(id -u):$(id -g)" "-e" "HOME=/workspace/src/packages")
     # check if running attached to terminal
     # makes it possible to stop build with Ctrl+C
     if [[ -t 1 ]]; then OPTS+=("-it"); fi
 
-    docker run "${OPTS[@]}" xroad-deb-bionic /workspace/src/packages/build-deb.sh bionic
-    docker run "${OPTS[@]}" xroad-deb-focal /workspace/src/packages/build-deb.sh focal
-    docker run "${OPTS[@]}" xroad-rpm /workspace/src/packages/build-rpm.sh
-    docker run "${OPTS[@]}" xroad-rpm-el8 /workspace/src/packages/build-rpm.sh
+    docker run "${OPTS[@]}" xroad-deb-bionic /workspace/src/packages/build-deb.sh bionic || errorExit "Error building deb-bionic packages."
+    docker run "${OPTS[@]}" xroad-deb-focal /workspace/src/packages/build-deb.sh focal || errorExit "Error building deb-focal packages."
+    docker run "${OPTS[@]}" xroad-rpm /workspace/src/packages/build-rpm.sh || errorExit "Error building rpm packages."
+    docker run "${OPTS[@]}" xroad-rpm-el8 /workspace/src/packages/build-rpm.sh || errorExit "Error building rpm-el8 packages."
 else
     echo "Docker not installed, building only .deb packages for this distribution"
     cd "$XROAD/packages"
-    ./build-deb.sh "$(lsb_release -sc)"
+    ./build-deb.sh "$(lsb_release -sc)" || errorExit "Error building deb packages."
 fi


### PR DESCRIPTION
Changes to the build script and the build instructions:

- if docker is available, the whole process can be performed in docker containers if passing the `-d` or `--docker-build` as a command line option, so that there is no need to install further build dependencies on the build host
- if docker is not available, perform some minimal checking on the build dependencies on the host
- implement early fail error handling
- changed the build instructions accordingly 

This PR should not make any changes to existing build environments necessary.