### PR TITLE
Extend pause time for trust services test case

### DIFF
--- a/src/centralserver/admin-ui/tests/e2e/specs/070-trust-services.js
+++ b/src/centralserver/admin-ui/tests/e2e/specs/070-trust-services.js
@@ -75,7 +75,7 @@ module.exports = {
 
     browser
       .waitForElementVisible(trustServicesPage.elements.successSnackBar)
-      .pause(1000);
+      .pause(5 * 1000);
     const certificationServices =
       await certificationServicesSection.getCertificationServices();
     browser.assert.ok(


### PR DESCRIPTION
Extend pause time for trust services test case, so that the element calculation would be correct