### PR TITLE
Ansible: Exclude gpghome from rsync

### DIFF
--- a/ansible/ss_cluster/roles/slave/tasks/main.yml
+++ b/ansible/ss_cluster/roles/slave/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: do initial configuration sync
   become_user: xroad
   become: yes
-  command: rsync -e "ssh -o StrictHostKeyChecking=no" -aqz --delete-delay --exclude "/db.properties" --exclude "/conf.d/node.ini" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/backup.d" "{{ xroad_slave_ssh_user }}@{{ master_host }}":/etc/xroad/ /etc/xroad/
+  command: rsync -e "ssh -o StrictHostKeyChecking=no" -aqz --delete-delay --exclude "/db.properties" --exclude "/conf.d/node.ini" --exclude "/gpghome" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/backup.d" "{{ xroad_slave_ssh_user }}@{{ master_host }}":/etc/xroad/ /etc/xroad/
 
 - name: install configuration sync
   include_tasks: "{{ ansible_distribution | lower }}.yml"

--- a/ansible/ss_cluster/roles/slave/templates/xroad-sync.conf.j2
+++ b/ansible/ss_cluster/roles/slave/templates/xroad-sync.conf.j2
@@ -9,6 +9,6 @@ pre-start script
 end script
 
 script
-  su -s /bin/sh -c 'exec "$0" "$@"' xroad -- rsync -e "ssh -o ConnectTimeout=5 " -aqz --timeout=10 --delete-delay --exclude db.properties --exclude "/conf.d/node.ini" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/globalconf" --exclude "/jetty" --delay-updates --log-file=/var/log/xroad/slave-sync.log ${XROAD_USER}@${MASTER}:/etc/xroad/ /etc/xroad/
+  su -s /bin/sh -c 'exec "$0" "$@"' xroad -- rsync -e "ssh -o ConnectTimeout=5 " -aqz --timeout=10 --delete-delay --exclude db.properties --exclude "/conf.d/node.ini" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/globalconf" --exclude "/gpghome" --exclude "/jetty" --delay-updates --log-file=/var/log/xroad/slave-sync.log ${XROAD_USER}@${MASTER}:/etc/xroad/ /etc/xroad/
 end script
 

--- a/ansible/ss_cluster/roles/slave/templates/xroad-sync.service.j2
+++ b/ansible/ss_cluster/roles/slave/templates/xroad-sync.service.j2
@@ -15,7 +15,7 @@ Environment=MASTER={{ master_host }}
 
 ExecStartPre=/usr/bin/test ! -f /var/tmp/xroad/sync-disabled
 
-ExecStart=/usr/bin/rsync -e "ssh -o ConnectTimeout=5 " -aqz --timeout=10 --delete-delay --exclude db.properties --exclude "/conf.d/node.ini" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/globalconf"  --exclude "/jetty" --exclude "/backup.d" --delay-updates --log-file=/var/log/xroad/slave-sync.log ${XROAD_USER}@${MASTER}:/etc/xroad/ /etc/xroad/
+ExecStart=/usr/bin/rsync -e "ssh -o ConnectTimeout=5 " -aqz --timeout=10 --delete-delay --exclude db.properties --exclude "/conf.d/node.ini" --exclude "*.tmp" --exclude "/postgresql" --exclude "/nginx" --exclude "/globalconf" --exclude "/gpghome" --exclude "/jetty" --exclude "/backup.d" --delay-updates --log-file=/var/log/xroad/slave-sync.log ${XROAD_USER}@${MASTER}:/etc/xroad/ /etc/xroad/
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Accordingly with [X-Road: External Load Balancer Installation Guide
](https://github.com/nordic-institute/X-Road/blob/develop/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md)