### PR TITLE
XRDDEV-1353

### DIFF
--- a/src/proxy-ui-api/frontend/src/views/KeyDetails/KeyDetails.vue
+++ b/src/proxy-ui-api/frontend/src/views/KeyDetails/KeyDetails.vue
@@ -234,6 +234,8 @@ export default Vue.extend({
         .then((res) => {
           this.key = res.data;
           this.fetchPossibleActions(id);
+          // If the key has no name, use key id instead
+          this.setKeyName();
         })
         .catch((error) => {
           this.$store.dispatch('showError', error);
@@ -288,6 +290,11 @@ export default Vue.extend({
           }
         })
         .finally(() => (this.deleting = false));
+    },
+    setKeyName() : void {
+      if (this.key.name === '') {
+        this.key.name = this.key.id;
+      }
     },
   },
   created() {

--- a/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/SignAndAuthKeys/KeyRow.vue
+++ b/src/proxy-ui-api/frontend/src/views/KeysAndCertificates/SignAndAuthKeys/KeyRow.vue
@@ -28,7 +28,8 @@
     <td class="name-wrap-top no-border">
       <i class="icon-xrd_key icon clickable" @click="keyClick"></i>
       <div class="clickable-link identifier-wrap" @click="keyClick">
-        {{ tokenKey.name }}
+        <span v-if="tokenKey.name === ''">{{ tokenKey.id }}</span>
+        <span v-else>{{ tokenKey.name }}</span>
       </div>
     </td>
     <td class="no-border" colspan="4"></td>


### PR DESCRIPTION
In the UI, use key id to identify auth and sign keys if label and friendly name are missing:

- Show key id (`id`) in the Keys and certificates list if the key does not have a label (`label`) and a friendly name (`name`).
- Show key id (`id`) in the Key details view in the Friendly name field if the key does not have a friendly name (`name`).

Changes are implemented on the frontend side to make the UI more user friendly. The API returns empty `label` and `name` fields if the values have not been set.

JIRA issue: https://jira.niis.org/browse/XRDDEV-1353