### PR TITLE
XRDDEV-2022 Add content-length header by server proxy

### DIFF
--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerRestMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerRestMessageProcessor.java
@@ -556,7 +556,8 @@ class ServerRestMessageProcessor extends MessageProcessorBase {
             }
 
             if (req instanceof HttpEntityEnclosingRequest && requestProxyMessage.hasRestBody()) {
-                ((HttpEntityEnclosingRequest) req).setEntity(new InputStreamEntity(requestProxyMessage.getRestBody()));
+                ((HttpEntityEnclosingRequest) req).setEntity(new InputStreamEntity(requestProxyMessage.getRestBody(),
+                        requestProxyMessage.getRestBody().size()));
             }
 
             final HttpContext ctx = new BasicHttpContext();

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -120,6 +120,23 @@ public class RestProxyTest extends AbstractProxyIntegrationTest {
     }
 
     @Test
+    public void shouldHaveContentLengthHeader() {
+        String body = "{\"value\" : 42}";
+        service.setHandler((target, request, response) -> assertEquals(body.getBytes().length,
+                request.getContentLength()));
+
+        given()
+                .baseUri("http://127.0.0.1")
+                .port(proxyClientPort)
+                .header("Content-Type", "application/json")
+                .header("X-Road-Client", "EE/BUSINESS/consumer/sub")
+                .body(body)
+                .post(PREFIX + "/EE/BUSINESS/producer/sub/echo")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
     public void requestHashShouldBeUnique() {
         final String qid = "queryid";
         final String requestHash = given()


### PR DESCRIPTION
- Add content-length header based on message body size to the requests that are sent to service provider information system by server proxy.
- Update integrations tests.

JIRA: https://nordic-institute.atlassian.net/browse/XRDDEV-2022