### PR TITLE
Fixed a bug that doesn't create recovery.conf on RHEL7/8 standby nodes

### DIFF
--- a/ansible/ss_cluster/roles/slave/tasks/serverconf_slave_db.yml
+++ b/ansible/ss_cluster/roles/slave/tasks/serverconf_slave_db.yml
@@ -21,7 +21,9 @@
       dest: "{{ postgresql_data_dir }}/recovery.conf"
       owner: postgres
       group: postgres
-  when: ansible_distribution_release == "bionic"
+  when: >
+    ansible_distribution_release == "bionic" or 
+    (ansible_distribution == "RedHat" and (ansible_distribution_major_version == "7" or ansible_distribution_major_version == "8"))
 
 # recovery.conf is no longer supported in PostgreSQL12
 # see https://www.2ndquadrant.com/en/blog/replication-configuration-changes-in-postgresql-12/


### PR DESCRIPTION
According to https://github.com/nordic-institute/X-Road/blob/develop/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md#44-configuring-the-replica-instance-for-replication

You should create on standby node  the file `recovery.conf` on RHEL7/8 and Ubuntu 18.04... But the ss_cluster playbook doesn't do that... Hence the postgresql replication fails on RHEL7/8.