### PR TITLE
6.26 beta update dependencies

### DIFF
--- a/src/addons/metaservice/build.gradle
+++ b/src/addons/metaservice/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'wsdl4j:wsdl4j:1.6.3'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-    testImplementation 'org.apache.httpcomponents:httpmime:4.5.2'
+    testImplementation 'org.apache.httpcomponents:httpmime:4.5.13'
     testImplementation 'org.xmlunit:xmlunit-core:2.2.1'
     testImplementation 'org.xmlunit:xmlunit-matchers:2.2.1'
     testImplementation 'org.hsqldb:hsqldb:2.5.1'

--- a/src/addons/wsdlvalidator/build.gradle
+++ b/src/addons/wsdlvalidator/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation "org.apache.cxf:cxf-tools-validator:3.4.0"
+    implementation "org.apache.cxf:cxf-tools-validator:3.4.2"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 }
 

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -11,11 +11,11 @@ buildscript {
 
 plugins {
     id 'org.sonarqube' version '2.7.1'
-    id 'org.owasp.dependencycheck' version '6.0.3'
+    id 'org.owasp.dependencycheck' version '6.0.5'
     id 'jacoco'
     id 'idea'
-    id "io.spring.dependency-management" version "1.0.10.RELEASE" apply false
-    id 'org.springframework.boot' version '2.3.6.RELEASE' apply false
+    id "io.spring.dependency-management" version "1.0.11.RELEASE" apply false
+    id 'org.springframework.boot' version '2.3.8.RELEASE' apply false
 }
 
 repositories {
@@ -112,13 +112,13 @@ subprojects {
     dependencies {
         testImplementation 'org.hamcrest:hamcrest:2.2'
         testImplementation 'org.hamcrest:hamcrest-library:2.2'
-        testImplementation 'junit:junit:4.13'
+        testImplementation 'junit:junit:4.13.2'
 
-        compileOnly 'org.projectlombok:lombok:1.18.12'
-        annotationProcessor 'org.projectlombok:lombok:1.18.12'
+        compileOnly 'org.projectlombok:lombok:1.18.18'
+        annotationProcessor 'org.projectlombok:lombok:1.18.18'
 
-        testCompileOnly 'org.projectlombok:lombok:1.18.12'
-        testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
+        testCompileOnly 'org.projectlombok:lombok:1.18.18'
+        testAnnotationProcessor 'org.projectlombok:lombok:1.18.18'
     }
 
     task testJar(type: Jar) {

--- a/src/buildSrc/build.gradle
+++ b/src/buildSrc/build.gradle
@@ -9,8 +9,8 @@ repositories {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    implementation 'org.openapi4j:openapi-parser:1.0.4'
+    implementation 'org.openapi4j:openapi-parser:1.0.5'
     implementation 'org.openapitools.openapistylevalidator:openapi-style-validator-lib:1.4'
-    implementation 'io.swagger.parser.v3:swagger-parser:2.0.21'
+    implementation 'io.swagger.parser.v3:swagger-parser:2.0.24'
     implementation 'org.openapitools.empoa:empoa-swagger-core:1.1.0'
 }

--- a/src/center-common/Gemfile.lock
+++ b/src/center-common/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     builder (3.0.4)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     erubis (2.7.0)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
@@ -77,7 +77,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
     sprockets (2.2.3)
@@ -85,14 +85,14 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (1.0.1)
+    thor (1.1.0)
     tilt (1.4.1)
     transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.58)
+    tzinfo (0.3.60)
 
 PLATFORMS
   java

--- a/src/center-service/Gemfile.lock
+++ b/src/center-service/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     addressable (2.4.0)
     arel (3.0.3)
     builder (3.0.4)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     erubis (2.7.0)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
@@ -99,7 +99,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
     sprockets (2.2.3)
@@ -107,14 +107,14 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (1.0.1)
+    thor (1.1.0)
     tilt (1.4.1)
     transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.58)
+    tzinfo (0.3.60)
 
 PLATFORMS
   java

--- a/src/center-ui/Gemfile.lock
+++ b/src/center-ui/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     addressable (2.4.0)
     arel (3.0.3)
     builder (3.0.4)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     erubis (2.7.0)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
@@ -99,7 +99,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
     sprockets (2.2.3)
@@ -107,14 +107,14 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (1.0.1)
+    thor (1.1.0)
     tilt (1.4.1)
     transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.58)
+    tzinfo (0.3.60)
 
 PLATFORMS
   java

--- a/src/common-test/build.gradle
+++ b/src/common-test/build.gradle
@@ -5,9 +5,9 @@ plugins {
 dependencies {
     implementation project(':common-util')
     implementation project(':common-verifier')
-    implementation 'org.antlr:ST4:4.0.7'
+    implementation 'org.antlr:ST4:4.0.8'
     // JUnit is needed for ExpectedCodedException
-    implementation 'junit:junit:4.13'
+    implementation 'junit:junit:4.13.2'
     implementation 'com.google.code.gson:gson:2.8.6'
     api "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/src/common-test/build.gradle
+++ b/src/common-test/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation project(':common-util')
     implementation project(':common-verifier')
-    implementation 'org.antlr:ST4:4.0.8'
+    implementation 'org.antlr:ST4:4.0.7'
     // JUnit is needed for ExpectedCodedException
     implementation 'junit:junit:4.13.2'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/src/common-ui/Gemfile.lock
+++ b/src/common-ui/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     addressable (2.4.0)
     arel (3.0.3)
     builder (3.0.4)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.9.5)
@@ -80,7 +80,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
     sprockets (2.2.3)
@@ -88,12 +88,12 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (1.0.1)
+    thor (1.1.0)
     tilt (1.4.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.58)
+    tzinfo (0.3.60)
 
 PLATFORMS
   java

--- a/src/common-ui/build.gradle
+++ b/src/common-ui/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation project(':signer-protocol')
 
     compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-    implementation 'org.owasp.encoder:encoder:1.2.2'
+    implementation 'org.owasp.encoder:encoder:1.2.3'
     implementation 'org.kohsuke:libpam4j:1.11'
     implementation 'net.java.dev.jna:jna:4.5.2'
 

--- a/src/common-util/build.gradle
+++ b/src/common-util/build.gradle
@@ -17,7 +17,7 @@ sourceSets {
 }
 
 dependencies {
-    api 'org.apache.santuario:xmlsec:2.2.0'
+    api 'org.apache.santuario:xmlsec:2.2.1'
     api 'org.bouncycastle:bcpkix-jdk15on:1.66'
     api 'org.apache.commons:commons-lang3:3.11'
     api 'commons-io:commons-io:2.8.0'
@@ -27,7 +27,7 @@ dependencies {
     api 'com.sun.xml.messaging.saaj:saaj-impl:1.5.2'
     api 'com.sun.activation:jakarta.activation:1.2.2'
     api "org.eclipse.jetty:jetty-server:$jettyVersion"
-    api 'org.apache.httpcomponents:httpclient:4.5.6'
+    api 'org.apache.httpcomponents:httpclient:4.5.13'
     api 'org.apache.httpcomponents:httpasyncclient:4.1.4'
 
     api "com.typesafe.akka:akka-actor_$akkaVersion"

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -8,19 +8,17 @@ xroadVersion=6.26.0
 xroadBuildType=SNAPSHOT
 
 // common dependency versions
-akkaVersion=2.13:2.6.11
-metricsVersion=4.1.12.1
-jettyVersion=9.4.34.v20201102
+akkaVersion=2.13:2.6.12
+metricsVersion=4.1.17
+jettyVersion=9.4.36.v20210114
 jetty.version=${jettyVersion}
 jaxbVersion=2.3.3
 jaxb.version=${jaxbVersion}
-hibernateVersion=5.4.23.Final
+hibernateVersion=5.4.28.Final
 hibernate.version=${hibernateVersion}
 shadowJarVersion=6.0.0
-jackson.version=2.11.3
+jackson.version=2.11.4
 postgresql.version=42.2.18
 mockitoVersion=3.4.6
 mockito.version=${mockitoVersion}
-tomcat.version=9.0.39
-snakeyaml.version=1.26
 xercesVersion=2.12.1

--- a/src/monitor-common/build.gradle
+++ b/src/monitor-common/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
     implementation 'org.slf4j:slf4j-api:1.7.30'
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
 }
 

--- a/src/monitor-test/build.gradle
+++ b/src/monitor-test/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation project(':monitor-common')
     implementation 'org.slf4j:slf4j-api:1.7.30'
 
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/src/monitor/build.gradle
+++ b/src/monitor/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "io.dropwizard.metrics:metrics-jmx:$metricsVersion"
 
     testImplementation project(':common-test')
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "com.typesafe.akka:akka-testkit_$akkaVersion"
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/src/packages/src/xroad/common/center/etc/xroad/services/jetty.conf
+++ b/src/packages/src/xroad/common/center/etc/xroad/services/jetty.conf
@@ -12,7 +12,7 @@ done
 
 CP="/usr/share/xroad/jetty9/start.jar"
 
-JETTY_PARAMS=" -Xms150m -Xmx400m -XX:MaxMetaspaceSize=160m -Djruby.compile.mode=OFF \
+JETTY_PARAMS=" -Xms150m -Xmx400m -XX:MaxMetaspaceSize=200m -Djruby.compile.mode=OFF \
 -Djetty.admin.port=8083 \
 -Djetty.public.port=8084
 -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog

--- a/src/proxy-ui-api/build.gradle
+++ b/src/proxy-ui-api/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 ext {
-    set('springCloudVersion', "Hoxton.SR9")
+    set('springCloudVersion', "Hoxton.SR10")
 }
 
 sourceSets {


### PR DESCRIPTION
- upgrade dependencies to latest bugfix releases
- increase central server jetty MaxMetaspace to 200m to prevent OutOfMemoryErrors