### PR TITLE
XRDSD-262: Update parameter name to correct one

### DIFF
--- a/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
+++ b/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
@@ -6,7 +6,7 @@
 
 **X-ROAD 7**
 
-Version: 2.68 
+Version: 2.69 
 Doc. ID: UG-SS
 
 ---
@@ -101,6 +101,7 @@ Doc. ID: UG-SS
  30.11.2021 | 2.66    | Added chapter about configuring account lockouts | Caro Hautamäki
  09.12.2021 | 2.67    | Added instructions for ensuring user account security | Ilkka Seppälä
  09.12.2021 | 2.68    | Updated chapter [22](#22-additional-security-hardening) and added information about password policies  | Caro Hautamäki
+ 13.04.2022 | 2.69    | Updated max loggable body size parameter name to correct one | Raido Kaju
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -1653,9 +1654,9 @@ For example, to configure the parameters `archive-path` and `archive-max-filesiz
   
 5.  `disabled-body-logging-remote-producer-subsystems` - when message-body-logging is set to true, this field contains the overrides for the remote producer subsystems.
 
-6.  `max-loggable-body-size` - the maximum REST message body size that will be written to the messagelog.
+6.  `max-loggable-message-body-size` - the maximum REST message body size that will be written to the messagelog.
 
-7.  `truncated-body-allowed` - if the REST message body size exceeds the max-loggable-body-size, truncate the body (true) or reject the message (false)
+7.  `truncated-body-allowed` - if the REST message body size exceeds the max-loggable-message-body-size truncate the body (true) or reject the message (false)
 
 8.  `messagelog-encryption-enabled` - if set to true, the message bodies are written to the database in an encrypted format
 

--- a/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
+++ b/doc/Manuals/ug-syspar_x-road_v6_system_parameters.md
@@ -1,6 +1,6 @@
 # X-Road: System Parameters User Guide
 
-Version: 2.64  
+Version: 2.65  
 Doc. ID: UG-SYSPAR
 
 | Date       | Version  | Description                                                                  | Author             |
@@ -74,6 +74,7 @@ Doc. ID: UG-SYSPAR
 | 25.08.2021 | 2.62     | Update X-Road references from version 6 to 7 | Caro Hautamäki |
 | 31.08.2021 | 2.63     | Update messagelog and proxy parameters | Ilkka Seppälä |
 | 05.10.2021 | 2.64     | Added a new chapter about custom command line arguments [6](#6-adding-command-line-arguments) | Caro Hautamäki
+| 13.04.2022 | 2.65     | Corrected message logging max body size parameter name | Raido Kaju
 
 ## Table of Contents
 
@@ -354,7 +355,7 @@ Proxy-ui has been removed in version 6.24 and it's parameters are not used anymo
 | timestamper-client-read-timeout                  | 60000                                      |   |   | The timestamper client read timeout in milliseconds. A timeout of zero is interpreted as an infinite timeout. |
 | timestamp-retry-delay                            | 60                                         |   |   | Time-stamp retry delay in seconds when batch time-stamping fails. After failing to batch time-stamp, the timestamper waits for the time period defined by "timestamp-retry-delay" before trying again. This is repeated until fetching a time-stamp succeeds. After successfully fetching a time-stamp, the timestamper returns to normal time-stamping schedule. If the value of "timestamp-retry-delay" is higher than the value of the central server system parameter "timeStampingIntervalSeconds", the value of "timeStampingIntervalSeconds" is used. If the value of "timestamp-retry-delay" is zero, the value of "timeStampingIntervalSeconds" is used. |
 | archive-transaction-batch                        | 10000                                      |   |   | Size of transaction batch for archiving messagelog. This size is not exact because it will always make sure that last archived batch includes timestamp also (this might mean that it will go over transaction size). |
-| max-loggable-body-size                           | 10485760 (10 MiB)                          |   |   | Maximum loggable REST message body size |
+| max-loggable-message-body-size                   | 10485760 (10 MiB)                          |   |   | Maximum loggable REST message body size |
 | truncated-body-allowed                           | false                                      |   |   | If the REST message body exceeds the maximum loggable body size, truncate the body in the log (true) or reject the message (false). |
 | clean-transaction-batch                          | 10000                                      |   |   | Maximun number of log records to remove in one transaction. |
 | archive-grouping                                 | none                                       |   |   | Archive file grouping, one of 'none', 'member' (group by member), 'subsystem' (group by subsystem).


### PR DESCRIPTION
Updated incorrect parameter name `max-loggable-body-size` to `max-loggable-message-body-size`.