### PR TITLE
XRDDEV-1662 config for screenshots moved to test settings

### DIFF
--- a/src/proxy-ui-api/frontend/nightwatch.json
+++ b/src/proxy-ui-api/frontend/nightwatch.json
@@ -9,13 +9,14 @@
   "disable_colors": false,
   "test_workers" : false,
   "test_settings" : {
-    "screenshots" : {
-      "enabled" : true,
-      "on_failure" : true,
-      "on_error" : true,
-      "path" : "./tests/e2e/screenshots"
-    },
+    
     "default": {
+      "screenshots" : {
+        "enabled" : true,
+        "on_failure" : true,
+        "on_error" : true,
+        "path" : "./tests/e2e/screenshots"
+      },
       "use_xpath": true,
       "globals" : {
         "login_usr" : "xrd",


### PR DESCRIPTION
Seems that screenshots were missconfigured, settings were placed under `test_settings` where they do get overridden by non-default test settings.

Change seems to work fine also headlless execution. in such case it won't generate screenshots but doesn't fail on it either.