### PR TITLE
Fix certificate generation script

### DIFF
--- a/src/packages/src/xroad/common/base/usr/share/xroad/scripts/generate_certificate.sh
+++ b/src/packages/src/xroad/common/base/usr/share/xroad/scripts/generate_certificate.sh
@@ -32,7 +32,7 @@ OPENSSL_EXT=
 DIR=/etc/xroad/ssl
 
 
-while getopts “hpd:fn:s:Sa:c:” OPTION
+while getopts "hpd:fn:s:Sa:c:" OPTION
 do
     case $OPTION in
       h)
@@ -55,7 +55,10 @@ do
     SUBJECT=$OPTARG
     ;;
      S)
-    SUBJECT="/CN=`hostname -f`"
+    SUBJECT="/CN=$(hostname -f)"
+    if (( ${#SUBJECT} > 68 )); then
+      SUBJECT="/CN=$(hostname -s)"
+    fi
     ;;
      a)
     ALT=$OPTARG
@@ -98,7 +101,7 @@ if [[ -n $FILL ]]
 then
   LIST=
   for i in `ip addr | grep 'scope global' | tr '/' ' ' | awk '{print $2}'`; do LIST+="IP:$i,"; done;
-  ALT=${LIST}DNS:`hostname`,DNS:`hostname -f`
+  ALT="${LIST}DNS:$(hostname -f),DNS:$(hostname -s)"
 fi
 
 if [[ -n $ALT ]]
@@ -114,7 +117,7 @@ then
   OPENSSL_SUBJ=(-subj "${SUBJECT}")
 fi
 
-echo "$SUBJECT"  "$OPENSSL_SUBJ"
+echo "$SUBJECT  ${OPENSSL_SUBJ[*]}"
 
 
 openssl req -new -x509 -days 7300 -nodes -out "${DIR}"/"${NAME}".crt -keyout "${DIR}"/"${NAME}".key  -config "${CONF_DIR}"/openssl.cnf  "${OPENSSL_SUBJ[@]}"  "${OPENSSL_EXT[@]}"


### PR DESCRIPTION
CN is limited to 64 characters, and generating a certificate fails
if a fully qualified hostname exceeds that limit. Use the
hostname part as a fallback.