### PR TITLE
e2e test fixes v6.26

### DIFF
--- a/src/proxy-ui-api/frontend/src/components/wizard/WizardPageGenerateCsr.vue
+++ b/src/proxy-ui-api/frontend/src/components/wizard/WizardPageGenerateCsr.vue
@@ -131,31 +131,26 @@ export default Vue.extend({
     done(): void {
       this.$emit('done');
     },
-    generateCsr(): void {
+    async generateCsr(): Promise<void> {
       const tokenId = this.$store.getters.csrTokenId;
-      this.disableDone = false;
       if (this.keyAndCsr) {
         // Create key and CSR
-        this.$store.dispatch('generateKeyAndCsr', tokenId).then(
-          () => {
-            // noop
-          },
-          (error) => {
-            this.disableDone = true;
-            this.$store.dispatch('showError', error);
-          },
-        );
+        try {
+          await this.$store.dispatch('generateKeyAndCsr', tokenId);
+          this.disableDone = false;
+        } catch (error) {
+          this.disableDone = true;
+          await this.$store.dispatch('showError', error);
+        }
       } else {
         // Create only CSR
-        this.$store.dispatch('generateCsr').then(
-          () => {
-            // noop
-          },
-          (error) => {
-            this.disableDone = true;
-            this.$store.dispatch('showError', error);
-          },
-        );
+        try {
+          await this.$store.dispatch('generateCsr');
+          this.disableDone = false;
+        } catch (error) {
+          this.disableDone = true;
+          await this.$store.dispatch('showError', error);
+        }
       }
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/common/addSubjectsPopup.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/common/addSubjectsPopup.js
@@ -36,9 +36,7 @@ const commands = {
     this.click('@serviceClientTypeDropdown');
     // The picker menu is attached to the main app dom tree, not the dialog
     this.api.click(
-      '//div[@role="listbox"]//div[contains(@class,"v-list-item__title") and contains(text(),"' +
-        type +
-        '")]',
+      `//div[@role="option" and .//div[contains(text(), "${type}")]]`,
     );
     return this;
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
@@ -61,6 +61,10 @@ var navigateCommands = {
     this.click('@snackBarCloseButton');
     return this;
   },
+  closeSessionExpiredPopup: function () {
+    this.click('@sessionExpiredPopupOkButton');
+    return this;
+  },
 };
 
 var clientInfoCommands = {
@@ -635,6 +639,16 @@ module.exports = {
     },
     snackBarMessage: {
       selector: '//div[contains(@class, "v-snack__content")]',
+      locateStrategy: 'xpath',
+    },
+    sessionExpiredPopupMessage: {
+      selector:
+        '//div[contains(@class, "v-dialog--active") and .//span[contains(text(), "Session expired")]]//div[contains(@class, "v-card__text")]',
+      locateStrategy: 'xpath',
+    },
+    sessionExpiredPopupOkButton: {
+      selector:
+        '//div[contains(@class, "v-dialog--active") and .//span[contains(text(), "Session expired")]]//button[./span[contains(text(), "Ok")]]',
       locateStrategy: 'xpath',
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
@@ -562,7 +562,7 @@ const keysTab = {
         },
         csrUsage: {
           selector:
-            '//div[contains(@class, "v-select__selections") and input[@data-test="csr-usage-select"]]',
+            '//div[@role="button" and .//div[contains(@class, "v-select__selections") and input[@data-test="csr-usage-select"]]]',
           locateStrategy: 'xpath',
         },
         csrService: {

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
@@ -64,7 +64,7 @@ const backupAndRestoreCommands = {
   clickDownloadForBackup: function (backupFilename) {
     this.click(
       'xpath',
-      `//table[contains(@class, "xrd-table")]/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-download")]`,
+      `//table[contains(@class, "xrd-table")]/tbody/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-download")]`,
     );
 
     return this;
@@ -72,14 +72,14 @@ const backupAndRestoreCommands = {
   clickRestoreForBackup: function (backupFilename) {
     this.click(
       'xpath',
-      `//table[contains(@class, "xrd-table")]/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-restore")]`,
+      `//table[contains(@class, "xrd-table")]/tbody/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-restore")]`,
     );
     return this;
   },
   clickDeleteForBackup: function (backupFilename) {
     this.click(
       'xpath',
-      `//table[contains(@class, "xrd-table")]/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-delete")]`,
+      `//table[contains(@class, "xrd-table")]/tbody/tr/td[text() = "${backupFilename}"]/..//button[contains(@data-test, "backup-delete")]`,
     );
     return this;
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-backupandrestore.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-backupandrestore.js
@@ -134,7 +134,6 @@ module.exports = {
     // Filtering backup list with the name of created backup there should be only one backup in the list
     backupAndRestoreTab.enterFilterInput(createdBackupFileName);
     browser.expect
-      // xrd-table has thead but no tbody so use '/tr' to get only the row elements that are direct children of table
       .elements('//table[contains(@class, "xrd-table")]/tbody/tr')
       .count.to.equal(1);
     backupAndRestoreTab.clearFilterInput();

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-backupandrestore.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-backupandrestore.js
@@ -135,7 +135,7 @@ module.exports = {
     backupAndRestoreTab.enterFilterInput(createdBackupFileName);
     browser.expect
       // xrd-table has thead but no tbody so use '/tr' to get only the row elements that are direct children of table
-      .elements('//table[contains(@class, "xrd-table")]/tr')
+      .elements('//table[contains(@class, "xrd-table")]/tbody/tr')
       .count.to.equal(1);
     backupAndRestoreTab.clearFilterInput();
 

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-openapiservices.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-openapiservices.js
@@ -306,6 +306,7 @@ module.exports = {
       .verifyClientTypeVisible('SUBSYSTEM')
       .verifyClientTypeVisible('GLOBALGROUP')
       .verifyClientTypeVisible('LOCALGROUP');
+    browser.waitForElementNotVisible('//div[@role="listbox"]');
     addSubjectsPopup
       .startSearch()
       .verifyClientTypeNotPresent('LOCALGROUP')
@@ -528,7 +529,7 @@ module.exports = {
     addEndpointPopup.addSelected();
     browser.assert.containsText(
       mainPage.elements.snackBarMessage,
-      'Endpoint with equivalent service code, method and path already exists for this client',
+      'Endpoint already exists',
     );
     mainPage.closeSnackbar();
 
@@ -653,7 +654,7 @@ module.exports = {
     endpointPopup.addSelected();
     browser.assert.containsText(
       mainPage.elements.snackBarMessage,
-      'Endpoint with equivalent service code, method and path already exists for this client',
+      'Endpoint already exists',
     );
     mainPage.closeSnackbar();
 

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-openapiservices.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-openapiservices.js
@@ -698,7 +698,7 @@ module.exports = {
 
     browser.end();
   },
-  'Security server client edit openapi service': (browser) => {
+  'Security server client edit openapi service': async (browser) => {
     const frontPage = browser.page.ssFrontPage();
     const mainPage = browser.page.ssMainPage();
     const clientsTab = mainPage.section.clientsTab;
@@ -793,7 +793,7 @@ module.exports = {
 
     // Part 1 wait until at least 1 min has passed since refresh at the start of the test
     // Split this wait into two parts to not cause timeouts
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 30000) {
@@ -838,7 +838,7 @@ module.exports = {
     openApiServiceDetails.enterServiceCode('s3c2');
 
     // Part 2 wait until at least 1 min has passed since refresh at the start of the test
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 60000) {

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-restservices.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-restservices.js
@@ -157,6 +157,7 @@ module.exports = {
 
     // Verify tooltips
     browser.moveToElement(operationDetails.elements.urlHelp, 0, 0);
+    browser.waitForElementVisible(operationDetails.elements.activeTooltip);
     browser.expect
       .element(operationDetails.elements.activeTooltip)
       .to.be.visible.and.text.to.equal(
@@ -164,6 +165,7 @@ module.exports = {
       );
 
     browser.moveToElement(operationDetails.elements.timeoutHelp, 0, 0);
+    browser.waitForElementVisible(operationDetails.elements.activeTooltip);
     browser.expect
       .element(operationDetails.elements.activeTooltip)
       .to.be.visible.and.text.to.equal(
@@ -171,6 +173,7 @@ module.exports = {
       );
 
     browser.moveToElement(operationDetails.elements.verifyCertHelp, 0, 0);
+    browser.waitForElementVisible(operationDetails.elements.activeTooltip);
     browser.expect
       .element(operationDetails.elements.activeTooltip)
       .to.be.visible.and.text.to.equal(
@@ -712,7 +715,7 @@ module.exports = {
 
     browser.end();
   },
-  'Security server client edit rest service': (browser) => {
+  'Security server client edit rest service': async (browser) => {
     const frontPage = browser.page.ssFrontPage();
     const mainPage = browser.page.ssMainPage();
     const clientsTab = mainPage.section.clientsTab;
@@ -790,7 +793,7 @@ module.exports = {
 
     // Part 1 wait until at least 1 min has passed since refresh at the start of the test
     // Split this wait into two parts to not cause timeouts
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 30000) {
@@ -841,7 +844,7 @@ module.exports = {
     restServiceDetails.enterServiceCode('s1c2');
 
     // Part 2 wait until at least 1 min has passed since refresh at the start of the test
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 60000) {

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-restservices.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-restservices.js
@@ -554,7 +554,7 @@ module.exports = {
     addEndpointPopup.addSelected();
     browser.assert.containsText(
       mainPage.elements.snackBarMessage,
-      'Endpoint with equivalent service code, method and path already exists for this client',
+      'Endpoint already exists',
     );
     mainPage.closeSnackbar();
 
@@ -668,7 +668,7 @@ module.exports = {
     endpointPopup.addSelected();
     browser.assert.containsText(
       mainPage.elements.snackBarMessage,
-      'Endpoint with equivalent service code, method and path already exists for this client',
+      'Endpoint already exists',
     );
     mainPage.closeSnackbar();
 

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-wsdlservices.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-clients-wsdlservices.js
@@ -451,7 +451,7 @@ module.exports = {
 
     browser.end();
   },
-  'Security server client edit wsdl service': (browser) => {
+  'Security server client edit wsdl service': async (browser) => {
     const frontPage = browser.page.ssFrontPage();
     const mainPage = browser.page.ssMainPage();
     const clientsTab = mainPage.section.clientsTab;
@@ -549,7 +549,7 @@ module.exports = {
 
     // Part 1 wait until at least 1 min has passed since refresh at the start of the test
     // Split this wait into two parts to not cause timeouts
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 30000) {
@@ -581,7 +581,7 @@ module.exports = {
     browser.waitForElementVisible(servicesPopup);
 
     // Part 2 wait until at least 1 min has passed since refresh at the start of the test
-    browser.perform(function () {
+    await browser.perform(function () {
       const endTime = new Date().getTime();
       const passedTime = endTime - startTime;
       if (passedTime < 60000) {

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-keyscerts-authsignkeys.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-keyscerts-authsignkeys.js
@@ -81,7 +81,10 @@ module.exports = {
     browser.waitForElementVisible(addKeyWizardGenerate);
     addKeyWizardGenerate.enterOrganization('TestOrg');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
 
     browser.waitForElementVisible(
@@ -154,9 +157,12 @@ module.exports = {
     browser.waitForElementVisible(addKeyWizardGenerate.elements.serverDNS);
     addKeyWizardGenerate.enterServerDNS('foodns');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
-
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
+
     browser.waitForElementVisible(
       '//table[.//th[contains(@class, "title-col") and contains(text(), "AUTH Key and Certificate")]]//span[contains(text(), "testautlbl")]',
     );
@@ -243,7 +249,10 @@ module.exports = {
     browser.waitForElementVisible(addKeyWizardGenerate);
     addKeyWizardGenerate.enterOrganization('TestOrg');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
     browser.perform(function () {
       browser.click(
@@ -334,7 +343,10 @@ module.exports = {
     addKeyWizardGenerate.enterOrganization('TestOrg');
     addKeyWizardGenerate.enterServerDNS('foodns');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
 
     browser.perform(function () {
@@ -443,7 +455,10 @@ module.exports = {
     browser.waitForElementVisible(addKeyWizardGenerate);
     addKeyWizardGenerate.enterOrganization('TestOrg2');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
 
     // Verify that a request has been added
@@ -625,7 +640,10 @@ module.exports = {
     addKeyWizardGenerate.enterOrganization('TestOrg3');
     addKeyWizardGenerate.enterServerDNS('foodns');
 
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).to.not.be
+      .enabled;
     addKeyWizardGenerate.generateCSR();
+    browser.expect.element(addKeyWizardGenerate.elements.doneButton).enabled;
     addKeyWizardGenerate.close();
 
     // Verify that a request has been added

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-logout.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-logout.js
@@ -71,15 +71,15 @@ module.exports = {
 
     // Wait for the timeout message to appear
     browser.waitForElementVisible(
-      mainPage.elements.snackBarMessage,
+      mainPage.elements.sessionExpiredPopupMessage,
       browser.globals.logout_timeout_ms + 60000,
       1000,
     );
     browser.assert.containsText(
-      mainPage.elements.snackBarMessage,
-      'Error: Request failed with status code 401',
+      mainPage.elements.sessionExpiredPopupMessage,
+      'You have been idle for 30 minutes and your session has expired. For security reasons, you will be logged out.',
     );
-    mainPage.closeSnackbar();
+    mainPage.closeSessionExpiredPopup();
 
     browser.waitForElementVisible('//*[@id="username"]');
     browser.end();


### PR DESCRIPTION
e2e environment was upgraded from X-Road 6.24 to 6.26. This upgrade introduced frontend changes that broke some of the e2e tests. This PR fixes those tests. 

This PR also changes Add Key and CSR wizard's `Done` buttons `disabled` status behavior: the button will be enabled after the API request returns success (instead of being enabled right after the request is sent)