### PR TITLE
XRDDEV-1362

### DIFF
--- a/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
+++ b/src/proxy-ui-api/frontend/src/store/modules/addClient.ts
@@ -30,6 +30,7 @@ import { ActionTree, GetterTree, Module, MutationTree } from 'vuex';
 import { RootState } from '../types';
 import { AddMemberWizardModes, UsageTypes } from '@/global';
 import { createClientId } from '@/util/helpers';
+import { encodePathParameter } from '@/util/api';
 import {
   Token,
   Client,
@@ -186,9 +187,9 @@ export const actions: ActionTree<AddClientState, RootState> = {
     commit('resetAddClientState');
   },
 
-  fetchSelectableClients({ commit }) {
+  fetchSelectableClients({ commit }, instanceId: string) {
     const globalClientsPromise = api.get<Client[]>(
-      '/clients?exclude_local=true&internal_search=false&show_members=false',
+      `/clients?exclude_local=true&internal_search=false&show_members=false&instance=${encodePathParameter(instanceId)}`,
     );
     const localClientsPromise = api.get<Client[]>('/clients');
     // Fetch list of local clients and filter out global clients
@@ -210,10 +211,10 @@ export const actions: ActionTree<AddClientState, RootState> = {
       });
   },
 
-  fetchSelectableMembers({ commit }) {
+  fetchSelectableMembers({ commit }, instanceId: string) {
     // Fetch clients from backend that can be selected
     return api
-      .get<Client[]>('/clients?internal_search=false&show_members=true')
+      .get<Client[]>(`/clients?internal_search=false&show_members=true&instance=${encodePathParameter(instanceId)}`)
       .then((res) => {
         // Filter out subsystems
         const filtered = res.data.filter((client: Client) => {

--- a/src/proxy-ui-api/frontend/src/views/AddClient/ClientDetailsPage.vue
+++ b/src/proxy-ui-api/frontend/src/views/AddClient/ClientDetailsPage.vue
@@ -277,7 +277,7 @@ export default Vue.extend({
   created() {
     that = this;
     this.$store.commit('setAddMemberWizardMode', AddMemberWizardModes.FULL);
-    this.$store.dispatch('fetchSelectableClients');
+    this.$store.dispatch('fetchSelectableClients', that.currentSecurityServer.instance_id);
     this.$store.dispatch('fetchMemberClassesForCurrentInstance');
   },
 

--- a/src/proxy-ui-api/frontend/src/views/AddMember/MemberDetailsPage.vue
+++ b/src/proxy-ui-api/frontend/src/views/AddMember/MemberDetailsPage.vue
@@ -144,7 +144,12 @@ export default Vue.extend({
     SelectClientDialog,
   },
   computed: {
-    ...mapGetters(['reservedMember', 'memberClassesCurrentInstance', 'selectedMemberName']),
+    ...mapGetters([
+      'reservedMember',
+      'memberClassesCurrentInstance',
+      'selectedMemberName',
+      'currentSecurityServer',
+    ]),
 
     memberClass: {
       get(): string {
@@ -253,7 +258,7 @@ export default Vue.extend({
   created() {
     that = this;
     this.$store.commit('setAddMemberWizardMode', AddMemberWizardModes.FULL);
-    this.$store.dispatch('fetchSelectableMembers');
+    this.$store.dispatch('fetchSelectableMembers', that.currentSecurityServer.instance_id);
   },
 
   watch: {


### PR DESCRIPTION
Add instance parameter to client and member searches so that results contain only clients / members that belong to the Security Server's home instance:

- Add instance parameter to client search in Add client flow.
- Add instance parameter to member search in Add member flow.
- Search results contain only clients/members that belong to the same instance with the Security Server.

JIRA issue: https://jira.niis.org/browse/XRDDEV-1362