### PR TITLE
XRDDEV-1448

### DIFF
--- a/Docker/centralserver/Dockerfile
+++ b/Docker/centralserver/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
   && apt-get -qq upgrade \
-  && apt-get -qq install sudo ca-certificates gnupg supervisor net-tools locales setpriv openjdk-8-jre-headless rlwrap ca-certificates-java crudini adduser expect nginx-light curl rsyslog authbind wget devscripts \
+  && apt-get -qq install sudo ca-certificates gnupg supervisor net-tools locales openjdk-8-jre-headless rlwrap ca-certificates-java crudini adduser expect nginx-light curl rsyslog wget \
   && echo "LC_ALL=en_US.UTF-8" >>/etc/environment \
   && locale-gen en_US.UTF-8 \
   && adduser --quiet --system --uid 998 --home /var/lib/postgresql --no-create-home --shell /bin/bash --group postgres \

--- a/Docker/securityserver/files/ss-xroad.conf
+++ b/Docker/securityserver/files/ss-xroad.conf
@@ -29,7 +29,7 @@ user=xroad
 autorestart=true
 
 [program:xroad-proxy]
-command=/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=-all,+NET_BIND_SERVICE --ambient-caps=-all,+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
+command=/usr/bin/setpriv --reuid=xroad --regid=xroad --init-groups --inh-caps=+NET_BIND_SERVICE --ambient-caps=+NET_BIND_SERVICE /usr/share/xroad/bin/xroad-proxy
 autorestart=true
 stopwaitsecs=30
 


### PR DESCRIPTION
When running on Linux kernel 5.8+, xroad-proxy process in docker container does
not start due to an error: setpriv: libcap-ng is too old for "all" caps