### PR TITLE
Xrddev 1838 remove unnecessary locate strategies

### DIFF
--- a/src/proxy-ui-api/frontend/tests/e2e/pages/common/addSubjectsPopup.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/common/addSubjectsPopup.js
@@ -78,29 +78,13 @@ const commands = {
 const addSubjectsPopup = {
   selector:
     '//div[contains(@class, "xrd-card") and .//span[contains(@class, "headline") and @data-test="access-rights-dialog-title"]]',
-  locateStrategy: 'xpath',
   commands: [commands],
   elements: {
-    searchButton: {
-      selector: '//button[@data-test="search-button"]',
-      locateStrategy: 'xpath',
-    },
-    addButton: {
-      selector: '//button[@data-test="save"]',
-      locateStrategy: 'xpath',
-    },
-    cancelButton: {
-      selector: '//button[@data-test="cancel-button"]',
-      locateStrategy: 'xpath',
-    },
-    serviceClientTypeDropdown: {
-      selector: '//input[@data-test="serviceClientType"]/parent::*',
-      locateStrategy: 'xpath',
-    },
-    timeoutApplyToAllCheckbox: {
-      selector: '//input[@data-test="timeout-all"]/following-sibling::div',
-      locateStrategy: 'xpath',
-    },
+    searchButton: '//button[@data-test="search-button"]',
+    addButton:  '//button[@data-test="save"]',
+    cancelButton: '//button[@data-test="cancel-button"]',
+    serviceClientTypeDropdown: '//input[@data-test="serviceClientType"]/parent::*',
+    timeoutApplyToAllCheckbox: '//input[@data-test="timeout-all"]/following-sibling::div',
   },
 };
 

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/endpoints/accessRightsPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/endpoints/accessRightsPage.js
@@ -53,24 +53,12 @@ module.exports = {
     `${process.env.VUE_DEV_SERVER_URL}/#/service/${clientId}/${serviceId}/endpoints/${endpointId}/accessrights`,
   commands: commands,
   elements: {
-    removeAllButton: {
-      selector: '//button[@data-test="remove-all-access-rights"]',
-      locateStrategy: 'xpath',
-    },
-    addSubjectsButton: {
-      selector: '//button[@data-test="add-subjects-dialog"]',
-      locateStrategy: 'xpath',
-    },
-    closeButton: {
-      selector:
+    removeAllButton: '//button[@data-test="remove-all-access-rights"]',
+    addSubjectsButton:  '//button[@data-test="add-subjects-dialog"]',
+    closeButton:
         '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
-      locateStrategy: 'xpath',
-    },
-    pageHeader: {
-      selector:
+    pageHeader:
         '//div[contains(@class, "group-members-row)]//div[contains(@class, "row-title")]/text()',
-      locateStrategy: 'xpath',
-    },
   },
   sections: {
     addSubjectsPopup,

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/addSubjectMemberStepPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/addSubjectMemberStepPage.js
@@ -97,38 +97,17 @@ module.exports = {
     `${process.env.VUE_DEV_SERVER_URL}/#/subsystem/serviceclients/${subsystemId}/add`,
   commands: commands,
   elements: {
-    wizardStepIndicator: {
-      selector:
+    wizardStepIndicator:
         '//div[contains(@class, "v-stepper__step--active")]/span[contains(@class, "primary") and contains(text(), "1")]',
-      locateStrategy: 'xpath',
-    },
-    filterField: {
-      selector: '//input[@data-test="search-service-client"]',
-      locateStrategy: 'xpath',
-    },
-    cancelButton: {
-      selector:
+    filterField: '//input[@data-test="search-service-client"]',
+    cancelButton:
         '//div[@class="v-stepper__wrapper" and .//table[contains(@class, "service-clients-table")]]//button[@data-test="cancel-button"]',
-      locateStrategy: 'xpath',
-    },
-    nextButton: {
-      selector:
+    nextButton:
         '//div[@class="v-stepper__wrapper" and .//table[contains(@class, "service-clients-table")]]//button[@data-test="next-button"]',
-      locateStrategy: 'xpath',
-    },
-    addSubjectWizardHeader: {
-      selector: '//div[@data-test="add-subject-title"]',
-      locateStrategy: 'xpath',
-    },
-    selectedSubjects: {
-      selector:
+    addSubjectWizardHeader:'//div[@data-test="add-subject-title"]',
+    selectedSubjects:
         '//div[contains(@class, "checkbox-wrap")]/div[contains(@class, "v-radio") and contains(@class, "v-item--active")]',
-      locateStrategy: 'xpath',
-    },
-    selectedSubjectName: {
-      selector:
+    selectedSubjectName:
         '//tr[.//div[contains(@class, "v-radio") and contains(@class, "v-item--active")]]/td[3]',
-      locateStrategy: 'xpath',
-    },
   },
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/addSubjectServiceStepPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/addSubjectServiceStepPage.js
@@ -96,33 +96,15 @@ module.exports = {
     `${process.env.VUE_DEV_SERVER_URL}/#/subsystem/serviceclients/${subsystemId}/add`,
   commands: commands,
   elements: {
-    wizardStepIndicator: {
-      selector:
+    wizardStepIndicator:
         '//div[contains(@class, "v-stepper__step--active")]/span[contains(@class, "primary") and contains(text(), "2")]',
-      locateStrategy: 'xpath',
-    },
-    filterField: {
-      selector: '//input[@data-test="search-service-client-service"]',
-      locateStrategy: 'xpath',
-    },
-    cancelButton: {
-      selector:
+    filterField: '//input[@data-test="search-service-client-service"]',
+    cancelButton:
         '//div[contains(@class, "button-footer") and .//button[@data-test="previous-button"]]//button[@data-test="cancel-button"]',
-      locateStrategy: 'xpath',
-    },
-    addSelectedButton: {
-      selector:
+    addSelectedButton:
         '//div[contains(@class, "button-footer") and .//button[@data-test="previous-button"]]//button[@data-test="finish-button"]',
-      locateStrategy: 'xpath',
-    },
-    previousButton: {
-      selector: '//button[@data-test="previous-button"]',
-      locateStrategy: 'xpath',
-    },
-    selectedServices: {
-      selector:
+    previousButton: '//button[@data-test="previous-button"]',
+    selectedServices:
         '//td[@class="selection-checkbox"]//div[contains(@class, "v-input--is-label-active")]',
-      locateStrategy: 'xpath',
-    },
   },
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/serviceClientDetails.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/serviceClientDetails.js
@@ -99,46 +99,21 @@ module.exports = {
     `${process.env.VUE_DEV_SERVER_URL}/#/subsystem/${subsystemId}/serviceclients/`,
   commands: commands,
   elements: {
-    wizardStepIndicator: {
-      selector: '//span[contains(@class, "primary") and contains(text(), "1")]',
-      locateStrategy: 'xpath',
-    },
-    addServiceButton: {
-      selector: '//button[@data-test="add-subjects-dialog"]',
-      locateStrategy: 'xpath',
-    },
-    removeAllButton: {
-      selector: '//button[@data-test="remove-all-access-rights"]',
-      locateStrategy: 'xpath',
-    },
-    closeButton: {
-      selector: '//button[@data-test="close"]',
-      locateStrategy: 'xpath',
-    },
+    wizardStepIndicator: '//span[contains(@class, "primary") and contains(text(), "1")]',
+    addServiceButton: '//button[@data-test="add-subjects-dialog"]',
+    removeAllButton:  '//button[@data-test="remove-all-access-rights"]',
+    closeButton:  '//button[@data-test="close"]',
   },
   sections: {
     addServicesPopup: {
       selector: '//div[@data-test="dialog-simple"]',
-      locateStrategy: 'xpath',
       commands: [addServiceCommands],
       elements: {
-        searchField: {
-          selector: '//input[@data-test="search-service-client"]',
-          locateStrategy: 'xpath',
-        },
-        addButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        closeButton: {
-          selector:
+        searchField: '//input[@data-test="search-service-client"]',
+        addButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
+        closeButton:
             '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
-          locateStrategy: 'xpath',
-        },
       },
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/serviceClientsPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/serviceClients/serviceClientsPage.js
@@ -49,32 +49,17 @@ module.exports = {
     `${process.env.VUE_DEV_SERVER_URL}/#/subsystem/serviceclients/${subsystemId}`,
   commands: commands,
   elements: {
-    addServiceClientButton: {
-      selector: '//button[@data-test="add-service-client"]',
-      locateStrategy: 'xpath',
-    },
-    unregisterButton: {
-      selector: '//button[@data-test="unregister-client-button"]',
-      locateStrategy: 'xpath',
-    },
-    addSubjectWizardHeader: {
-      selector: '//div[@data-test="add-subject-title"]',
-      locateStrategy: 'xpath',
-    },
-    searchField: {
-      selector: '//input[@data-test="search-service-client"]',
-      locateStrategy: 'xpath',
-    },
+    addServiceClientButton: '//button[@data-test="add-service-client"]',
+    unregisterButton:  '//button[@data-test="unregister-client-button"]',
+    addSubjectWizardHeader: '//div[@data-test="add-subject-title"]',
+    searchField:  '//input[@data-test="search-service-client"]',
+
   },
   sections: {
     serviceClientsTab: {
       selector:
         '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Service clients")]',
-      locateStrategy: 'xpath',
-    },
-    wizardSelectServices: {
-      selector:
-        '//div[contains(@class, "view-wrap")]//div[contains(@class, "v-stepper"]//span[contains(@class, "primary") and contains(text(), "2"]',
+    wizardSelectServices:  '//div[contains(@class, "view-wrap")]//div[contains(@class, "v-stepper"]//span[contains(@class, "primary") and contains(text(), "2"]',
     },
   },
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssFrontPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssFrontPage.js
@@ -74,21 +74,9 @@ module.exports = {
   url: process.env.VUE_DEV_SERVER_URL,
   commands: [loginCommands],
   elements: {
-    usernameInput: {
-      selector: '//input[@id="username"]',
-      locateStrategy: 'xpath',
-    },
-    passwordInput: {
-      selector: '//input[@id="password"]',
-      locateStrategy: 'xpath',
-    },
-    loginButton: {
-      selector: '//button[@id="submit-button"]',
-      locateStrategy: 'xpath',
-    },
-    LoginError: {
-      selector: '//button[@id="submit-button"]',
-      locateStrategy: 'xpath',
-    },
+    usernameInput: '//input[@id="username"]',
+    passwordInput: '//input[@id="password"]',
+    loginButton: '//button[@id="submit-button"]',
+    LoginError: '//button[@id="submit-button"]',
   },
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
@@ -680,19 +680,19 @@ module.exports = {
   url: process.env.VUE_DEV_SERVER_URL,
   commands: [navigateCommands],
   elements: {
-    clientsTab:  '//a[@data-test="clients"]',
-    keysTab:  '//a[@data-test="keys"]',
+    clientsTab: '//a[@data-test="clients"]',
+    keysTab: '//a[@data-test="keys"]',
     diagnosticsTab: '//a[@data-test="diagnostics"]',
     settingsTab: '//a[@data-test="settings"]',
     userMenuButton: '//button[@data-test="username-button"]',
     userMenuitemLogout: '//*[@data-test="logout-list-tile"]',
     logoutOKButton:
-        '//div[contains(@class, "v-dialog")]//button[.//*[contains(text(), "Ok")]]',
+      '//div[contains(@class, "v-dialog")]//button[.//*[contains(text(), "Ok")]]',
     snackBarCloseButton: '//button[@data-test="close-snackbar"]',
     snackBarMessage: '//div[@data-test="success-snackbar"]',
     alertCloseButton: '//button[@data-test="close-alert"]',
     alertMessage:
-        '//div[@data-test="contextual-alert"]//div[contains(@class, "row-wrapper")]/div',
+      '//div[@data-test="contextual-alert"]//div[contains(@class, "row-wrapper")]/div',
     sessionExpiredPopupOkButton: '//button[@data-test="session-expired-ok-button"]',
   },
   sections: {
@@ -706,18 +706,18 @@ module.exports = {
       commands: [clientInfoCommands],
       elements: {
         detailsTab:
-            '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Details")]',
+          '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Details")]',
         serviceClientsTab:
-            '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Service clients")]',
+          '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Service clients")]',
 
         servicesTab:
-            '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Services")]',
+          '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Services")]',
 
         internalServersTab:
-            '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Internal servers")]',
+          '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Internal servers")]',
 
         localGroupsTab:
-            '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Local groups")]',
+          '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Local groups")]',
 
       },
       sections: {
@@ -737,12 +737,11 @@ module.exports = {
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Internal servers")]]//div[contains(@class, "xrd-view-common")]',
           commands: [clientInternalServersCommands],
           elements: {
-            addButton:  '//button[.//*[contains(text(), "Add")]]',
+            addButton: '//button[.//*[contains(text(), "Add")]]',
             exportButton: '//button[.//*[contains(text(), "Export")]]',
             connectionTypeMenu: '//div[contains(@class, "v-select__selection")]',
             tlsCertificate:
-                '//table[contains(@class, "server-certificates")]//span[contains(@class, "certificate-link")]',
-
+              '//table[contains(@class, "server-certificates")]//span[contains(@class, "certificate-link")]',
           },
         },
         localGroups: {
@@ -750,19 +749,19 @@ module.exports = {
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Local groups")]]//div[contains(@class, "xrd-view-common")]',
           commands: [clientLocalGroupsCommands],
           elements: {
-            filterInput:  '//input',
-            addGroupButton:  '//button[@data-test="add-local-group-button"]',
-            confirmAddButton:  '//button[@data-test="dialog-save-button"]',
-            cancelAddButton:  '//button[@data-test="dialog-cancel-button"]',
+            filterInput: '//input',
+            addGroupButton: '//button[@data-test="add-local-group-button"]',
+            confirmAddButton: '//button[@data-test="dialog-save-button"]',
+            cancelAddButton: '//button[@data-test="dialog-cancel-button"]',
             groupCode: '//input[@data-test="add-local-group-code-input"]',
             groupDescription:
-                '//input[@data-test="add-local-group-description-input"]',
+              '//input[@data-test="add-local-group-description-input"]',
             groupCodeCellAbb:
-                '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"abb")]',
+              '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"abb")]',
             groupCodeCellBac:
-                '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"bac")]',
+              '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"bac")]',
             groupCodeCellCbb:
-                '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"cbb")]',
+              '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"cbb")]',
           },
         },
         services: {
@@ -770,35 +769,35 @@ module.exports = {
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Services")]]//div[contains(@class, "xrd-view-common")]',
           commands: [clientServicesCommands],
           elements: {
-            addWSDLButton:  '//button[@data-test="add-wsdl-button"]',
-            addRESTButton:  '//button[@data-test="add-rest-button"]',
-            filterServices:  '//input[@data-test="search-service"]',
-            addDialogTitle:  '//input[@data-test="dialog-title"]',
+            addWSDLButton: '//button[@data-test="add-wsdl-button"]',
+            addRESTButton: '//button[@data-test="add-rest-button"]',
+            filterServices: '//input[@data-test="search-service"]',
+            addDialogTitle: '//input[@data-test="dialog-title"]',
             newServiceUrl: '//input[contains(@name, "serviceUrl")]',
-            newServiceCode:  '//input[contains(@name, "serviceCode")]',
-            serviceUrlMessage:  '//div[contains(@class, "v-messages__message")]',
+            newServiceCode: '//input[contains(@name, "serviceCode")]',
+            serviceUrlMessage: '//div[contains(@class, "v-messages__message")]',
             serviceCodeMessage:
-                '//div[contains(@class, "v-input") and .//input[@name="serviceCode"]]//div[contains(@class, "v-messages__message")]',
-            confirmAddServiceButton:  '//button[@data-test="dialog-save-button"]',
-            cancelAddServiceButton:  '//button[@data-test="dialog-cancel-button"]',
-            RESTPathRadioButton:  '//input[@name="REST"]',
-            RESTPathRadioButtonClickArea:  '//input[@name="REST"]/following-sibling::div',
-            OpenApiRadioButton:  '//input[@name="OPENAPI3"]',
-            OpenApiRadioButtonClickArea:  '//input[@name="OPENAPI3"]/following-sibling::div',
-            serviceDescription:  '//*[@data-test="service-description-header"]',
+              '//div[contains(@class, "v-input") and .//input[@name="serviceCode"]]//div[contains(@class, "v-messages__message")]',
+            confirmAddServiceButton: '//button[@data-test="dialog-save-button"]',
+            cancelAddServiceButton: '//button[@data-test="dialog-cancel-button"]',
+            RESTPathRadioButton: '//input[@name="REST"]',
+            RESTPathRadioButtonClickArea: '//input[@name="REST"]/following-sibling::div',
+            OpenApiRadioButton: '//input[@name="OPENAPI3"]',
+            OpenApiRadioButtonClickArea: '//input[@name="OPENAPI3"]/following-sibling::div',
+            serviceDescription: '//*[@data-test="service-description-header"]',
             serviceExpandButton:
-                '//*[@data-test="service-description-accordion"]//button',
-            refreshButton:  '//button[@data-test="refresh-button"]',
-            refreshTimestamp:  '//*[contains(@class, "refresh-time")]',
-            serviceDetailsDeleteButton:  '//button[.//*[contains(text(), "Delete")]]',
-            serviceDetailsSaveButton:  '//button[.//*[contains(text(), "Save")]]',
-            serviceDetailsCancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+              '//*[@data-test="service-description-accordion"]//button',
+            refreshButton: '//button[@data-test="refresh-button"]',
+            refreshTimestamp: '//*[contains(@class, "refresh-time")]',
+            serviceDetailsDeleteButton: '//button[.//*[contains(text(), "Delete")]]',
+            serviceDetailsSaveButton: '//button[.//*[contains(text(), "Save")]]',
+            serviceDetailsCancelButton: '//button[.//*[contains(text(), "Cancel")]]',
             serviceEnableToggle:
-                '//*[contains(@class, "v-input--selection-controls__ripple")]',
-            confirmDisableButton:  '//button[@data-test="dialog-save-button"]',
-            cancelDisableButton:  '//button[@data-test="dialog-cancel-button"]',
+              '//*[contains(@class, "v-input--selection-controls__ripple")]',
+            confirmDisableButton: '//button[@data-test="dialog-save-button"]',
+            cancelDisableButton: '//button[@data-test="dialog-cancel-button"]',
             disableNotice: '//div[contains(@class, "dlg-edit-row") and .//*[contains(@class, "dlg-row-title")]]//input',
-            operationUrl:  '//td[@data-test="service-url"]',
+            operationUrl: '//td[@data-test="service-url"]',
           },
         },
       },
@@ -807,16 +806,16 @@ module.exports = {
       selector: '//div[contains(@class, "certificate-details-wrapper")]',
       commands: [certificatePopupCommands],
       elements: {
-        certificateInfoCloseButton:  '//*[@data-test="close-x"]',
-        deleteButton:  '//button[.//*[contains(text(), "Delete")]]',
+        certificateInfoCloseButton: '//*[@data-test="close-x"]',
+        deleteButton: '//button[.//*[contains(text(), "Delete")]]',
       },
     },
     certificateDetails: {
       selector: '//*[@data-test="certificate-details-dialog"]',
       commands: [certificatePopupCommands],
       elements: {
-        certificateInfoCloseButton:  '//*[@data-test="close-x"]',
-        deleteButton:  '//button[.//*[contains(text(), "Delete")]]',
+        certificateInfoCloseButton: '//*[@data-test="close-x"]',
+        deleteButton: '//button[.//*[contains(text(), "Delete")]]',
       },
     },
     localGroupPopup: {
@@ -824,27 +823,27 @@ module.exports = {
         '//div[contains(@class, "xrd-tab-max-width") and .//div[contains(@class, "cert-hash") and @data-test="local-group-title"]]',
       commands: [localGroupPopupCommands],
       elements: {
-        groupIdentifier:  '//span[contains(@class, "identifier-wrap")]', // Title in the "xrd-sub-view-title" component
-        localGroupAddMembersButton:  '//button[@data-test="add-members-button"]',
-        localGroupRemoveAllButton:  '//button[@data-test="remove-all-members-button"]',
-        localGroupDeleteButton:  '//button[@data-test="delete-local-group-button"]',
-        localGroupAddSelectedButton:  '//button[.//*[contains(text(), "Add selected")]]',
-        localGroupSearchButton:  '//button[.//*[contains(text(), "Search")]]',
+        groupIdentifier: '//span[contains(@class, "identifier-wrap")]', // Title in the "xrd-sub-view-title" component
+        localGroupAddMembersButton: '//button[@data-test="add-members-button"]',
+        localGroupRemoveAllButton: '//button[@data-test="remove-all-members-button"]',
+        localGroupDeleteButton: '//button[@data-test="delete-local-group-button"]',
+        localGroupAddSelectedButton: '//button[.//*[contains(text(), "Add selected")]]',
+        localGroupSearchButton: '//button[.//*[contains(text(), "Search")]]',
         localGroupCancelAddButton: '//button[.//*[contains(text(), "Cancel")]]',
         localGroupTestComCheckbox:
-            '//tr[.//*[contains(text(), "TestCom")]]//*[contains(@class, "v-input--selection-controls__ripple")]',
-        localGroupRemoveMemberButton:  '//button[.//*[contains(text(), "Add group")]]',
-        localGroupSearchWrap:  '//div[contains(@class, "search-wrap")]',
-        localGroupRemoveYesButton:  '//button[@data-test="dialog-save-button"]',
-        localGroupRemoveCancelButton:  '//button[@data-test="dialog-cancel-button"]',
+          '//tr[.//*[contains(text(), "TestCom")]]//*[contains(@class, "v-input--selection-controls__ripple")]',
+        localGroupRemoveMemberButton: '//button[.//*[contains(text(), "Add group")]]',
+        localGroupSearchWrap: '//div[contains(@class, "search-wrap")]',
+        localGroupRemoveYesButton: '//button[@data-test="dialog-save-button"]',
+        localGroupRemoveCancelButton: '//button[@data-test="dialog-cancel-button"]',
         localGroupTestComRemoveButton:
-            '//tr[.//*[contains(text(), "TestCom")]]//button[.//*[contains(text(), "Remove")]]',
+          '//tr[.//*[contains(text(), "TestCom")]]//button[.//*[contains(text(), "Remove")]]',
         localGroupTestGovRemoveButton:
-            '//tr[.//*[contains(text(), "TestGov")]]//button[.//*[contains(text(), "Remove")]]',
+          '//tr[.//*[contains(text(), "TestGov")]]//button[.//*[contains(text(), "Remove")]]',
         localGroupTestOrgRemoveButton:
-            '//tr[.//*[contains(text(), "TestOrg")]]//button[.//*[contains(text(), "Remove")]]',
-        localGroupDescription:  '//input[@data-test="local-group-edit-description-input"]',
-        localGroupPopupCloseButton:  '//button[.//*[contains(text(), "Close")]]',
+          '//tr[.//*[contains(text(), "TestOrg")]]//button[.//*[contains(text(), "Remove")]]',
+        localGroupDescription: '//input[@data-test="local-group-edit-description-input"]',
+        localGroupPopupCloseButton: '//button[.//*[contains(text(), "Close")]]',
       },
     },
     servicesWarningPopup: {
@@ -852,12 +851,12 @@ module.exports = {
         '//div[contains(@class, "v-dialog") and .//*[contains(@class, "headline")]]',
       commands: [servicesWarningPopupCommands],
       elements: {
-        warningContinueButton:  '//button[.//*[contains(text(), "Continue")]]',
-        warningCancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+        warningContinueButton: '//button[.//*[contains(text(), "Continue")]]',
+        warningCancelButton: '//button[.//*[contains(text(), "Cancel")]]',
         addedServices:
-            '//div[contains(@class, "dlg-warning-header") and contains(text(), "Adding services:")]/following-sibling::div',
+          '//div[contains(@class, "dlg-warning-header") and contains(text(), "Adding services:")]/following-sibling::div',
         deletedServices:
-            '//div[contains(@class, "dlg-warning-header") and contains(text(), "Deleting services:")]/following-sibling::div',
+          '//div[contains(@class, "dlg-warning-header") and contains(text(), "Deleting services:")]/following-sibling::div',
       },
     },
     wsdlServiceDetails: {
@@ -866,18 +865,18 @@ module.exports = {
       commands: [serviceDetailsCommands],
       elements: {
         serviceDetailsCloseButton:
-            '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
+          '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
         deleteServiceButton:
-            '//button[@data-test="service-description-details-delete-button"]',
-        confirmDeleteButton:  '//button[@data-test="dialog-save-button"]',
-        cancelDeleteButton:  '//button[@data-test="dialog-cancel-button"]',
+          '//button[@data-test="service-description-details-delete-button"]',
+        confirmDeleteButton: '//button[@data-test="dialog-save-button"]',
+        cancelDeleteButton: '//button[@data-test="dialog-cancel-button"]',
         serviceURL: '//*[contains(@class, "url-input")]//input',
         URLMessage:
-            '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
+          '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
         confirmDialogButton:
-            '//button[@data-test="service-description-details-save-button"]',
+          '//button[@data-test="service-description-details-save-button"]',
         cancelDialogButton:
-            '//button[@data-test="service-description-details-cancel-button"]',
+          '//button[@data-test="service-description-details-cancel-button"]',
       },
     },
     restServiceDetails: {
@@ -886,20 +885,20 @@ module.exports = {
       commands: [serviceDetailsCommands],
       elements: {
         serviceDetailsCloseButton:
-            '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
+          '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
         deleteServiceButton: '//button[@data-test="service-description-details-delete-button"]',
-        confirmDeleteButton:  '//button[@data-test="dialog-save-button"]',
-         cancelDeleteButton:  '//button[@data-test="dialog-cancel-button"]',
+        confirmDeleteButton: '//button[@data-test="dialog-save-button"]',
+        cancelDeleteButton: '//button[@data-test="dialog-cancel-button"]',
         serviceURL: '//*[contains(@class, "url-input")]//input',
         serviceCode: '//*[contains(@class, "code-input")]//input',
         serviceType: '//div[@data-test="service-description-details-url-type-value"]',
         URLMessage: '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
         codeMessage:
-            '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
+          '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
         confirmDialogButton:
-            '//button[@data-test="service-description-details-save-button"]',
+          '//button[@data-test="service-description-details-save-button"]',
         cancelDialogButton:
-            '//button[@data-test="service-description-details-cancel-button"]',
+          '//button[@data-test="service-description-details-cancel-button"]',
       },
     },
     openApiServiceDetails: {
@@ -908,25 +907,24 @@ module.exports = {
       commands: [serviceDetailsCommands],
       elements: {
         serviceDetailsCloseButton:
-            '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
+          '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
         deleteServiceButton:
-            '//button[@data-test="service-description-details-delete-button"]',
+          '//button[@data-test="service-description-details-delete-button"]',
         confirmDeleteButton: '//button[@data-test="dialog-save-button"]',
         cancelDeleteButton: '//button[@data-test="dialog-cancel-button"]',
         serviceURL: '//*[contains(@class, "url-input")]//input',
         serviceCode:
-            '//*[contains(@class, "code-input")]//input[@name="code_field"]',
+          '//*[contains(@class, "code-input")]//input[@name="code_field"]',
         serviceType:
-            '//div[@data-test="service-description-details-url-type-value"]',
+          '//div[@data-test="service-description-details-url-type-value"]',
         URLMessage:
-            '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
+          '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
         codeMessage:
-            '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
+          '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
         confirmDialogButton:
-            '//button[@data-test="service-description-details-save-button"]',
+          '//button[@data-test="service-description-details-save-button"]',
         cancelDialogButton:
-            '//button[@data-test="service-description-details-cancel-button"]',
-        },
+          '//button[@data-test="service-description-details-cancel-button"]',
       },
     },
     wsdlOperationDetails: {
@@ -934,24 +932,24 @@ module.exports = {
         '//div[contains(@class, "base-full-width") and .//div[contains(@class, "apply-to-all-text")]]',
       commands: [wsdlOperationCommands],
       elements: {
-        parametersTab:  '//*[@data-test="parameters"]',
-        endpointsTab:  '//*[@data-test="endpoints"]',
-        urlApplyToAllCheckbox:  '//input[@data-test="url-all"]/following-sibling::div',
-        timeoutApplyToAllCheckbox:  '//input[@data-test="timeout-all"]/following-sibling::div',
+        parametersTab: '//*[@data-test="parameters"]',
+        endpointsTab: '//*[@data-test="endpoints"]',
+        urlApplyToAllCheckbox: '//input[@data-test="url-all"]/following-sibling::div',
+        timeoutApplyToAllCheckbox: '//input[@data-test="timeout-all"]/following-sibling::div',
         verifyCertApplyToAllCheckbox: '//input[@data-test="ssl-auth-all"]/following-sibling::div',
-        serviceURL:  '//input[@data-test="service-url"]',
-        timeout:  '//input[@data-test="service-timeout"]',
-        sslAuth:  '//input[@data-test="ssl-auth"]',
-        sslAuthClickarea:  '//input[@data-test="ssl-auth"]/following-sibling::div',
+        serviceURL: '//input[@data-test="service-url"]',
+        timeout: '//input[@data-test="service-timeout"]',
+        sslAuth: '//input[@data-test="ssl-auth"]',
+        sslAuthClickarea: '//input[@data-test="ssl-auth"]/following-sibling::div',
         save2Button: '//button[@data-test="save-service-parameters"]/following-sibling::div',
         saveButton: '//button[@data-test="save-service-parameters"]',
         closeButton: '//button[@data-test="close"]',
         urlHelp: '//div[@data-test="service-parameters-service-url-label"]//i',
-        timeoutHelp:  '//div[@data-test="service-parameters-timeout-label"]//i',
+        timeoutHelp: '//div[@data-test="service-parameters-timeout-label"]//i',
         verifyCertHelp: '//div[@data-test="service-parameters-verify-tls-label"]//i',
         activeTooltip: '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
-        addSubjectsButton:  '//button[@data-test="show-add-subjects"]',
-        removeAllButton:  '//button[@data-test="remove-subjects"]',
+        addSubjectsButton: '//button[@data-test="show-add-subjects"]',
+        removeAllButton: '//button[@data-test="remove-subjects"]',
       },
     },
     restOperationDetails: {
@@ -959,24 +957,24 @@ module.exports = {
         '//div[contains(@class, "base-full-width") and .//*[@data-test="parameters"]]',
       commands: [wsdlOperationCommands],
       elements: {
-        parametersTab:  '//*[@data-test="parameters"]',
-        endpointsTab:  '//*[@data-test="endpoints"]',
+        parametersTab: '//*[@data-test="parameters"]',
+        endpointsTab: '//*[@data-test="endpoints"]',
         serviceURL: '//input[@data-test="service-url"]',
         timeout: '//input[@data-test="service-timeout"]',
         sslAuth: '//input[@data-test="ssl-auth"]',
-        sslAuthClickarea:  '//input[@data-test="ssl-auth"]/following-sibling::div',
+        sslAuthClickarea: '//input[@data-test="ssl-auth"]/following-sibling::div',
         save2Button:
-            '//button[@data-test="save-service-parameters"]/following-sibling::div',
+          '//button[@data-test="save-service-parameters"]/following-sibling::div',
         saveButton: '//button[@data-test="save-service-parameters"]',
-        addButton:  '//button[@data-test="endpoint-add"]',
-        closeButton:  '//button[@data-test="close"]',
+        addButton: '//button[@data-test="endpoint-add"]',
+        closeButton: '//button[@data-test="close"]',
         urlHelp: '//div[@data-test="service-parameters-service-url-label"]//i',
-        timeoutHelp:  '//div[@data-test="service-parameters-timeout-label"]//i',
+        timeoutHelp: '//div[@data-test="service-parameters-timeout-label"]//i',
         verifyCertHelp: '//div[@data-test="service-parameters-verify-tls-label"]//i',
         activeTooltip:
-            '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
-        addSubjectsButton:  '//button[@data-test="show-add-subjects"]',
-        removeAllButton:  '//button[@data-test="remove-subjects"]',
+          '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
+        addSubjectsButton: '//button[@data-test="show-add-subjects"]',
+        removeAllButton: '//button[@data-test="remove-subjects"]',
       },
     },
     sslCheckFailDialog: {
@@ -984,8 +982,8 @@ module.exports = {
         '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
       commands: [sslCheckFailDialogCommands],
       elements: {
-        continueButton:  '//button[@data-test="dialog-save-button"]',
-        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        continueButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
     restServiceEndpoints: {
@@ -993,12 +991,12 @@ module.exports = {
         '//div[contains(@class, "base-full-width") and .//*[@data-test="endpoints"]]',
       commands: [restEndpointCommands],
       elements: {
-        parametersTab:  '//*[@data-test="parameters"]',
-        endpointsTab:  '//*[@data-test="endpoints"]',
-        addButton:  '//button[@data-test="endpoint-add"]',
-        closeButton:  '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
-        editButton:  '//button[@data-test="endpoint-edit"]',
-        accessRightsButton:  '//button[@data-test="endpoint-edit-accessrights"]',
+        parametersTab: '//*[@data-test="parameters"]',
+        endpointsTab: '//*[@data-test="endpoints"]',
+        addButton: '//button[@data-test="endpoint-add"]',
+        closeButton: '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
+        editButton: '//button[@data-test="endpoint-edit"]',
+        accessRightsButton: '//button[@data-test="endpoint-edit-accessrights"]',
       },
     },
     wsdlAddSubjectsPopup: addSubjectsPopup,
@@ -1008,10 +1006,10 @@ module.exports = {
       commands: [addEndpointCommands],
       elements: {
         addButton: '//button[@data-test="dialog-save-button"]',
-        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
-        requestPath:  '//input[@data-test="endpoint-path"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
+        requestPath: '//input[@data-test="endpoint-path"]',
         requestPathMessage: '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
-        methodDropdown:  '//input[@data-test="endpoint-method"]/parent::*',
+        methodDropdown: '//input[@data-test="endpoint-method"]/parent::*',
       },
     },
     editEndpointPopup: {
@@ -1020,13 +1018,13 @@ module.exports = {
       commands: [addEndpointCommands],
       elements: {
         addButton: '//button[.//*[contains(text(), "Save")]]',
-        cancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+        cancelButton: '//button[.//*[contains(text(), "Cancel")]]',
         deleteButton: '//button[.//*[contains(text(), "Delete")]]',
-        requestPath:  '//input[@data-test="endpoint-path"]',
+        requestPath: '//input[@data-test="endpoint-path"]',
         requestPathMessage: '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
         methodDropdown: '//input[@data-test="endpoint-method"]/parent::*',
-        deleteYesButton:  '//button[@data-test="dialog-save-button"]',
-        deleteCancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        deleteYesButton: '//button[@data-test="dialog-save-button"]',
+        deleteCancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
     removeAccessRightPopup: {
@@ -1043,9 +1041,8 @@ module.exports = {
         '//div[contains(@class, "xrd-card") and //div[@data-test="dialog-simple"] and .//*[@data-test="dialog-title"]]',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton:  '//button[@data-test="dialog-save-button"]',
-        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
-
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
     deleteCertPopup: {
@@ -1054,17 +1051,16 @@ module.exports = {
       commands: [confirmationDialogCommands],
       elements: {
         yesButton: '//button[@data-test="dialog-save-button"]',
-        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
-
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
     deleteCSRPopup: {
-      selector:
-        '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
+      selector: '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton:  '//button[@data-test="dialog-save-button"]',
-        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
-};
+  },
+}

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
@@ -703,40 +703,27 @@ module.exports = {
     clientInfo: {
       selector:
         '//div[contains(@class, "v-main__wrap") and .//*[@data-test="clients" and @aria-selected="true"]]',
-      locateStrategy: 'xpath',
       commands: [clientInfoCommands],
       elements: {
-        detailsTab: {
-          selector:
+        detailsTab:
             '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Details")]',
-          locateStrategy: 'xpath',
-        },
-        serviceClientsTab: {
-          selector:
+        serviceClientsTab:
             '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Service clients")]',
-          locateStrategy: 'xpath',
-        },
-        servicesTab: {
-          selector:
+
+        servicesTab:
             '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Services")]',
-          locateStrategy: 'xpath',
-        },
-        internalServersTab: {
-          selector:
+
+        internalServersTab:
             '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Internal servers")]',
-          locateStrategy: 'xpath',
-        },
-        localGroupsTab: {
-          selector:
+
+        localGroupsTab:
             '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Local groups")]',
-          locateStrategy: 'xpath',
-        },
+
       },
       sections: {
         details: {
           selector:
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Details")]]//div[contains(@class, "xrd-view-common")]',
-          locateStrategy: 'xpath',
           commands: [clientDetailsCommands],
           elements: {
             clientSignCertificate: {
@@ -748,836 +735,339 @@ module.exports = {
         internalServers: {
           selector:
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Internal servers")]]//div[contains(@class, "xrd-view-common")]',
-          locateStrategy: 'xpath',
           commands: [clientInternalServersCommands],
           elements: {
-            addButton: {
-              selector: '//button[.//*[contains(text(), "Add")]]',
-              locateStrategy: 'xpath',
-            },
-            exportButton: {
-              selector: '//button[.//*[contains(text(), "Export")]]',
-              locateStrategy: 'xpath',
-            },
-            connectionTypeMenu: {
-              selector: '//div[contains(@class, "v-select__selection")]',
-              locateStrategy: 'xpath',
-            },
-            tlsCertificate: {
-              selector:
+            addButton:  '//button[.//*[contains(text(), "Add")]]',
+            exportButton: '//button[.//*[contains(text(), "Export")]]',
+            connectionTypeMenu: '//div[contains(@class, "v-select__selection")]',
+            tlsCertificate:
                 '//table[contains(@class, "server-certificates")]//span[contains(@class, "certificate-link")]',
-              locateStrategy: 'xpath',
-            },
+
           },
         },
         localGroups: {
           selector:
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Local groups")]]//div[contains(@class, "xrd-view-common")]',
-          locateStrategy: 'xpath',
           commands: [clientLocalGroupsCommands],
           elements: {
-            filterInput: {
-              selector: '//input',
-              locateStrategy: 'xpath',
-            },
-            addGroupButton: {
-              selector: '//button[@data-test="add-local-group-button"]',
-              locateStrategy: 'xpath',
-            },
-            confirmAddButton: {
-              selector: '//button[@data-test="dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancelAddButton: {
-              selector: '//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
-            groupCode: {
-              selector: '//input[@data-test="add-local-group-code-input"]',
-              locateStrategy: 'xpath',
-            },
-            groupDescription: {
-              selector:
+            filterInput:  '//input',
+            addGroupButton:  '//button[@data-test="add-local-group-button"]',
+            confirmAddButton:  '//button[@data-test="dialog-save-button"]',
+            cancelAddButton:  '//button[@data-test="dialog-cancel-button"]',
+            groupCode: '//input[@data-test="add-local-group-code-input"]',
+            groupDescription:
                 '//input[@data-test="add-local-group-description-input"]',
-              locateStrategy: 'xpath',
-            },
-            groupCodeCellAbb: {
-              selector:
+            groupCodeCellAbb:
                 '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"abb")]',
-              locateStrategy: 'xpath',
-            },
-            groupCodeCellBac: {
-              selector:
+            groupCodeCellBac:
                 '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"bac")]',
-              locateStrategy: 'xpath',
-            },
-            groupCodeCellCbb: {
-              selector:
+            groupCodeCellCbb:
                 '//*[contains(@data-test, "local-groups-table")]//*[contains(text(),"cbb")]',
-              locateStrategy: 'xpath',
-            },
           },
         },
         services: {
           selector:
             '//div[contains(@class, "base-full-width") and .//*[contains(@class, "v-tab--active") and contains(text(),"Services")]]//div[contains(@class, "xrd-view-common")]',
-          locateStrategy: 'xpath',
           commands: [clientServicesCommands],
           elements: {
-            addWSDLButton: {
-              selector: '//button[@data-test="add-wsdl-button"]',
-              locateStrategy: 'xpath',
-            },
-            addRESTButton: {
-              selector: '//button[@data-test="add-rest-button"]',
-              locateStrategy: 'xpath',
-            },
-            filterServices: {
-              selector: '//input[@data-test="search-service"]',
-              locateStrategy: 'xpath',
-            },
-            addDialogTitle: {
-              selector: '//input[@data-test="dialog-title"]',
-              locateStrategy: 'xpath',
-            },
-            newServiceUrl: {
-              selector: '//input[contains(@name, "serviceUrl")]',
-              locateStrategy: 'xpath',
-            },
-            newServiceCode: {
-              selector: '//input[contains(@name, "serviceCode")]',
-              locateStrategy: 'xpath',
-            },
-            serviceUrlMessage: {
-              selector: '//div[contains(@class, "v-messages__message")]',
-              locateStrategy: 'xpath',
-            },
-            serviceCodeMessage: {
-              selector:
+            addWSDLButton:  '//button[@data-test="add-wsdl-button"]',
+            addRESTButton:  '//button[@data-test="add-rest-button"]',
+            filterServices:  '//input[@data-test="search-service"]',
+            addDialogTitle:  '//input[@data-test="dialog-title"]',
+            newServiceUrl: '//input[contains(@name, "serviceUrl")]',
+            newServiceCode:  '//input[contains(@name, "serviceCode")]',
+            serviceUrlMessage:  '//div[contains(@class, "v-messages__message")]',
+            serviceCodeMessage:
                 '//div[contains(@class, "v-input") and .//input[@name="serviceCode"]]//div[contains(@class, "v-messages__message")]',
-              locateStrategy: 'xpath',
-            },
-            confirmAddServiceButton: {
-              selector: '//button[@data-test="dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancelAddServiceButton: {
-              selector: '//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
-            RESTPathRadioButton: {
-              selector: '//input[@name="REST"]',
-              locateStrategy: 'xpath',
-            },
-            RESTPathRadioButtonClickArea: {
-              selector: '//input[@name="REST"]/following-sibling::div',
-              locateStrategy: 'xpath',
-            },
-            OpenApiRadioButton: {
-              selector: '//input[@name="OPENAPI3"]',
-              locateStrategy: 'xpath',
-            },
-            OpenApiRadioButtonClickArea: {
-              selector: '//input[@name="OPENAPI3"]/following-sibling::div',
-              locateStrategy: 'xpath',
-            },
-            serviceDescription: {
-              selector: '//*[@data-test="service-description-header"]',
-              locateStrategy: 'xpath',
-            },
-            serviceExpandButton: {
-              selector:
+            confirmAddServiceButton:  '//button[@data-test="dialog-save-button"]',
+            cancelAddServiceButton:  '//button[@data-test="dialog-cancel-button"]',
+            RESTPathRadioButton:  '//input[@name="REST"]',
+            RESTPathRadioButtonClickArea:  '//input[@name="REST"]/following-sibling::div',
+            OpenApiRadioButton:  '//input[@name="OPENAPI3"]',
+            OpenApiRadioButtonClickArea:  '//input[@name="OPENAPI3"]/following-sibling::div',
+            serviceDescription:  '//*[@data-test="service-description-header"]',
+            serviceExpandButton:
                 '//*[@data-test="service-description-accordion"]//button',
-              locateStrategy: 'xpath',
-            },
-            refreshButton: {
-              selector: '//button[@data-test="refresh-button"]',
-              locateStrategy: 'xpath',
-            },
-            refreshTimestamp: {
-              selector: '//*[contains(@class, "refresh-time")]',
-              locateStrategy: 'xpath',
-            },
-            serviceDetailsDeleteButton: {
-              selector: '//button[.//*[contains(text(), "Delete")]]',
-              locateStrategy: 'xpath',
-            },
-            serviceDetailsSaveButton: {
-              selector: '//button[.//*[contains(text(), "Save")]]',
-              locateStrategy: 'xpath',
-            },
-            serviceDetailsCancelButton: {
-              selector: '//button[.//*[contains(text(), "Cancel")]]',
-              locateStrategy: 'xpath',
-            },
-            serviceEnableToggle: {
-              selector:
+            refreshButton:  '//button[@data-test="refresh-button"]',
+            refreshTimestamp:  '//*[contains(@class, "refresh-time")]',
+            serviceDetailsDeleteButton:  '//button[.//*[contains(text(), "Delete")]]',
+            serviceDetailsSaveButton:  '//button[.//*[contains(text(), "Save")]]',
+            serviceDetailsCancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+            serviceEnableToggle:
                 '//*[contains(@class, "v-input--selection-controls__ripple")]',
-              locateStrategy: 'xpath',
-            },
-            confirmDisableButton: {
-              selector: '//button[@data-test="dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancelDisableButton: {
-              selector: '//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
-            disableNotice: {
-              selector:
-                '//div[contains(@class, "dlg-edit-row") and .//*[contains(@class, "dlg-row-title")]]//input',
-              locateStrategy: 'xpath',
-            },
-            operationUrl: {
-              selector: '//td[@data-test="service-url"]',
-              locateStrategy: 'xpath',
-            },
+            confirmDisableButton:  '//button[@data-test="dialog-save-button"]',
+            cancelDisableButton:  '//button[@data-test="dialog-cancel-button"]',
+            disableNotice: '//div[contains(@class, "dlg-edit-row") and .//*[contains(@class, "dlg-row-title")]]//input',
+            operationUrl:  '//td[@data-test="service-url"]',
           },
         },
       },
     },
     certificatePopup: {
       selector: '//div[contains(@class, "certificate-details-wrapper")]',
-      locateStrategy: 'xpath',
       commands: [certificatePopupCommands],
       elements: {
-        certificateInfoCloseButton: {
-          selector: '//*[@data-test="close-x"]',
-          locateStrategy: 'xpath',
-        },
-        deleteButton: {
-          selector: '//button[.//*[contains(text(), "Delete")]]',
-          locateStrategy: 'xpath',
-        },
+        certificateInfoCloseButton:  '//*[@data-test="close-x"]',
+        deleteButton:  '//button[.//*[contains(text(), "Delete")]]',
       },
     },
     certificateDetails: {
       selector: '//*[@data-test="certificate-details-dialog"]',
-      locateStrategy: 'xpath',
       commands: [certificatePopupCommands],
       elements: {
-        certificateInfoCloseButton: {
-          selector: '//*[@data-test="close-x"]',
-          locateStrategy: 'xpath',
-        },
-        deleteButton: {
-          selector: '//button[.//*[contains(text(), "Delete")]]',
-          locateStrategy: 'xpath',
-        },
+        certificateInfoCloseButton:  '//*[@data-test="close-x"]',
+        deleteButton:  '//button[.//*[contains(text(), "Delete")]]',
       },
     },
     localGroupPopup: {
       selector:
         '//div[contains(@class, "xrd-tab-max-width") and .//div[contains(@class, "cert-hash") and @data-test="local-group-title"]]',
-      locateStrategy: 'xpath',
       commands: [localGroupPopupCommands],
       elements: {
-        groupIdentifier: {
-          selector: '//span[contains(@class, "identifier-wrap")]', // Title in the "xrd-sub-view-title" component
-          locateStrategy: 'xpath',
-        },
-        localGroupAddMembersButton: {
-          selector: '//button[@data-test="add-members-button"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupRemoveAllButton: {
-          selector: '//button[@data-test="remove-all-members-button"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupDeleteButton: {
-          selector: '//button[@data-test="delete-local-group-button"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupAddSelectedButton: {
-          selector: '//button[.//*[contains(text(), "Add selected")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupSearchButton: {
-          selector: '//button[.//*[contains(text(), "Search")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupCancelAddButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupTestComCheckbox: {
-          selector:
+        groupIdentifier:  '//span[contains(@class, "identifier-wrap")]', // Title in the "xrd-sub-view-title" component
+        localGroupAddMembersButton:  '//button[@data-test="add-members-button"]',
+        localGroupRemoveAllButton:  '//button[@data-test="remove-all-members-button"]',
+        localGroupDeleteButton:  '//button[@data-test="delete-local-group-button"]',
+        localGroupAddSelectedButton:  '//button[.//*[contains(text(), "Add selected")]]',
+        localGroupSearchButton:  '//button[.//*[contains(text(), "Search")]]',
+        localGroupCancelAddButton: '//button[.//*[contains(text(), "Cancel")]]',
+        localGroupTestComCheckbox:
             '//tr[.//*[contains(text(), "TestCom")]]//*[contains(@class, "v-input--selection-controls__ripple")]',
-          locateStrategy: 'xpath',
-        },
-        localGroupRemoveMemberButton: {
-          selector: '//button[.//*[contains(text(), "Add group")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupSearchWrap: {
-          selector: '//div[contains(@class, "search-wrap")]',
-          locateStrategy: 'xpath',
-        },
-        localGroupRemoveYesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupRemoveCancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupTestComRemoveButton: {
-          selector:
+        localGroupRemoveMemberButton:  '//button[.//*[contains(text(), "Add group")]]',
+        localGroupSearchWrap:  '//div[contains(@class, "search-wrap")]',
+        localGroupRemoveYesButton:  '//button[@data-test="dialog-save-button"]',
+        localGroupRemoveCancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        localGroupTestComRemoveButton:
             '//tr[.//*[contains(text(), "TestCom")]]//button[.//*[contains(text(), "Remove")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupTestGovRemoveButton: {
-          selector:
+        localGroupTestGovRemoveButton:
             '//tr[.//*[contains(text(), "TestGov")]]//button[.//*[contains(text(), "Remove")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupTestOrgRemoveButton: {
-          selector:
+        localGroupTestOrgRemoveButton:
             '//tr[.//*[contains(text(), "TestOrg")]]//button[.//*[contains(text(), "Remove")]]',
-          locateStrategy: 'xpath',
-        },
-        localGroupDescription: {
-          selector: '//input[@data-test="local-group-edit-description-input"]',
-          locateStrategy: 'xpath',
-        },
-        localGroupPopupCloseButton: {
-          selector: '//button[.//*[contains(text(), "Close")]]',
-          locateStrategy: 'xpath',
-        },
+        localGroupDescription:  '//input[@data-test="local-group-edit-description-input"]',
+        localGroupPopupCloseButton:  '//button[.//*[contains(text(), "Close")]]',
       },
     },
     servicesWarningPopup: {
       selector:
         '//div[contains(@class, "v-dialog") and .//*[contains(@class, "headline")]]',
-      locateStrategy: 'xpath',
       commands: [servicesWarningPopupCommands],
       elements: {
-        warningContinueButton: {
-          selector: '//button[.//*[contains(text(), "Continue")]]',
-          locateStrategy: 'xpath',
-        },
-        warningCancelButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        addedServices: {
-          selector:
+        warningContinueButton:  '//button[.//*[contains(text(), "Continue")]]',
+        warningCancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+        addedServices:
             '//div[contains(@class, "dlg-warning-header") and contains(text(), "Adding services:")]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        deletedServices: {
-          selector:
+        deletedServices:
             '//div[contains(@class, "dlg-warning-header") and contains(text(), "Deleting services:")]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
       },
     },
     wsdlServiceDetails: {
       selector:
         '//div[@data-test="service-description-details-dialog" and .//div[@data-test="wsdl-service-description-details-dialog"]]',
-      locateStrategy: 'xpath',
       commands: [serviceDetailsCommands],
       elements: {
-        serviceDetailsCloseButton: {
-          selector:
+        serviceDetailsCloseButton:
             '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
-          locateStrategy: 'xpath',
-        },
-        deleteServiceButton: {
-          selector:
+        deleteServiceButton:
             '//button[@data-test="service-description-details-delete-button"]',
-          locateStrategy: 'xpath',
-        },
-        confirmDeleteButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelDeleteButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        serviceURL: {
-          selector: '//*[contains(@class, "url-input")]//input',
-          locateStrategy: 'xpath',
-        },
-        URLMessage: {
-          selector:
+        confirmDeleteButton:  '//button[@data-test="dialog-save-button"]',
+        cancelDeleteButton:  '//button[@data-test="dialog-cancel-button"]',
+        serviceURL: '//*[contains(@class, "url-input")]//input',
+        URLMessage:
             '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        confirmDialogButton: {
-          selector:
+        confirmDialogButton:
             '//button[@data-test="service-description-details-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelDialogButton: {
-          selector:
+        cancelDialogButton:
             '//button[@data-test="service-description-details-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
       },
     },
     restServiceDetails: {
       selector:
         '//div[@data-test="service-description-details-dialog" and .//div[@data-test="rest-service-description-details-dialog"]]',
-      locateStrategy: 'xpath',
       commands: [serviceDetailsCommands],
       elements: {
-        serviceDetailsCloseButton: {
-          selector:
+        serviceDetailsCloseButton:
             '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
-          locateStrategy: 'xpath',
-        },
-        deleteServiceButton: {
-          selector:
-            '//button[@data-test="service-description-details-delete-button"]',
-          locateStrategy: 'xpath',
-        },
-        confirmDeleteButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelDeleteButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        serviceURL: {
-          selector: '//*[contains(@class, "url-input")]//input',
-          locateStrategy: 'xpath',
-        },
-        serviceCode: {
-          selector: '//*[contains(@class, "code-input")]//input',
-          locateStrategy: 'xpath',
-        },
-        serviceType: {
-          selector:
+        deleteServiceButton: '//button[@data-test="service-description-details-delete-button"]',
+        confirmDeleteButton:  '//button[@data-test="dialog-save-button"]',
+         cancelDeleteButton:  '//button[@data-test="dialog-cancel-button"]',
+        serviceURL:  '//*[contains(@class, "url-input")]//input',
+        serviceCode:  '//*[contains(@class, "code-input")]//input',
+        serviceType:
             '//div[@data-test="service-description-details-url-type-value"]',
-          locateStrategy: 'xpath',
-        },
-        URLMessage: {
-          selector:
+        URLMessage:
             '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        codeMessage: {
-          selector:
+        codeMessage:
             '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        confirmDialogButton: {
-          selector:
+        confirmDialogButton:
             '//button[@data-test="service-description-details-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelDialogButton: {
-          selector:
+        cancelDialogButton:
             '//button[@data-test="service-description-details-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
       },
     },
     openApiServiceDetails: {
       selector:
         '//div[@data-test="service-description-details-dialog" and .//div[@data-test="openapi-service-description-details-dialog"]]',
-      locateStrategy: 'xpath',
       commands: [serviceDetailsCommands],
       elements: {
-        serviceDetailsCloseButton: {
-          selector:
+        serviceDetailsCloseButton:
             '//*[contains(@class, "cert-dialog-header")]//*[contains(@id, "close-x")]',
-          locateStrategy: 'xpath',
-        },
-        deleteServiceButton: {
-          selector:
+        deleteServiceButton:
             '//button[@data-test="service-description-details-delete-button"]',
-          locateStrategy: 'xpath',
-        },
-        confirmDeleteButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
+        confirmDeleteButton: '//button[@data-test="dialog-save-button"]',
         cancelDeleteButton: {
           selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        serviceURL: {
-          selector: '//*[contains(@class, "url-input")]//input',
-          locateStrategy: 'xpath',
-        },
-        serviceCode: {
-          selector:
+        serviceURL: '//*[contains(@class, "url-input")]//input',
+        serviceCode:
             '//*[contains(@class, "code-input")]//input[@name="code_field"]',
-          locateStrategy: 'xpath',
-        },
-        serviceType: {
-          selector:
+        serviceType:
             '//div[@data-test="service-description-details-url-type-value"]',
-          locateStrategy: 'xpath',
-        },
-        URLMessage: {
-          selector:
+        URLMessage:
             '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        codeMessage: {
-          selector:
+        codeMessage:
             '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        confirmDialogButton: {
-          selector:
+        confirmDialogButton:
             '//button[@data-test="service-description-details-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelDialogButton: {
-          selector:
+        cancelDialogButton:
             '//button[@data-test="service-description-details-cancel-button"]',
-          locateStrategy: 'xpath',
         },
       },
     },
     wsdlOperationDetails: {
       selector:
         '//div[contains(@class, "base-full-width") and .//div[contains(@class, "apply-to-all-text")]]',
-      locateStrategy: 'xpath',
       commands: [wsdlOperationCommands],
       elements: {
-        parametersTab: {
-          selector: '//*[@data-test="parameters"]',
-          locateStrategy: 'xpath',
-        },
-        endpointsTab: {
-          selector: '//*[@data-test="endpoints"]',
-          locateStrategy: 'xpath',
-        },
-        urlApplyToAllCheckbox: {
-          selector: '//input[@data-test="url-all"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        timeoutApplyToAllCheckbox: {
-          selector: '//input[@data-test="timeout-all"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        verifyCertApplyToAllCheckbox: {
-          selector: '//input[@data-test="ssl-auth-all"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        serviceURL: {
-          selector: '//input[@data-test="service-url"]',
-          locateStrategy: 'xpath',
-        },
-        timeout: {
-          selector: '//input[@data-test="service-timeout"]',
-          locateStrategy: 'xpath',
-        },
-        sslAuth: {
-          selector: '//input[@data-test="ssl-auth"]',
-          locateStrategy: 'xpath',
-        },
-        sslAuthClickarea: {
-          selector: '//input[@data-test="ssl-auth"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        save2Button: {
-          selector:
-            '//button[@data-test="save-service-parameters"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        saveButton: {
-          selector: '//button[@data-test="save-service-parameters"]',
-          locateStrategy: 'xpath',
-        },
-        closeButton: {
-          selector: '//button[@data-test="close"]',
-          locateStrategy: 'xpath',
-        },
-        urlHelp: {
-          selector:
-            '//div[@data-test="service-parameters-service-url-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        timeoutHelp: {
-          selector: '//div[@data-test="service-parameters-timeout-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        verifyCertHelp: {
-          selector:
-            '//div[@data-test="service-parameters-verify-tls-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        activeTooltip: {
-          selector:
-            '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
-          locateStrategy: 'xpath',
-        },
-        addSubjectsButton: {
-          selector: '//button[@data-test="show-add-subjects"]',
-          locateStrategy: 'xpath',
-        },
-        removeAllButton: {
-          selector: '//button[@data-test="remove-subjects"]',
-          locateStrategy: 'xpath',
-        },
+        parametersTab:  '//*[@data-test="parameters"]',
+        endpointsTab:  '//*[@data-test="endpoints"]',
+        urlApplyToAllCheckbox:  '//input[@data-test="url-all"]/following-sibling::div',
+        timeoutApplyToAllCheckbox:  '//input[@data-test="timeout-all"]/following-sibling::div',
+        verifyCertApplyToAllCheckbox: '//input[@data-test="ssl-auth-all"]/following-sibling::div',
+        serviceURL:  '//input[@data-test="service-url"]',
+        timeout:  '//input[@data-test="service-timeout"]',
+        sslAuth:  '//input[@data-test="ssl-auth"]',
+        sslAuthClickarea:  '//input[@data-test="ssl-auth"]/following-sibling::div',
+        save2Button: '//button[@data-test="save-service-parameters"]/following-sibling::div',
+        saveButton: '//button[@data-test="save-service-parameters"]',
+        closeButton: '//button[@data-test="close"]',
+        urlHelp: '//div[@data-test="service-parameters-service-url-label"]//i',
+        timeoutHelp:  '//div[@data-test="service-parameters-timeout-label"]//i',
+        verifyCertHelp: '//div[@data-test="service-parameters-verify-tls-label"]//i',
+        activeTooltip: '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
+        addSubjectsButton:  '//button[@data-test="show-add-subjects"]',
+        removeAllButton:  '//button[@data-test="remove-subjects"]',
       },
     },
     restOperationDetails: {
       selector:
         '//div[contains(@class, "base-full-width") and .//*[@data-test="parameters"]]',
-      locateStrategy: 'xpath',
       commands: [wsdlOperationCommands],
       elements: {
-        parametersTab: {
-          selector: '//*[@data-test="parameters"]',
-          locateStrategy: 'xpath',
-        },
-        endpointsTab: {
-          selector: '//*[@data-test="endpoints"]',
-          locateStrategy: 'xpath',
-        },
-        serviceURL: {
-          selector: '//input[@data-test="service-url"]',
-          locateStrategy: 'xpath',
-        },
-        timeout: {
-          selector: '//input[@data-test="service-timeout"]',
-          locateStrategy: 'xpath',
-        },
-        sslAuth: {
-          selector: '//input[@data-test="ssl-auth"]',
-          locateStrategy: 'xpath',
-        },
-        sslAuthClickarea: {
-          selector: '//input[@data-test="ssl-auth"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        save2Button: {
-          selector:
+        parametersTab:  '//*[@data-test="parameters"]',
+        endpointsTab:  '//*[@data-test="endpoints"]',
+        serviceURL: '//input[@data-test="service-url"]',
+        timeout: '//input[@data-test="service-timeout"]',
+        sslAuth: '//input[@data-test="ssl-auth"]',
+        sslAuthClickarea:  '//input[@data-test="ssl-auth"]/following-sibling::div',
+        save2Button:
             '//button[@data-test="save-service-parameters"]/following-sibling::div',
-          locateStrategy: 'xpath',
-        },
-        saveButton: {
-          selector: '//button[@data-test="save-service-parameters"]',
-          locateStrategy: 'xpath',
-        },
-        addButton: {
-          selector: '//button[@data-test="endpoint-add"]',
-          locateStrategy: 'xpath',
-        },
-        closeButton: {
-          selector: '//button[@data-test="close"]',
-          locateStrategy: 'xpath',
-        },
-        urlHelp: {
-          selector:
-            '//div[@data-test="service-parameters-service-url-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        timeoutHelp: {
-          selector: '//div[@data-test="service-parameters-timeout-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        verifyCertHelp: {
-          selector:
-            '//div[@data-test="service-parameters-verify-tls-label"]//i',
-          locateStrategy: 'xpath',
-        },
-        activeTooltip: {
-          selector:
+        saveButton: '//button[@data-test="save-service-parameters"]',
+        addButton:  '//button[@data-test="endpoint-add"]',
+        closeButton:  '//button[@data-test="close"]',
+        urlHelp: '//div[@data-test="service-parameters-service-url-label"]//i',
+        timeoutHelp:  '//div[@data-test="service-parameters-timeout-label"]//i',
+        verifyCertHelp: '//div[@data-test="service-parameters-verify-tls-label"]//i',
+        activeTooltip:
             '//div[contains(@class, "v-tooltip__content") and contains(@class,"menuable__content__active")]//span',
-          locateStrategy: 'xpath',
-        },
-        addSubjectsButton: {
-          selector: '//button[@data-test="show-add-subjects"]',
-          locateStrategy: 'xpath',
-        },
-        removeAllButton: {
-          selector: '//button[@data-test="remove-subjects"]',
-          locateStrategy: 'xpath',
-        },
+        addSubjectsButton:  '//button[@data-test="show-add-subjects"]',
+        removeAllButton:  '//button[@data-test="remove-subjects"]',
       },
     },
     sslCheckFailDialog: {
       selector:
         '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
-      locateStrategy: 'xpath',
       commands: [sslCheckFailDialogCommands],
       elements: {
-        continueButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        continueButton:  '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
       },
     },
     restServiceEndpoints: {
       selector:
         '//div[contains(@class, "base-full-width") and .//*[@data-test="endpoints"]]',
-      locateStrategy: 'xpath',
       commands: [restEndpointCommands],
       elements: {
-        parametersTab: {
-          selector: '//*[@data-test="parameters"]',
-          locateStrategy: 'xpath',
-        },
-        endpointsTab: {
-          selector: '//*[@data-test="endpoints"]',
-          locateStrategy: 'xpath',
-        },
-        addButton: {
-          selector: '//button[@data-test="endpoint-add"]',
-          locateStrategy: 'xpath',
-        },
-        closeButton: {
-          selector:
-            '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
-          locateStrategy: 'xpath',
-        },
-        editButton: {
-          selector: '//button[@data-test="endpoint-edit"]',
-          locateStrategy: 'xpath',
-        },
-        accessRightsButton: {
-          selector: '//button[@data-test="endpoint-edit-accessrights"]',
-          locateStrategy: 'xpath',
-        },
+        parametersTab:  '//*[@data-test="parameters"]',
+        endpointsTab:  '//*[@data-test="endpoints"]',
+        addButton:  '//button[@data-test="endpoint-add"]',
+        closeButton:  '//*[contains(@class, "cert-dialog-header")]//*[@data-test="close-x"]',
+        editButton:  '//button[@data-test="endpoint-edit"]',
+        accessRightsButton:  '//button[@data-test="endpoint-edit-accessrights"]',
       },
     },
     wsdlAddSubjectsPopup: addSubjectsPopup,
     addEndpointPopup: {
       selector:
         '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
-      locateStrategy: 'xpath',
       commands: [addEndpointCommands],
       elements: {
-        addButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        requestPath: {
-          selector: '//input[@data-test="endpoint-path"]',
-          locateStrategy: 'xpath',
-        },
-        requestPathMessage: {
-          selector:
-            '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        methodDropdown: {
-          selector: '//input[@data-test="endpoint-method"]/parent::*',
-          locateStrategy: 'xpath',
-        },
+        addButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        requestPath:  '//input[@data-test="endpoint-path"]',
+        requestPathMessage: '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
+        methodDropdown:  '//input[@data-test="endpoint-method"]/parent::*',
       },
     },
     editEndpointPopup: {
       selector:
         '//div[contains(@class, "xrd-tab-max-width") and //div[@data-test="endpoint-details-dialog"]]',
-      locateStrategy: 'xpath',
       commands: [addEndpointCommands],
       elements: {
-        addButton: {
-          selector: '//button[.//*[contains(text(), "Save")]]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        deleteButton: {
-          selector: '//button[.//*[contains(text(), "Delete")]]',
-          locateStrategy: 'xpath',
-        },
-        requestPath: {
-          selector: '//input[@data-test="endpoint-path"]',
-          locateStrategy: 'xpath',
-        },
-        requestPathMessage: {
-          selector:
-            '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        methodDropdown: {
-          selector: '//input[@data-test="endpoint-method"]/parent::*',
-          locateStrategy: 'xpath',
-        },
-        deleteYesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        deleteCancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        addButton: '//button[.//*[contains(text(), "Save")]]',
+        cancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+        deleteButton: '//button[.//*[contains(text(), "Delete")]]',
+        requestPath:  '//input[@data-test="endpoint-path"]',
+        requestPathMessage: '//div[contains(@class, "dlg-edit-row") and .//*[@data-test="endpoint-path"]]//*[contains(@class, "v-messages__message")]',
+        methodDropdown: '//input[@data-test="endpoint-method"]/parent::*',
+        deleteYesButton:  '//button[@data-test="dialog-save-button"]',
+        deleteCancelButton:  '//button[@data-test="dialog-cancel-button"]',
       },
     },
     removeAccessRightPopup: {
       selector:
         '//div[contains(@class, "xrd-card") and //div[@data-test="dialog-simple"] and .//*[@data-test="dialog-title"]]',
-      locateStrategy: 'xpath',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton: '//button[@data-test="dialog-cancel-button"]',
       },
     },
     removeAllAccessRightsPopup: {
       selector:
         '//div[contains(@class, "xrd-card") and //div[@data-test="dialog-simple"] and .//*[@data-test="dialog-title"]]',
-      locateStrategy: 'xpath',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        yesButton:  '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+
       },
     },
     deleteCertPopup: {
       selector:
         '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title" and //*[@data-test="dialog-content-text"]]]',
-      locateStrategy: 'xpath',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+
       },
     },
     deleteCSRPopup: {
       selector:
         '//*[@data-test="dialog-simple" and .//*[@data-test="dialog-title"]]',
-      locateStrategy: 'xpath',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        yesButton:  '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
       },
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
@@ -890,12 +890,10 @@ module.exports = {
         deleteServiceButton: '//button[@data-test="service-description-details-delete-button"]',
         confirmDeleteButton:  '//button[@data-test="dialog-save-button"]',
          cancelDeleteButton:  '//button[@data-test="dialog-cancel-button"]',
-        serviceURL:  '//*[contains(@class, "url-input")]//input',
-        serviceCode:  '//*[contains(@class, "code-input")]//input',
-        serviceType:
-            '//div[@data-test="service-description-details-url-type-value"]',
-        URLMessage:
-            '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
+        serviceURL: '//*[contains(@class, "url-input")]//input',
+        serviceCode: '//*[contains(@class, "code-input")]//input',
+        serviceType: '//div[@data-test="service-description-details-url-type-value"]',
+        URLMessage: '//*[contains(@class, "validation-provider")]//*[contains(@class, "v-messages__message")]',
         codeMessage:
             '//*[contains(@class, "code-input")]//*[contains(@class, "v-messages__message")]',
         confirmDialogButton:
@@ -914,8 +912,7 @@ module.exports = {
         deleteServiceButton:
             '//button[@data-test="service-description-details-delete-button"]',
         confirmDeleteButton: '//button[@data-test="dialog-save-button"]',
-        cancelDeleteButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
+        cancelDeleteButton: '//button[@data-test="dialog-cancel-button"]',
         serviceURL: '//*[contains(@class, "url-input")]//input',
         serviceCode:
             '//*[contains(@class, "code-input")]//input[@name="code_field"]',
@@ -1070,5 +1067,4 @@ module.exports = {
         cancelButton:  '//button[@data-test="dialog-cancel-button"]',
       },
     },
-  },
 };

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/ssMainPage.js
@@ -680,56 +680,20 @@ module.exports = {
   url: process.env.VUE_DEV_SERVER_URL,
   commands: [navigateCommands],
   elements: {
-    clientsTab: {
-      selector: '//a[@data-test="clients"]',
-      locateStrategy: 'xpath',
-    },
-    keysTab: {
-      selector: '//a[@data-test="keys"]',
-      locateStrategy: 'xpath',
-    },
-    diagnosticsTab: {
-      selector: '//a[@data-test="diagnostics"]',
-      locateStrategy: 'xpath',
-    },
-    settingsTab: {
-      selector: '//a[@data-test="settings"]',
-      locateStrategy: 'xpath',
-    },
-    userMenuButton: {
-      selector: '//button[@data-test="username-button"]',
-      locateStrategy: 'xpath',
-    },
-    userMenuitemLogout: {
-      selector: '//*[@data-test="logout-list-tile"]',
-      locateStrategy: 'xpath',
-    },
-    logoutOKButton: {
-      selector:
+    clientsTab:  '//a[@data-test="clients"]',
+    keysTab:  '//a[@data-test="keys"]',
+    diagnosticsTab: '//a[@data-test="diagnostics"]',
+    settingsTab: '//a[@data-test="settings"]',
+    userMenuButton: '//button[@data-test="username-button"]',
+    userMenuitemLogout: '//*[@data-test="logout-list-tile"]',
+    logoutOKButton:
         '//div[contains(@class, "v-dialog")]//button[.//*[contains(text(), "Ok")]]',
-      locateStrategy: 'xpath',
-    },
-    snackBarCloseButton: {
-      selector: '//button[@data-test="close-snackbar"]',
-      locateStrategy: 'xpath',
-    },
-    snackBarMessage: {
-      selector: '//div[@data-test="success-snackbar"]',
-      locateStrategy: 'xpath',
-    },
-    alertCloseButton: {
-      selector: '//button[@data-test="close-alert"]',
-      locateStrategy: 'xpath',
-    },
-    alertMessage: {
-      selector:
+    snackBarCloseButton: '//button[@data-test="close-snackbar"]',
+    snackBarMessage: '//div[@data-test="success-snackbar"]',
+    alertCloseButton: '//button[@data-test="close-alert"]',
+    alertMessage:
         '//div[@data-test="contextual-alert"]//div[contains(@class, "row-wrapper")]/div',
-      locateStrategy: 'xpath',
-    },
-    sessionExpiredPopupOkButton: {
-      selector: '//button[@data-test="session-expired-ok-button"]',
-      locateStrategy: 'xpath',
-    },
+    sessionExpiredPopupOkButton: '//button[@data-test="session-expired-ok-button"]',
   },
   sections: {
     clientsTab: clientsTab,

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/clientsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/clientsTab.js
@@ -59,41 +59,16 @@ const clientsTab = {
   url: `${process.env.VUE_DEV_SERVER_URL}/clients`,
   selector:
     '//div[.//a[contains(@class, "v-tab--active") and @data-test="clients"]]//div[contains(@class, "base-full-width")]',
-  locateStrategy: 'xpath',
   commands: clientsTabCommands,
   elements: {
-    searchIcon: {
-      selector: '//*[contains(@class, "mdi-magnify")]',
-      locateStrategy: 'xpath',
-    },
-    searchField: {
-      selector: '//*[@data-test="search-input"]',
-      locateStrategy: 'xpath',
-    },
-    addClientButton: {
-      selector: '//button[@data-test="add-client-button"]',
-      locateStrategy: 'xpath',
-    },
-    listNameHeader: {
-      selector: '//th[contains(@class, "xrd-table-header-name")]',
-      locateStrategy: 'xpath',
-    },
-    listIDHeader: {
-      selector: '//th[contains(@class, "xrd-table-header-id")]',
-      locateStrategy: 'xpath',
-    },
-    listStatusHeader: {
-      selector: '//th[contains(@class, "xrd-table-header-status")]',
-      locateStrategy: 'xpath',
-    },
-    testServiceListItem: {
-      selector: '//tbody//span[contains(text(),"TestService")]',
-      locateStrategy: 'xpath',
-    },
-    testGovListItem: {
-      selector: '//tbody//span[contains(text(),"TestGov")]',
-      locateStrategy: 'xpath',
-    },
+    searchIcon: '//*[contains(@class, "mdi-magnify")]',
+    searchField: '//*[@data-test="search-input"]',
+    addClientButton: '//button[@data-test="add-client-button"]',
+    listNameHeader: '//th[contains(@class, "xrd-table-header-name")]',
+    listIDHeader: '//th[contains(@class, "xrd-table-header-id")]',
+    listStatusHeader: '//th[contains(@class, "xrd-table-header-status")]',
+    testServiceListItem: '//tbody//span[contains(text(),"TestService")]',
+    testGovListItem: '//tbody//span[contains(text(),"TestGov")]',
   },
 };
 

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/diagnosticsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/diagnosticsTab.js
@@ -28,17 +28,9 @@ const diagnosticsTab = {
   url: `${process.env.VUE_DEV_SERVER_URL}/diagnostics`,
   selector:
     '//div[.//a[contains(@class, "v-tab--active") and //span[@data-test="diagnostics-global-configuration"]]]//div[contains(@class, "base-full-width")]',
-  locateStrategy: 'xpath',
-  commands: [],
   elements: {
-    globalConfiguration: {
-      selector: '//span[@data-test="diagnostics-global-configuration"]',
-      locateStrategy: 'xpath',
-    },
-    javaVersion: {
-      selector: '//*[@data-test="java-version"]',
-      locateStrategy: 'xpath',
-    },
+    globalConfiguration:  '//span[@data-test="diagnostics-global-configuration"]',
+    javaVersion: '//*[@data-test="java-version"]',
   },
 };
 

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
@@ -292,414 +292,195 @@ const keysTab = {
   url: `${process.env.VUE_DEV_SERVER_URL}/keys`,
   selector:
     '//div[.//a[contains(@class, "v-tab--active") and @data-test="keys"]]//div[contains(@class, "base-full-width")]',
-  locateStrategy: 'xpath',
   commands: keysTabCommands,
   elements: {
-    signAndAuthKeysTab: {
-      selector:
+    signAndAuthKeysTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "SIGN and AUTH Keys")]',
-      locateStrategy: 'xpath',
-    },
-    APIKeysTab: {
-      selector:
+
+    APIKeysTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "API Keys")]',
-      locateStrategy: 'xpath',
-    },
-    securityServerTLSKeyTab: {
-      selector:
+    securityServerTLSKeyTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "Security Server TLS Key")]',
-      locateStrategy: 'xpath',
-    },
-    tokenName: {
-      selector: '//*[@data-test="token-name"]',
-      locateStrategy: 'xpath',
-    },
-    createAPIKeyButton: {
-      selector: '//*[@data-test="api-key-create-key-button"]',
-      locateStrategy: 'xpath',
-    },
-    generateKeyButton: {
-      selector:
+
+    tokenName:  '//*[@data-test="token-name"]',
+    createAPIKeyButton:  '//*[@data-test="api-key-create-key-button"]',
+    generateKeyButton:
         '//*[@data-test="security-server-tls-certificate-generate-key-button"]',
-      locateStrategy: 'xpath',
-    },
-    exportCertButton: {
-      selector:
+    exportCertButton:
         '//*[@data-test="security-server-tls-certificate-export-certificate-button"]',
-      locateStrategy: 'xpath',
-    },
   },
   sections: {
     signAuthKeysTab: {
       selector:
         '//div[.//a[contains(@class, "v-tab--active") and contains(text(), "SIGN and AUTH Keys")]]//div[contains(@class, "base-full-width")]',
-      locateStrategy: 'xpath',
       commands: [signAuthKeysTabCommands],
       elements: {
-        expandButton: {
-          selector:
+        expandButton:
             '//div[contains(@class, "expandable")]//button[contains(@class, "v-btn--icon")]',
-          locateStrategy: 'xpath',
-        },
-        tokenLink: {
-          selector: '//*[@data-test="token-name"]',
-          locateStrategy: 'xpath',
-        },
-        logoutButton: {
-          selector: '//button[@data-test="token-logout-button"]',
-          locateStrategy: 'xpath',
-        },
-        loginButton: {
-          selector: '//button[@data-test="token-login-button"]',
-          locateStrategy: 'xpath',
-        },
-        addTokenKeyButton: {
-          selector: '//button[@data-test="token-add-key-button"]',
-          locateStrategy: 'xpath',
-        },
-        importCertButton: {
-          selector: '//button[@data-test="token-import-cert-button"]',
-          locateStrategy: 'xpath',
-        },
-        authGenerateCSRButton: {
-          selector:
+        tokenLink:  '//*[@data-test="token-name"]',
+        logoutButton:  '//button[@data-test="token-logout-button"]',
+        loginButton:  '//button[@data-test="token-login-button"]',
+        addTokenKeyButton: '//button[@data-test="token-add-key-button"]',
+        importCertButton: '//button[@data-test="token-import-cert-button"]',
+        authGenerateCSRButton:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//button[.//*[contains(text(), "Generate CSR")]]',
-          locateStrategy: 'xpath',
-        },
-        authKeyIcon: {
-          selector:
+
+        authKeyIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//i[contains(@class, "icon-xrd_key")]',
-          locateStrategy: 'xpath',
-        },
-        authKeyLink: {
-          selector:
+        authKeyLink:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//div[contains(@class, "clickable-link")]',
-          locateStrategy: 'xpath',
-        },
-        authCertIcon: {
-          selector:
+        authCertIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//i[contains(@class, "icon-xrd_certificate")]',
-          locateStrategy: 'xpath',
-        },
-        signGenerateCSRButton: {
-          selector:
+
+        signGenerateCSRButton:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//button[.//*[contains(text(), "Generate CSR")]]',
-          locateStrategy: 'xpath',
-        },
-        signKeyIcon: {
-          selector:
+
+        signKeyIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//i[contains(@class, "icon-xrd_key")]',
-          locateStrategy: 'xpath',
-        },
-        signKeyLink: {
-          selector:
+        signKeyLink:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//div[contains(@class, "clickable-link")]',
-          locateStrategy: 'xpath',
-        },
-        signCertIcon: {
-          selector:
+
+        signCertIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//i[contains(@class, "icon-xrd_certificate")]',
-          locateStrategy: 'xpath',
-        },
-        initializedAuthCert: {
-          selector:
+          initializedAuthCert:
             '//tr[.//td[contains(text(), "Disabled")] and .//div[contains(@class, "status-text") and contains(text(), "Saved")]]//div[contains(@class, "clickable-link")]',
-          locateStrategy: 'xpath',
-        },
       },
     },
     logoutTokenPopup: {
       selector:
         '//div[contains(@class, "xrd-card") and .//*[@data-test="dialog-title" and contains(text(),"Log out")]]',
-      locateStrategy: 'xpath',
       commands: [confirmationDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+
       },
     },
     loginTokenPopup: {
       selector:
         '//div[contains(@class, "xrd-card") and .//*[@data-test="dialog-title" and contains(text(),"Log in")]]',
-      locateStrategy: 'xpath',
       commands: [loginDialogCommands],
       elements: {
-        yesButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        pinCode: {
-          selector: '//input[@name="tokenPin"]',
-          locateStrategy: 'xpath',
-        },
-        pinMessage: {
-          selector: '//div[contains(@class, "v-messages__wrapper")]',
-          locateStrategy: 'xpath',
-        },
+        yesButton: '//button[@data-test="dialog-save-button"]',
+        cancelButton:  '//button[@data-test="dialog-cancel-button"]',
+        pinCode:  '//input[@name="tokenPin"]',
+        pinMessage: '//div[contains(@class, "v-messages__wrapper")]',
       },
     },
     authKeyDetails: {
       selector:
         '//div[contains(@class, "xrd-view-common") and .//*[contains(@class, "identifier-wrap") and contains(text(),"AUTH Key details")]]',
-      locateStrategy: 'xpath',
       commands: [keyDetailsCommands],
       elements: {
-        saveButton: {
-          selector: '//button[.//*[contains(text(), "Save")]]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        deleteButton: {
-          selector: '//button[.//*[contains(text(), "Delete")]]',
-          locateStrategy: 'xpath',
-        },
-        friendlyName: {
-          selector: '//input[@name="keys.friendlyName"]',
-          locateStrategy: 'xpath',
-        },
-        label: {
-          selector:
+        saveButton:  '//button[.//*[contains(text(), "Save")]]',
+        cancelButton:  '//button[.//*[contains(text(), "Cancel")]]',
+        deleteButton: '//button[.//*[contains(text(), "Delete")]]',
+        friendlyName:  '//input[@name="keys.friendlyName"]',
+        label:
             '//div[contains(@class, "row-title") and contains(text(), "Label:")]//following-sibling::div[contains(@class, "row-data")]',
-          locateStrategy: 'xpath',
         },
       },
-    },
     signKeyDetails: {
       selector:
         '//div[contains(@class, "xrd-view-common") and .//*[contains(@class, "identifier-wrap") and contains(text(),"SIGN Key details")]]',
-      locateStrategy: 'xpath',
       commands: [keyDetailsCommands],
       elements: {
-        saveButton: {
-          selector: '//button[.//*[contains(text(), "Save")]]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        deleteButton: {
-          selector: '//button[.//*[contains(text(), "Delete")]]',
-          locateStrategy: 'xpath',
-        },
-        friendlyName: {
-          selector: '//input[@name="keys.friendlyName"]',
-          locateStrategy: 'xpath',
-        },
-        friendlyNameMessage: {
-          selector:
+        saveButton:  '//button[.//*[contains(text(), "Save")]]',
+        cancelButton: '//button[.//*[contains(text(), "Cancel")]]',
+        deleteButton:  '//button[.//*[contains(text(), "Delete")]]',
+        friendlyName:  '//input[@name="keys.friendlyName"]',
+        friendlyNameMessage:
             '//span[contains(@class, "validation-provider")]//div[contains(@class, "v-messages__message")]',
-          locateStrategy: 'xpath',
-        },
-        label: {
-          selector:
-            '//div[contains(@class, "row-title") and contains(text(), "Label:")]//following-sibling::div[contains(@class, "row-data")]',
-          locateStrategy: 'xpath',
-        },
+        label: '//div[contains(@class, "row-title") and contains(text(), "Label:")]//following-sibling::div[contains(@class, "row-data")]',
+
       },
     },
     tokenDetails: {
       selector:
         '//div[contains(@class, "xrd-view-common") and .//*[contains(@class, "identifier-wrap") and contains(text(),"Token details")]]',
-      locateStrategy: 'xpath',
       commands: [keyDetailsCommands],
       elements: {
-        saveButton: {
-          selector: '//button[.//*[contains(text(), "Save")]]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[.//*[contains(text(), "Cancel")]]',
-          locateStrategy: 'xpath',
-        },
-        friendlyName: {
-          selector: '//input[@name="keys.friendlyName"]',
-          locateStrategy: 'xpath',
-        },
-        type: {
-          selector:
+        saveButton:  '//button[.//*[contains(text(), "Save")]]',
+        cancelButton: '//button[.//*[contains(text(), "Cancel")]]',
+        friendlyName:
+          '//input[@name="keys.friendlyName"]',
+        type:
             '//div[contains(@class, "row-title") and contains(text(), "Type:")]//following-sibling::div[contains(@class, "row-data")]',
-          locateStrategy: 'xpath',
-        },
       },
     },
     addKeyWizardDetails: {
       selector:
         '//div[contains(@class, "v-stepper__step--active") and .//*[contains(text(), "1")]]',
-      locateStrategy: 'xpath',
       commands: [addKeywizardDetailCommands],
       elements: {
-        nextButton: {
-          selector: '//button[@data-test="next-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        keyLabel: {
-          selector: '//input[@data-test="key-label-button"]',
-          locateStrategy: 'xpath',
-        },
+        nextButton: '//button[@data-test="next-button"]',
+        cancelButton: '//button[@data-test="cancel-button"]',
+        keyLabel:  '//input[@data-test="key-label-button"]',
       },
     },
     addKeyWizardCSR: {
       selector:
         '//div[contains(@class, "v-stepper__step--active") and .//*[contains(text(), "2")]]',
-      locateStrategy: 'xpath',
       commands: [addKeywizardCSRCommands],
       elements: {
-        continueButton: {
-          selector: '//button[@data-test="save-button"]',
-          locateStrategy: 'xpath',
-        },
-        previousButton: {
-          selector: '//button[@data-test="previous-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        csrUsage: {
-          selector:
+        continueButton:'//button[@data-test="save-button"]',
+        previousButton: '//button[@data-test="previous-button"]',
+        cancelButton:  '//button[@data-test="cancel-button"]',
+        csrUsage:
             '//div[contains(@class, "v-select__selections") and ./input[@data-test="csr-usage-select"]]',
-          locateStrategy: 'xpath',
-        },
-        csrService: {
-          selector:
+        csrService:
             '//div[contains(@class, "v-select__selections") and input[@data-test="csr-certification-service-select"]]',
-          locateStrategy: 'xpath',
-        },
-        csrFormat: {
-          selector:
+        csrFormat:
             '//div[contains(@class, "v-select__selections") and input[@data-test="csr-format-select"]]',
-          locateStrategy: 'xpath',
-        },
-        csrClient: {
-          selector:
-            '//div[contains(@class, "v-select__selections") and input[@data-test="csr-client-select"]]',
-          locateStrategy: 'xpath',
-        },
+        csrClient: '//div[contains(@class, "v-select__selections") and input[@data-test="csr-client-select"]]',
+
       },
     },
     addKeyWizardGenerate: {
       selector:
         '//div[contains(@class, "v-stepper__step--active") and .//*[contains(text(), "3")]]',
-      locateStrategy: 'xpath',
       commands: [addKeywizardGenerateCommands],
       elements: {
-        doneButton: {
-          selector: '(//button[@data-test="save-button"])[2]',
-          locateStrategy: 'xpath',
-        },
-        previousButton: {
-          selector: '//button[@data-test="previous-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '(//button[@data-test="cancel-button"])[2]',
-          locateStrategy: 'xpath',
-        },
-        generateButton: {
-          selector: '//button[@data-test="generate-csr-button"]',
-          locateStrategy: 'xpath',
-        },
-        organizationName: {
-          selector: '//input[@name="O" and @data-test="dynamic-csr-input"]',
-          locateStrategy: 'xpath',
-        },
-        serverDNS: {
-          selector: '//input[@name="CN" and @data-test="dynamic-csr-input"]',
-          locateStrategy: 'xpath',
-        },
+        doneButton: '(//button[@data-test="save-button"])[2]',
+        previousButton:  '//button[@data-test="previous-button"]',
+        cancelButton:  '(//button[@data-test="cancel-button"])[2]',
+        generateButton: '//button[@data-test="generate-csr-button"]',
+        organizationName: '//input[@name="O" and @data-test="dynamic-csr-input"]',
+        serverDNS: '//input[@name="CN" and @data-test="dynamic-csr-input"]',
       },
     },
     generateKeyCsrWizardCsr: {
       // Generate csr for existing sign key. Page 1, CSR details
       selector:
         '//div[contains(@class, "v-stepper__step--active") and .//*[contains(text(), "1")]]',
-      locateStrategy: 'xpath',
       commands: [addKeywizardCSRCommands],
       elements: {
-        continueButton: {
-          selector: '//button[@data-test="save-button"]',
-          locateStrategy: 'xpath',
-        },
-        previousButton: {
-          selector: '//button[@data-test="previous-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '//button[@data-test="cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        csrUsage: {
-          selector:
+        continueButton: '//button[@data-test="save-button"]',
+        previousButton: '//button[@data-test="previous-button"]',
+
+        cancelButton: '//button[@data-test="cancel-button"]',
+        csrUsage:
             '//div[@role="button" and .//div[contains(@class, "v-select__selections") and input[@data-test="csr-usage-select"]]]',
-          locateStrategy: 'xpath',
-        },
-        csrService: {
-          selector:
+        csrService:
             '//div[contains(@class, "v-select__selections") and input[@data-test="csr-certification-service-select"]]',
-          locateStrategy: 'xpath',
-        },
-        csrFormat: {
-          selector:
+        csrFormat:
             '//div[contains(@class, "v-select__selections") and input[@data-test="csr-format-select"]]',
-          locateStrategy: 'xpath',
-        },
-        csrClient: {
-          selector:
-            '//div[contains(@class, "v-select__selections") and input[@data-test="csr-client-select"]]',
-          locateStrategy: 'xpath',
-        },
+        csrClient: '//div[contains(@class, "v-select__selections") and input[@data-test="csr-client-select"]]',
       },
     },
     generateKeyCsrWizardGenerate: {
       // Generate csr for existing sign key. Page 2, generate
       selector:
         '//div[contains(@class, "v-stepper__step--active") and .//*[contains(text(), "2")]]',
-      locateStrategy: 'xpath',
       commands: [addKeywizardGenerateCommands],
       elements: {
-        doneButton: {
-          selector: '(//button[@data-test="save-button"])[2]',
-          locateStrategy: 'xpath',
-        },
-        previousButton: {
-          selector: '//button[@data-test="previous-button"]',
-          locateStrategy: 'xpath',
-        },
-        cancelButton: {
-          selector: '(//button[@data-test="cancel-button"])[2]',
-          locateStrategy: 'xpath',
-        },
-        generateButton: {
-          selector: '//button[@data-test="generate-csr-button"]',
-          locateStrategy: 'xpath',
-        },
-        organizationName: {
-          selector: '//input[@name="O" and @data-test="dynamic-csr-input"]',
-          locateStrategy: 'xpath',
-        },
-        serverDNS: {
-          selector: '//input[@name="CN" and @data-test="dynamic-csr-input"]',
-          locateStrategy: 'xpath',
-        },
+        doneButton: '(//button[@data-test="save-button"])[2]',
+        previousButton:  '//button[@data-test="previous-button"]',
+        cancelButton: '(//button[@data-test="cancel-button"])[2]',
+        generateButton:'//button[@data-test="generate-csr-button"]',
+        organizationName: '//input[@name="O" and @data-test="dynamic-csr-input"]',
+        serverDNS:  '//input[@name="CN" and @data-test="dynamic-csr-input"]',
+
       },
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/keysTab.js
@@ -296,12 +296,10 @@ const keysTab = {
   elements: {
     signAndAuthKeysTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "SIGN and AUTH Keys")]',
-
     APIKeysTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "API Keys")]',
     securityServerTLSKeyTab:
         '//div[contains(@class, "v-tabs-bar__content")]//*[contains(@class, "v-tab") and contains(text(), "Security Server TLS Key")]',
-
     tokenName:  '//*[@data-test="token-name"]',
     createAPIKeyButton:  '//*[@data-test="api-key-create-key-button"]',
     generateKeyButton:
@@ -324,22 +322,18 @@ const keysTab = {
         importCertButton: '//button[@data-test="token-import-cert-button"]',
         authGenerateCSRButton:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//button[.//*[contains(text(), "Generate CSR")]]',
-
         authKeyIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//i[contains(@class, "icon-xrd_key")]',
         authKeyLink:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//div[contains(@class, "clickable-link")]',
         authCertIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "AUTH Key and Certificate")]]//i[contains(@class, "icon-xrd_certificate")]',
-
         signGenerateCSRButton:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//button[.//*[contains(text(), "Generate CSR")]]',
-
         signKeyIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//i[contains(@class, "icon-xrd_key")]',
         signKeyLink:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//div[contains(@class, "clickable-link")]',
-
         signCertIcon:
             '//table[./thead//th[@class="title-col" and contains(text(), "SIGN Key and Certificate")]]//i[contains(@class, "icon-xrd_certificate")]',
           initializedAuthCert:
@@ -392,7 +386,6 @@ const keysTab = {
         friendlyNameMessage:
             '//span[contains(@class, "validation-provider")]//div[contains(@class, "v-messages__message")]',
         label: '//div[contains(@class, "row-title") and contains(text(), "Label:")]//following-sibling::div[contains(@class, "row-data")]',
-
       },
     },
     tokenDetails: {
@@ -433,7 +426,6 @@ const keysTab = {
         csrFormat:
             '//div[contains(@class, "v-select__selections") and input[@data-test="csr-format-select"]]',
         csrClient: '//div[contains(@class, "v-select__selections") and input[@data-test="csr-client-select"]]',
-
       },
     },
     addKeyWizardGenerate: {
@@ -480,7 +472,6 @@ const keysTab = {
         generateButton:'//button[@data-test="generate-csr-button"]',
         organizationName: '//input[@name="O" and @data-test="dynamic-csr-input"]',
         serverDNS:  '//input[@name="CN" and @data-test="dynamic-csr-input"]',
-
       },
     },
   },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
@@ -165,7 +165,6 @@ const settingsTab = {
             '//tr[@data-test="system.parameters-timestamping-service-row"]/td[1]',
         timestampingTableSecondCell:
             '//tr[@data-test="system.parameters-timestamping-service-row"]/td[2]',
-
       },
     },
     backupAndRestoreTab: {
@@ -178,7 +177,6 @@ const settingsTab = {
         backupButton: '//*[@data-test="backup-create-configuration"]',
         searchButton: '//button[contains(@class, "mdi-magnify")]',
         searchField: '//input[@data-test="search-input"]',
-
       },
       sections: {
         deleteBackupConfirmationDialog: {
@@ -188,10 +186,8 @@ const settingsTab = {
           elements: {
             confirmation:
                 '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text" and contains(text(), "Are you sure you want to delete")]]//button[@data-test="dialog-save-button"]',
-
             cancel:
                 '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text" and contains(text(), "Are you sure you want to delete")]]//button[@data-test="dialog-cancel-button"]',
-
           },
         },
         backupFileAlreadyExistsDialog: {
@@ -201,7 +197,6 @@ const settingsTab = {
           elements: {
             confirmation:  '//button[@data-test="dialog-save-button"]',
             cancel:  '//button[@data-test="dialog-cancel-button"]',
-
           },
         },
         restoreConfirmationDialog: {
@@ -211,7 +206,6 @@ const settingsTab = {
           elements: {
             confirmation: '//button[@data-test, "dialog-save-button"]',
             cancel: '//button[@data-test="dialog-cancel-button"]',
-
           },
         },
       },

--- a/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
+++ b/src/proxy-ui-api/frontend/tests/e2e/pages/tabs/settingsTab.js
@@ -136,155 +136,82 @@ const confirmationDialog = {
 const settingsTab = {
   url: `${process.env.VUE_DEV_SERVER_URL}/settings`,
   selector: '//div[@data-test="settings-tab-view"]',
-  locateStrategy: 'xpath',
   commands: settingsTabCommands,
   elements: {
-    systemParametersTab: {
-      selector: '//a[@data-test="system-parameters-tab-button"]',
-      locateStrategy: 'xpath',
-    },
-    backupAndRestoreTab: {
-      selector: '//a[@data-test="backupandrestore-tab-button"]',
-      locateStrategy: 'xpath',
-    },
+    systemParametersTab: '//a[@data-test="system-parameters-tab-button"]',
+    backupAndRestoreTab: '//a[@data-test="backupandrestore-tab-button"]',
   },
   sections: {
     systemParametersTab: {
       selector: '//div[@data-test="system-parameters-tab-view"]',
-      locateStrategy: 'xpath',
       commands: systemParametersTabCommands,
       elements: {
-        timestampingServiceTableRow: {
-          selector:
-            '//tr[@data-test="system.parameters-timestamping-service-row"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingDeleteButton: {
-          selector:
+        timestampingServiceTableRow: '//tr[@data-test="system.parameters-timestamping-service-row"]',
+        timestampingDeleteButton:
             '//button[@data-test="system-parameters-timestamping-service-delete-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingAddButton: {
-          selector:
+        timestampingAddButton:
             '//button[@data-test="system-parameters-timestamping-services-add-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingAddButtonDisabled: {
-          selector:
+        timestampingAddButtonDisabled:
             '//button[@data-test="system-parameters-timestamping-services-add-button" and @disabled="disabled"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingDeleteDialog: {
-          selector: '//div[@data-test="dialog-simple"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingDeleteDialogCancelButton: {
-          selector: '//button[@data-test="dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingDeleteDialogSaveButton: {
-          selector: '//button[@data-test="dialog-save-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingAddDialogAddButton: {
-          selector:
-            '//button[@data-test="system-parameters-add-timestamping-service-dialog-add-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingAddDialogCancelButton: {
-          selector:
+        timestampingDeleteDialog:  '//div[@data-test="dialog-simple"]',
+        timestampingDeleteDialogCancelButton:
+          '//button[@data-test="dialog-cancel-button"]',
+        timestampingDeleteDialogSaveButton: '//button[@data-test="dialog-save-button"]',
+        timestampingAddDialogAddButton: '//button[@data-test="system-parameters-add-timestamping-service-dialog-add-button"]',
+        timestampingAddDialogCancelButton:
             '//button[@data-test="system-parameters-add-timestamping-service-dialog-cancel-button"]',
-          locateStrategy: 'xpath',
-        },
-        timestampingAddDialogServiceSelection: {
-          selector: '//input[@value="X-Road Test TSA CN"]/../../label',
-          locateStrategy: 'xpath',
-        },
-        timestampingTableFirstCell: {
-          selector:
+        timestampingAddDialogServiceSelection: '//input[@value="X-Road Test TSA CN"]/../../label',
+        timestampingTableFirstCell:
             '//tr[@data-test="system.parameters-timestamping-service-row"]/td[1]',
-          locateStrategy: 'xpath',
-        },
-        timestampingTableSecondCell: {
-          selector:
+        timestampingTableSecondCell:
             '//tr[@data-test="system.parameters-timestamping-service-row"]/td[2]',
-          locateStrategy: 'xpath',
-        },
+
       },
     },
     backupAndRestoreTab: {
       selector:
         '//div[contains(@class, "v-tabs-bar__content")]//a[contains(@class, "v-tab") and contains(text(), "Backup And Restore")]',
-      locateStrategy: 'xpath',
       commands: backupAndRestoreCommands,
       elements: {
-        anchorDownloadButton: {
-          selector:
+        anchorDownloadButton:
             '//*[@data-test="system-parameters-configuration-anchor-download-button"]',
-          locateStrategy: 'xpath',
-        },
-        backupButton: {
-          selector: '//*[@data-test="backup-create-configuration"]',
-          locateStrategy: 'xpath',
-        },
-        searchButton: {
-          selector: '//button[contains(@class, "mdi-magnify")]',
-          locateStrategy: 'xpath',
-        },
-        searchField: {
-          selector: '//input[@data-test="search-input"]',
-          locateStrategy: 'xpath',
-        },
+        backupButton: '//*[@data-test="backup-create-configuration"]',
+        searchButton: '//button[contains(@class, "mdi-magnify")]',
+        searchField: '//input[@data-test="search-input"]',
+
       },
       sections: {
         deleteBackupConfirmationDialog: {
           selector:
             '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text" and contains(text(), "Are you sure you want to delete")]]',
-          locateStrategy: 'xpath',
           commands: confirmationDialog,
           elements: {
-            confirmation: {
-              selector:
+            confirmation:
                 '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text" and contains(text(), "Are you sure you want to delete")]]//button[@data-test="dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancel: {
-              selector:
+
+            cancel:
                 '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text" and contains(text(), "Are you sure you want to delete")]]//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
+
           },
         },
         backupFileAlreadyExistsDialog: {
           selector:
             '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text"]]',
-          locateStrategy: 'xpath',
           commands: confirmationDialog,
           elements: {
-            confirmation: {
-              selector: '//button[@data-test="dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancel: {
-              selector: '//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
+            confirmation:  '//button[@data-test="dialog-save-button"]',
+            cancel:  '//button[@data-test="dialog-cancel-button"]',
+
           },
         },
         restoreConfirmationDialog: {
           selector:
             '//div[@data-test="dialog-simple" and .//div[@data-test="dialog-content-text"]]',
-          locateStrategy: 'xpath',
           commands: confirmationDialog,
           elements: {
-            confirmation: {
-              selector: '//button[@data-test, "dialog-save-button"]',
-              locateStrategy: 'xpath',
-            },
-            cancel: {
-              selector: '//button[@data-test="dialog-cancel-button"]',
-              locateStrategy: 'xpath',
-            },
+            confirmation: '//button[@data-test, "dialog-save-button"]',
+            cancel: '//button[@data-test="dialog-cancel-button"]',
+
           },
         },
       },


### PR DESCRIPTION
This is to remove all unnecessary locateStrategy-object from securityServer -tests. Since we do have default locateStrategy of xpath, it doesn't need to be defined unless different strategy is explicitly used and elements can be saved in shorter format of `locatorAlias : locatorString`instead of 

``` 
locatorAlias: {
selector: locatorString,
locateStrategy: 'xpath'
},
``` 

This saves almost over thousand lines of code from pageobjects.

This is now done and all tests are passing:
https://jenkins.niis.org/view/api-based-ui/job/rest-ui-e2e-tests/900/