### PR TITLE
XRDDEV-1365: Stricter constraints for fetching service client candi…

### DIFF
--- a/src/proxy-ui-api/frontend/src/locales/en.json
+++ b/src/proxy-ui-api/frontend/src/locales/en.json
@@ -184,7 +184,8 @@
     "servicesStep": "Services",
     "addServiceClientTitle": "Add a subject",
     "addSelected": "Add Selected",
-    "serviceSelectionStep": "Servicecode"
+    "serviceSelectionStep": "Servicecode",
+    "memberGroupCodeLabel": "Member/Group code"
   },
   "localGroups": {
     "addGroup": "Add group",

--- a/src/proxy-ui-api/frontend/src/views/Service/AccessRightsDialog.vue
+++ b/src/proxy-ui-api/frontend/src/views/Service/AccessRightsDialog.vue
@@ -79,7 +79,7 @@
                     ></v-select>
                     <v-text-field
                       v-model="memberCode"
-                      label="Member group code"
+                      :label="$t('serviceClients.memberGroupCodeLabel')"
                       single-line
                       hide-details
                       data-test="memberCode"

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/AccessRightService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/AccessRightService.java
@@ -815,7 +815,7 @@ public class AccessRightService {
             if (xRoadId instanceof LocalGroupId) {
                 return true;
             } else {
-                return instance.equalsIgnoreCase((dto.getSubjectId().getXRoadInstance()));
+                return instance.equalsIgnoreCase(dto.getSubjectId().getXRoadInstance());
             }
         };
     }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/AccessRightService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/AccessRightService.java
@@ -800,7 +800,7 @@ public class AccessRightService {
             XRoadId xRoadId = dto.getSubjectId();
             if (xRoadId instanceof ClientId) {
                 String clientMemberClass = ((ClientId) xRoadId).getMemberClass();
-                return StringUtils.containsIgnoreCase(clientMemberClass, memberClass);
+                return memberClass.equalsIgnoreCase(clientMemberClass);
             } else {
                 return false;
             }
@@ -811,11 +811,11 @@ public class AccessRightService {
         return dto -> {
             XRoadId xRoadId = dto.getSubjectId();
             // In case the Subject is a LocalGroup: LocalGroups do not have explicit X-Road instances
-            // -> always return
+            // -> always return true
             if (xRoadId instanceof LocalGroupId) {
                 return true;
             } else {
-                return StringUtils.containsIgnoreCase(dto.getSubjectId().getXRoadInstance(), instance);
+                return instance.equalsIgnoreCase((dto.getSubjectId().getXRoadInstance()));
             }
         };
     }

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -858,7 +858,15 @@ public class ClientsApiControllerIntegrationTest extends AbstractApiControllerTe
                 null, null, TestUtils.INSTANCE_EE, null, null, null);
         List<ServiceClient> serviceClients = serviceClientResponse.getBody();
         assertEquals(6, serviceClients.size()); // includes localgroups
+
+        ResponseEntity<List<ServiceClient>> partialInstanceMatchResponse =
+                clientsApiController.findServiceClientCandidates(
+                TestUtils.CLIENT_ID_SS1,
+                null, ServiceClientType.SUBSYSTEM, "E", null, null, null);
+        List<ServiceClient> partialInstanceMatch = partialInstanceMatchResponse.getBody();
+        assertEquals(0, partialInstanceMatch.size());
     }
+
 
     @Test
     @WithMockUser(authorities = { "VIEW_CLIENT_ACL_SUBJECTS" })
@@ -868,6 +876,13 @@ public class ClientsApiControllerIntegrationTest extends AbstractApiControllerTe
                 null, null, null, TestUtils.MEMBER_CLASS_GOV, null, null);
         List<ServiceClient> serviceClients = serviceClientResponse.getBody();
         assertEquals(3, serviceClients.size());
+
+        ResponseEntity<List<ServiceClient>> partialMemberClassMatchResponse =
+                clientsApiController.findServiceClientCandidates(
+                TestUtils.CLIENT_ID_SS1,
+                null, ServiceClientType.SUBSYSTEM, null, "GO", null, null);
+        List<ServiceClient> partialMemberClassMatch = partialMemberClassMatchResponse.getBody();
+        assertEquals(0, partialMemberClassMatch.size());
     }
 
     @Test


### PR DESCRIPTION
…dates

Use equalsIgnoreCase when comparing instance and memberclass parameters while searching service client candidates

https://jira.niis.org/browse/XRDDEV-1365