### PR TITLE
Issue #1054: fix compatibility issues with LXD4 and Fedora.

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -165,6 +165,8 @@ sudo lxd init
 
 An example of an LXD-specific host file can be found in `hosts/lxd_hosts.txt`. While it is possible to use and modify this file it is recommended to create your own host file to facilitate further configuration.
 
+Some LXD installations may create the Unix-domain socket for connecting to the service in a location different from those searched by ansible. If that is the case in your environment, override the variable `lxd_url` for the server running LXD (group `lxd_servers` in the example inventory file) by creating a yml file in the `group_vars` directory.
+
 The playbook initializes LXD-containers according to the hosts defined in the inventory. The host for the LXD-containers themselves is
 defined with the group `lxd_servers`, normally localhost. After inventory configurations, Ansible playbooks can be used to deploy X-Road to the LXD-hosts much like with other inventories.
 

--- a/ansible/hosts/lxd_hosts.txt
+++ b/ansible/hosts/lxd_hosts.txt
@@ -1,27 +1,27 @@
 #central servers (ubuntu lxd containers)
 [cs_servers]
-xroadlxdcs ansible_connection=lxd
+xroad-lxd-cs ansible_connection=lxd
 
 #configuration proxies (ubuntu lxd containers, optional)
 [cp_servers]
-#xroadlxdcp ansible_connection=lxd
+#xroad-lxd-cp ansible_connection=lxd
 
 #certification authority, time stamping authority and ocsp service server for testing purposes (ubuntu)
 [ca_servers]
-xroadlxdcs ansible_connection=lxd
+xroad-lxd-cs ansible_connection=lxd
 
 #security servers (ubuntu lxd containers)
 [ss_servers]
-xroadlxdss1 ansible_connection=lxd
+xroad-lxd-ss1 ansible_connection=lxd
 #for a more realistic setup, add at least one additional server
-#xroadlxdss2 ansible_connection=lxd
+#xroad-lxd-ss2 ansible_connection=lxd
 
 [ss_servers:children]
 centos_ss
 
 #security servers (centos lxd containers, not supported in variant ee)
 [centos_ss]
-#xroadlxdrhss1 ansible_connection=lxd
+#xroad-lxd-rh-ss1 ansible_connection=lxd
 
 #container host
 [lxd_servers]

--- a/ansible/hosts/lxd_hosts.txt
+++ b/ansible/hosts/lxd_hosts.txt
@@ -1,27 +1,27 @@
 #central servers (ubuntu lxd containers)
 [cs_servers]
-xroad-lxd-cs ansible_connection=lxd
+xroadlxdcs ansible_connection=lxd
 
 #configuration proxies (ubuntu lxd containers, optional)
 [cp_servers]
-#xroad-lxd-cp ansible_connection=lxd
+#xroadlxdcp ansible_connection=lxd
 
 #certification authority, time stamping authority and ocsp service server for testing purposes (ubuntu)
 [ca_servers]
-xroad-lxd-cs ansible_connection=lxd
+xroadlxdcs ansible_connection=lxd
 
 #security servers (ubuntu lxd containers)
 [ss_servers]
-xroad-lxd-ss1 ansible_connection=lxd
+xroadlxdss1 ansible_connection=lxd
 #for a more realistic setup, add at least one additional server
-#xroad-lxd-ss2 ansible_connection=lxd
+#xroadlxdss2 ansible_connection=lxd
 
 [ss_servers:children]
 centos_ss
 
 #security servers (centos lxd containers, not supported in variant ee)
 [centos_ss]
-#xroad-lxd-rh-ss1 ansible_connection=lxd
+#xroadlxdrhss1 ansible_connection=lxd
 
 #container host
 [lxd_servers]

--- a/ansible/roles/init-lxd/tasks/main.yml
+++ b/ansible/roles/init-lxd/tasks/main.yml
@@ -3,8 +3,7 @@
   with_inventory_hostnames: all:!lxd_servers:!centos_ss
   lxd_container:
     name: "{{item}}"
-    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
-    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    url: "{{ lxd_url | default(omit) }}"
     state: started
     source:
       type: image
@@ -22,8 +21,7 @@
   with_inventory_hostnames: centos_ss
   lxd_container:
     name: "{{item}}"
-    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
-    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    url: "{{ lxd_url | default(omit) }}"
     state: started
     source:
       type: image

--- a/ansible/roles/init-lxd/tasks/main.yml
+++ b/ansible/roles/init-lxd/tasks/main.yml
@@ -3,6 +3,8 @@
   with_inventory_hostnames: all:!lxd_servers:!centos_ss
   lxd_container:
     name: "{{item}}"
+    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
     state: started
     source:
       type: image
@@ -20,6 +22,8 @@
   with_inventory_hostnames: centos_ss
   lxd_container:
     name: "{{item}}"
+    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
     state: started
     source:
       type: image

--- a/ansible/roles/restart-lxd/tasks/main.yml
+++ b/ansible/roles/restart-lxd/tasks/main.yml
@@ -2,6 +2,5 @@
   with_inventory_hostnames: ss_servers, cs_servers, cp_servers
   lxd_container:
     name: "{{item}}"
-    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
-    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    url: "{{ lxd_url | default(omit) }}"
     state: restarted

--- a/ansible/roles/restart-lxd/tasks/main.yml
+++ b/ansible/roles/restart-lxd/tasks/main.yml
@@ -2,4 +2,6 @@
   with_inventory_hostnames: ss_servers, cs_servers, cp_servers
   lxd_container:
     name: "{{item}}"
+    url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
+    snap_url: "{{ lxd_url | default('unix:/var/lib/lxd/unix.socket') }}"
     state: restarted


### PR DESCRIPTION
This patch fixes the above problem by changing the host names in the LXD example inventory and making the path to the socket for connecting to LXD configurable. 