### PR TITLE
Fix archive transport script curl url specifying

### DIFF
--- a/src/addons/messagelog/scripts/archive-http-transporter.sh
+++ b/src/addons/messagelog/scripts/archive-http-transporter.sh
@@ -116,7 +116,7 @@ flock -n 123 || die "There is archive transporter process already running"
   shopt -s nullglob
   for i in "$ARCHIVE_DIR"/*.zip; do
     http_code=$(curl -s -S -o /dev/null -w "%{http_code}" \
-        -F file=@"$i" $HTTPS_OPTIONS $URL)
+        -F file=@"$i" $HTTPS_OPTIONS --url "$URL")
     ret=$?
 
     if [ $ret -ne 0 ]; then


### PR DESCRIPTION
Curl URL specifying is currently not by the book meaning that using URL with https is not possible.

`--url <url>` is the correct way

Thanks @Tuudik !