### PR TITLE
XRDDEV-1743

### DIFF
--- a/src/packages/src/xroad/common/base/usr/share/xroad/scripts/generate_gpg_keypair.sh
+++ b/src/packages/src/xroad/common/base/usr/share/xroad/scripts/generate_gpg_keypair.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
+set -euo pipefail
 
-GPGHOME="$1"
-if [ -d "$GPGHOME" ] ; then
-  rm -rf "$GPGHOME"
+if [[ $# -ne 2 ]]; then
+  echo "Usage $0 <gpghome> <user id>" >&2
+  exit 1
 fi
 
-echo "GENERATING NEW KEYPAIR"
-mkdir -p "$GPGHOME"
-chmod 700 "$GPGHOME"
+GPGHOME="$1"
+USERID="$2"
 
-gpg --homedir "$GPGHOME" --batch --gen-key <<EOF
+if [[ -f "$GPGHOME/pubring.kbx" || -f "$GPGHOME/pubring.gpg" ]] && gpg --homedir "$GPGHOME" --quiet --batch --list-secret-keys "=$USERID"; then
+  echo "GPG key for '$USERID' already exists in '$GPGHOME'" >&2
+  exit 0
+fi
+
+echo "Generating new GPG keypair for '$USERID'"
+mkdir -p -m 0700 "$GPGHOME"
+
+gpg --homedir "$GPGHOME" --quiet --batch --gen-key <<EOF
 Key-Type: 1
 Key-Length: 4096
-Name-Real: $2
+Name-Real: $USERID
 Expire-Date: 0
 %no-protection
 EOF
-
 


### PR DESCRIPTION
generate_gpg_keypair.sh would always remove the gpg home directory passed as a
parameter. Change the script to check for an existing key, and never remove
anything.