### PR TITLE
XRDDEV-2021 - Update GSON to 2.9.0

### DIFF
--- a/src/common-test/build.gradle
+++ b/src/common-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'org.antlr:ST4:4.0.7'
     // JUnit is needed for ExpectedCodedException
     implementation 'junit:junit:4.13.2'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
     api "org.mockito:mockito-core:$mockitoVersion"
 }
 

--- a/src/common-util/build.gradle
+++ b/src/common-util/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
-    api 'com.google.code.gson:gson:2.8.7'
+    api 'com.google.code.gson:gson:2.9.0'
     api "com.google.guava:guava:$guavaVersion"
 
     api ('org.quartz-scheduler:quartz:2.3.2') {


### PR DESCRIPTION
Related to CVE-2022-25647 vulnerability which doesn't concern X-Road source code as it doesn't utilize any of the following structures:
- com.google.gson.internal.LazilyParsedNumber
- com.google.gson.internal.LinkedHashTreeMap
- com.google.gson.internal.LinkedTreeMap