### PR TITLE
Ansible improvements

### DIFF
--- a/ansible/roles/xroad-base/tasks/main.yml
+++ b/ansible/roles/xroad-base/tasks/main.yml
@@ -15,7 +15,8 @@
 - name: xroad user
   user:
     name: xroad
-    comment: "XRoad User"
+    comment: "X-Road User"
+    groups: xroad
     state: present
     shell: "/bin/bash"
     password: '*'

--- a/ansible/ss_cluster/roles/master/tasks/main.yml
+++ b/ansible/ss_cluster/roles/master/tasks/main.yml
@@ -9,7 +9,7 @@
             value=master
             create=true
             mode=0640
-            owner=root
+            owner=xroad
             group=xroad
 
 - name: start services

--- a/ansible/ss_cluster/roles/slave/tasks/main.yml
+++ b/ansible/ss_cluster/roles/slave/tasks/main.yml
@@ -29,7 +29,7 @@
             value=slave
             create=true
             mode=0640
-            owner=root
+            owner=xroad
             group=xroad
 
 - name: start services


### PR DESCRIPTION
* In the xroad-base role, when creating xroad user, add it to xroad group
* In the ss_cluster master and slave role, when creating node.ini it's owner to xroad

These changes will also fix the problem with slave nodes not being able to create conf backups since xroad user cannot read node.ini