### PR TITLE
Switch the add wsdl and add rest permissions

### DIFF
--- a/src/proxy-ui-api/frontend/src/views/Clients/Services/Services.vue
+++ b/src/proxy-ui-api/frontend/src/views/Clients/Services/Services.vue
@@ -40,7 +40,7 @@
 
       <div>
         <v-btn
-          v-if="showAddWSDLButton"
+          v-if="showAddRestButton"
           color="primary"
           :loading="addRestBusy"
           @click="showAddRestDialog"
@@ -52,7 +52,7 @@
         >
 
         <v-btn
-          v-if="showAddRestButton"
+          v-if="showAddWSDLButton"
           color="primary"
           :loading="addWsdlBusy"
           @click="showAddWsdlDialog"


### PR DESCRIPTION
Switches the permissions used for "add WSDL" and "add REST" buttons.
Doesn't affect UI functionality.