### PR TITLE
XRDDEV-1226 token pin change frontend part2

### DIFF
--- a/src/proxy-ui-api/frontend/src/components/ui/ContextualAlerts.vue
+++ b/src/proxy-ui-api/frontend/src/components/ui/ContextualAlerts.vue
@@ -67,8 +67,28 @@
                 {{ notification.errorObject }}
               </div>
 
+              <!-- Special case for pin code validation -->
+              <template v-if="errorCode(notification) === 'weak_pin'">
+                <div>
+                  {{
+                    $t(`error_code.${errorMetadata(notification)[0]}`) +
+                    `: ${errorMetadata(notification)[1]}`
+                  }}
+                </div>
+                <div>
+                  {{
+                    $t(`error_code.${errorMetadata(notification)[2]}`) +
+                    `: ${errorMetadata(notification)[3]}`
+                  }}
+                </div>
+              </template>
+
               <!-- Show the error metadata if it exists -->
-              <div v-for="meta in errorMetadata(notification)" :key="meta">
+              <div
+                v-else
+                v-for="meta in errorMetadata(notification)"
+                :key="meta"
+              >
                 {{ meta }}
               </div>
 

--- a/src/proxy-ui-api/frontend/src/views/TokenDetails/TokenDetails.vue
+++ b/src/proxy-ui-api/frontend/src/views/TokenDetails/TokenDetails.vue
@@ -66,7 +66,7 @@
                 ></v-text-field>
               </ValidationProvider>
             </v-row>
-            <v-row v-if="canUpdatePin" no-gutters>
+            <v-row v-if="isSoftwareToken() && canUpdatePin" no-gutters>
               <xrd-expandable
                 class="expandable"
                 @open="toggleChangePinOpen"
@@ -182,7 +182,12 @@ import * as api from '@/util/api';
 import { encodePathParameter } from '@/util/api';
 import { ValidationObserver, ValidationProvider } from 'vee-validate';
 import { Permissions } from '@/global';
-import { PossibleAction, Token, TokenPinUpdate } from '@/openapi-types';
+import {
+  PossibleAction,
+  Token,
+  TokenPinUpdate,
+  TokenType,
+} from '@/openapi-types';
 
 export default Vue.extend({
   components: {
@@ -277,6 +282,10 @@ export default Vue.extend({
           PossibleAction.TOKEN_CHANGE_PIN,
         ) ?? false
       );
+    },
+
+    isSoftwareToken(): boolean {
+      return this.token.type === TokenType.SOFTWARE;
     },
 
     toggleChangePinOpen(): void {


### PR DESCRIPTION
* Pin change is only shown for software tokens
* `weak_pin` error is now handled so that the metadata fields have translations

As background info: the weak pin error is formed in the backend as follows
```java
List<String> metadata = new ArrayList<>();
metadata.add(ERROR_METADATA_PIN_MIN_LENGTH);
metadata.add(String.valueOf(TokenPinPolicy.MIN_PASSWORD_LENGTH));
metadata.add(ERROR_METADATA_PIN_MIN_CHAR_CLASSES);
metadata.add(String.valueOf(TokenPinPolicy.MIN_CHARACTER_CLASS_COUNT));
```