### PR TITLE
XRDDEV-541

### DIFF
--- a/src/common-test/src/main/java/ee/ria/xroad/common/OcspTestUtils.java
+++ b/src/common-test/src/main/java/ee/ria/xroad/common/OcspTestUtils.java
@@ -28,6 +28,7 @@ package ee.ria.xroad.common;
 import ee.ria.xroad.common.util.CryptoUtils;
 
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.ocsp.BasicOCSPRespBuilder;
 import org.bouncycastle.cert.ocsp.CertificateID;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
@@ -96,7 +97,8 @@ public final class OcspTestUtils {
         ContentSigner contentSigner = CryptoUtils.createContentSigner(
                 subject.getSigAlgName(), signerKey);
 
-        Object responseObject = builder.build(contentSigner, null, new Date());
+        X509CertificateHolder[] chain = {new X509CertificateHolder(signer.getEncoded())};
+        Object responseObject = builder.build(contentSigner, chain, new Date());
 
         OCSPResp resp = new OCSPRespBuilder().build(
                 OCSPRespBuilder.SUCCESSFUL, responseObject);

--- a/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
@@ -35,6 +35,7 @@ public final class DiagnosticsErrorCodes {
 
     public static final int RETURN_SUCCESS = 0;
     public static final int ERROR_CODE_LOGMANAGER_UNAVAILABLE = 132;
+    public static final int ERROR_CODE_OCSP_RESPONSE_UNVERIFIED = 133;
     public static final int ERROR_CODE_OCSP_UNINITIALIZED = 131;
     public static final int ERROR_CODE_OCSP_RESPONSE_INVALID = 130;
     public static final int ERROR_CODE_OCSP_CONNECTION_ERROR = 129;

--- a/src/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
+++ b/src/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
@@ -140,7 +140,7 @@ public class OcspVerifierTest {
         thrown.expectError(X_INCORRECT_VALIDATION_INFO);
         OcspVerifier verifier =
                 new OcspVerifier(GlobalConf.getOcspFreshnessSeconds(true), new OcspVerifierOptions(true));
-        verifier.verifyValidityAndStatus(ocsp, issuer, anotherSignerCert);
+        verifier.verifyValidityAndStatus(ocsp, subject, issuer);
     }
 
     /**
@@ -285,6 +285,12 @@ public class OcspVerifierTest {
     }
 
     private class TestGlobalConf extends EmptyGlobalConf {
+
+        @Override
+        public boolean isOcspResponderCert(X509Certificate ca, X509Certificate ocspCert) {
+            return false;
+        }
+
         @Override
         public List<X509Certificate> getOcspResponderCertificates() {
             return Collections.singletonList(signer);

--- a/src/proxy-ui-api/frontend/src/locales/en.json
+++ b/src/proxy-ui-api/frontend/src/locales/en.json
@@ -838,6 +838,7 @@
         "ERROR_CODE_OCSP_FAILED": "Unable to fetch response from the OCSP responder",
         "ERROR_CODE_OCSP_RESPONSE_INVALID": "Unable to parse the OCSP response",
         "ERROR_CODE_OCSP_UNINITIALIZED": "Status request not sent yet",
+        "ERROR_CODE_OCSP_RESPONSE_UNVERIFIED" : "Unable to verify the OCSP response",
         "UNKNOWN": "Unknown"
       }
     }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/OcspStatusMapping.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/OcspStatusMapping.java
@@ -50,8 +50,9 @@ public enum OcspStatusMapping {
             OcspStatus.ERROR_CODE_OCSP_RESPONSE_INVALID),
     ERROR_CODE_OCSP_UNINITIALIZED(DiagnosticsErrorCodes.ERROR_CODE_OCSP_UNINITIALIZED,
             OcspStatus.ERROR_CODE_OCSP_UNINITIALIZED),
-    UNKNOWN(-1,
-            OcspStatus.UNKNOWN);
+    ERROR_CODE_OCSP_RESPONSE_UNVERIFIED(DiagnosticsErrorCodes.ERROR_CODE_OCSP_RESPONSE_UNVERIFIED,
+            OcspStatus.ERROR_CODE_OCSP_RESPONSE_UNVERIFIED),
+    UNKNOWN(-1, OcspStatus.UNKNOWN);
 
     private static final int DIAGNOSTICS_ERROR_CODE_UNKNOWN = -1;
     private final Integer diagnosticsErrorCode;
@@ -59,6 +60,7 @@ public enum OcspStatusMapping {
 
     /**
      * Return matching OcspStatus, if any
+     *
      * @param diagnosticsErrorCode
      * @return
      */
@@ -68,17 +70,13 @@ public enum OcspStatusMapping {
 
     /**
      * return OcspStatusMapping matching the given DiagnosticsErrorCode, if any
+     *
      * @param diagnosticsErrorCode
      * @return
      */
     public static Optional<OcspStatusMapping> getFor(Integer diagnosticsErrorCode) {
-        Optional<OcspStatusMapping> result = Arrays.stream(values())
+        return Optional.of(Arrays.stream(values())
                 .filter(mapping -> mapping.diagnosticsErrorCode.equals(diagnosticsErrorCode))
-                .findFirst();
-        if (result.isPresent()) {
-            return result;
-        }  else {
-            return getFor(DIAGNOSTICS_ERROR_CODE_UNKNOWN);
-        }
+                .findFirst().orElse(UNKNOWN));
     }
 }

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -6232,6 +6232,7 @@ components:
         - ERROR_CODE_OCSP_FAILED # Unable to fetch response from the OCSP responder.
         - ERROR_CODE_OCSP_RESPONSE_INVALID # Unable to parse the OCSP response.
         - ERROR_CODE_OCSP_UNINITIALIZED # Status request not sent yet.
+        - ERROR_CODE_OCSP_RESPONSE_UNVERIFIED # Unable to verify OCSP response.
         - UNKNOWN
     OrphanInformation: # ok
       type: object


### PR DESCRIPTION
https://jira.niis.org/browse/XRDDEV-541

- Old (ocsp responder has been changed and old removed) ocsp-responses are removed from the diagnostics 
- Diagnostics shows 'Unable to verify OCSP response' when the certificate isn't matching the certificate of the given ocsp-responder url