### PR TITLE
XRDDEV-1544: Define ordering for timestamped records

### DIFF
--- a/src/addons/messagelog/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
+++ b/src/addons/messagelog/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
@@ -211,7 +211,7 @@ public class TaskQueue extends UntypedAbstractActor {
 
     static String getTaskQueueQuery() {
         return "select new " + Task.class.getName() + "(m.id, m.signatureHash) "
-                + "from MessageRecord m where m.signatureHash is not null";
+                + "from MessageRecord m where m.signatureHash is not null order by m.id";
     }
 
     private static String getTaskQueueSizeQuery() {


### PR DESCRIPTION
Define explicit ordering for timestamped records, so that a clustered
setup that shares the messagelog database, all nodes update records
in the same order.

The query returning to-be-timestamped records uses an index that includes
the record id. The "order by id" added by this fix is virtually free
because the index is already sorted by id. Therefore it is also likely
that the records were already returned in the same order and a deadlock
could not occur in practice.