### PR TITLE
XRDDEV-2014 - Fix an issue caused by a dependency diversion introduced by XRDDEV-2014

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/control
+++ b/src/packages/src/xroad/ubuntu/generic/control
@@ -86,7 +86,9 @@ Description: X-Road configuration proxy
 
 Package: xroad-addon-hwtokens
 Architecture: all
-Depends: ${misc:Depends}, xroad-base (=${binary:Version}), xroad-confclient (=${binary:Version}), xroad-signer (=${binary:Version})
+# This `xroad-signer` "Depends"->"Pre-Depends" change was required to fix an issue caused by a dependency diversion from xroad-signer to xroad-addon-hwtokens in 7.1.0
+Pre-Depends: xroad-signer (=${binary:Version})
+Depends: ${misc:Depends}, xroad-base (=${binary:Version}), xroad-confclient (=${binary:Version})
 Description: X-Road AddOn: hwtokens
  AddOn for hardware tokens
 


### PR DESCRIPTION
`libpkcs11wrapper.so` was moved from `xroad-signer` to `xroad-addon-hwtokens`