### PR TITLE
Xrddev 1733 fix timestamping tests

### DIFF
--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AbstractMessageLogTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AbstractMessageLogTest.java
@@ -25,6 +25,7 @@
  */
 package ee.ria.xroad.proxy.messagelog;
 
+import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.messagelog.AbstractLogManager;
 import ee.ria.xroad.common.messagelog.MessageLogProperties;
@@ -106,6 +107,8 @@ abstract class AbstractMessageLogTest {
     }
 
     protected void testSetUp(boolean timestampImmediately) throws Exception {
+        System.setProperty(SystemProperties.TEMP_FILES_PATH, "build/tmp");
+
         jobManager = new JobManager();
         clearDeadLetters();
 

--- a/src/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCacheTest.java
+++ b/src/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCacheTest.java
@@ -25,6 +25,7 @@
  */
 package ee.ria.xroad.common.messagelog.archive;
 
+import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.asic.AsicContainer;
 import ee.ria.xroad.common.messagelog.MessageLogProperties;
 import ee.ria.xroad.common.messagelog.MessageRecord;
@@ -108,6 +109,8 @@ public class LogArchiveCacheTest {
 
     @Before
     public void setup() {
+        System.setProperty(SystemProperties.TEMP_FILES_PATH, "build/tmp");
+
         if (encrypted) {
             Assume.assumeTrue(Files.isExecutable(Paths.get("/usr/bin/gpg")));
         }

--- a/src/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveTest.java
+++ b/src/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveTest.java
@@ -25,6 +25,7 @@
  */
 package ee.ria.xroad.common.messagelog.archive;
 
+import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.conf.globalconf.EmptyGlobalConf;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.identifier.ClientId;
@@ -98,6 +99,7 @@ public class LogArchiveTest {
         recordNo = 0;
         rotated = false;
         Files.createDirectory(Paths.get("build/slog"));
+        System.setProperty(SystemProperties.TEMP_FILES_PATH, "build/tmp");
         System.setProperty(MessageLogProperties.ARCHIVE_GPG_HOME_DIRECTORY, "build/gpg");
         System.setProperty(MessageLogProperties.ARCHIVE_ENCRYPTION_KEYS_DIR, "build/gpg");
         System.setProperty(MessageLogProperties.ARCHIVE_ENCRYPTION_ENABLED, String.valueOf(encrypted));

--- a/src/proxy-ui-api/frontend/package.json
+++ b/src/proxy-ui-api/frontend/package.json
@@ -52,7 +52,7 @@
     "@vue/eslint-config-prettier": "~6.0.0",
     "@vue/eslint-config-typescript": "~7.0.0",
     "@vue/test-utils": "~1.2.0",
-    "chromedriver": "^87.0.5",
+    "chromedriver": "^93.0.0",
     "eslint": "6.8.0",
     "eslint-plugin-prettier": "~3.4.0",
     "eslint-plugin-vue": "~7.17.0",

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
@@ -64,7 +64,7 @@ const systemParametersTabCommands = {
     return this;
   },
 
-  assertTimestampingTableContents: function (expectedName, expectedUrl) {
+  assertTimestampingTableContents: function (expectedName) {
     // Service table row is visible
     this.waitForElementVisible('@timestampingServiceTableRow');
     // Delete button is visible in row
@@ -73,7 +73,7 @@ const systemParametersTabCommands = {
       assert.equal(foundName.value, expectedName);
     });
     this.getText('@timestampingTableSecondCell', function (foundUrl) {
-      assert.equal(foundUrl.value, expectedUrl);
+      assert(foundUrl.value.startsWith('http'));
     });
     return this;
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-settings-timestamping.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-settings-timestamping.js
@@ -42,6 +42,11 @@ module.exports = {
     browser.end();
   },
 
+  'timestamping service can be deleted': () => {
+    // when user confirms:
+    systemParametersTab.deleteCurrentTimestampingService();
+  },
+
   'User can add new timestamping service': () => {
     systemParametersTab.openTimeStampingAddDialog();
     // adding can be cancelled
@@ -93,8 +98,5 @@ module.exports = {
       'http://cs:8899',
     );
   },
-  'timestamping service can be deleted': () => {
-    // when user confirms:
-    systemParametersTab.deleteCurrentTimestampingService();
-  },
+
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/specs/ss-settings-timestamping.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/specs/ss-settings-timestamping.js
@@ -70,10 +70,7 @@ module.exports = {
     systemParametersTab.click('@timestampingAddButton');
     systemParametersTab.click('@timestampingAddDialogServiceSelection');
     systemParametersTab.click('@timestampingAddDialogAddButton');
-    systemParametersTab.assertTimestampingTableContents(
-      'X-Road Test TSA CN',
-      'http://cs:8899',
-    );
+    systemParametersTab.assertTimestampingTableContents('X-Road Test TSA CN');
 
     // add button is disabled if there is no room for new services
     systemParametersTab.waitForElementVisible('@timestampingServiceTableRow');
@@ -82,10 +79,7 @@ module.exports = {
 
   'Timestamp-table is visible': () => {
     // list shows name and url of the service
-    systemParametersTab.assertTimestampingTableContents(
-      'X-Road Test TSA CN',
-      'http://cs:8899',
-    );
+    systemParametersTab.assertTimestampingTableContents('X-Road Test TSA CN');
   },
   'service deletion can be cancelled': () => {
     systemParametersTab.openTimeStampingDeleteDialog();
@@ -93,10 +87,7 @@ module.exports = {
       '@timestampingDeleteDialogCancelButton',
     );
     systemParametersTab.click('@timestampingDeleteDialogCancelButton');
-    systemParametersTab.assertTimestampingTableContents(
-      'X-Road Test TSA CN',
-      'http://cs:8899',
-    );
+    systemParametersTab.assertTimestampingTableContents('X-Road Test TSA CN');
   },
 
 };


### PR DESCRIPTION
Fixed timestamping tests:
https://jenkins.niis.org/job/rest-ui-e2e-tests/731/

Two obvious issues:
- There was little misunderstanding of what is initial state in test environment after a reset, causing tests to fail because of already existing service. I changed order of tests so it starts from deletion test and continues to creating service afterwards. It seems to work in both local envs and in jenkins.
- When creating tests, there was an assumption that urls are same everywhere. This is not the case, value changes between environments, so assertion is modified in a way that it just checks that value starts with `http`. It should realiable enough for this purpose and will catch both http and https.