### PR TITLE
XRDDEV-1722: Fix file reference missing from manifest

### DIFF
--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainer.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainer.java
@@ -249,6 +249,10 @@ public class AsicContainer {
             b.addFile(entryName, MimeTypes.TEXT_XML); // assume files are XML
         }
 
+        if (attachment != null) {
+            b.addFile(ENTRY_ATTACHMENT + "1", MimeTypes.BINARY);
+        }
+
         put(ENTRY_MANIFEST, b.build());
     }
 


### PR DESCRIPTION
OpenDocument manifest lacked a reference to "attachment1" if one was
present in the container (applies only to REST messages)