### PR TITLE
XRDDEV-2014 - Provide a better solution to fix an issue caused by a dependency diversion introduced by XRDDEV-2014

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/control
+++ b/src/packages/src/xroad/ubuntu/generic/control
@@ -86,9 +86,10 @@ Description: X-Road configuration proxy
 
 Package: xroad-addon-hwtokens
 Architecture: all
-# This `xroad-signer` "Depends"->"Pre-Depends" change was required to fix an issue caused by a dependency diversion from xroad-signer to xroad-addon-hwtokens in 7.1.0
-Pre-Depends: xroad-signer (=${binary:Version})
-Depends: ${misc:Depends}, xroad-base (=${binary:Version}), xroad-confclient (=${binary:Version})
+# These following 2 package relationship changes were required to fix an issue caused by a file dependency diversion from xroad-signer to xroad-addon-hwtokens in 7.1.0
+Replaces: xroad-signer (<< 7.1.0)
+Breaks: xroad-signer (<< 7.1.0)
+Depends: ${misc:Depends}, xroad-base (=${binary:Version}), xroad-confclient (=${binary:Version}), xroad-signer (=${binary:Version})
 Description: X-Road AddOn: hwtokens
  AddOn for hardware tokens
 


### PR DESCRIPTION
Use `Replaces` and `Breaks` instead of `Pre-Depends`.

`libpkcs11wrapper.so` was moved from `xroad-signer` to `xroad-addon-hwtokens`