### PR TITLE
XRDDEV-2117 Fix file missing from global conf bug

### DIFF
--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectory.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectory.java
@@ -46,6 +46,7 @@ import java.util.Set;
  * Configuration directory interface.
  */
 public interface ConfigurationDirectory {
+    String FILES = "files";
     String METADATA_SUFFIX = ".metadata";
     String INSTANCE_IDENTIFIER_FILE = "instance-identifier";
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -49,7 +49,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static ee.ria.xroad.common.ErrorCodes.X_INTERNAL_ERROR;
-import static ee.ria.xroad.common.ErrorCodes.X_MALFORMED_GLOBALCONF;
 import static ee.ria.xroad.common.conf.globalconf.ConfigurationUtils.escapeInstanceIdentifier;
 
 /**
@@ -180,17 +179,14 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
     }
 
     protected List<Path> getConfigurationFiles() throws Exception {
-        List<Path> configurationFiles = excludeMetadataAndDirs(Files.walk(path));
-        if (configurationFiles.isEmpty()) {
-            throw new CodedException(X_MALFORMED_GLOBALCONF, "No configuration files found");
-        }
-        return configurationFiles;
+        return excludeMetadataAndDirs(Files.walk(path));
     }
 
     private List<Path> excludeMetadataAndDirs(Stream<Path> stream) {
         return stream.filter(Files::isRegularFile)
                 .filter(p -> !p.endsWith(ConfigurationDirectory.INSTANCE_IDENTIFIER_FILE))
                 .filter(p -> !p.toString().endsWith(ConfigurationDirectory.METADATA_SUFFIX))
+                .filter(p -> p.toString().equals("files"))
                 .collect(Collectors.toList());
     }
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -184,9 +184,9 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
 
     private List<Path> excludeMetadataAndDirs(Stream<Path> stream) {
         return stream.filter(Files::isRegularFile)
-                .filter(p -> !p.endsWith(ConfigurationDirectory.INSTANCE_IDENTIFIER_FILE))
+                .filter(p -> !p.toString().endsWith(ConfigurationDirectory.FILES))
+                .filter(p -> !p.toString().endsWith(ConfigurationDirectory.INSTANCE_IDENTIFIER_FILE))
                 .filter(p -> !p.toString().endsWith(ConfigurationDirectory.METADATA_SUFFIX))
-                .filter(p -> !p.getFileName().toString().equals(ConfigurationDirectory.FILES))
                 .collect(Collectors.toList());
     }
 

--- a/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -186,7 +186,7 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
         return stream.filter(Files::isRegularFile)
                 .filter(p -> !p.endsWith(ConfigurationDirectory.INSTANCE_IDENTIFIER_FILE))
                 .filter(p -> !p.toString().endsWith(ConfigurationDirectory.METADATA_SUFFIX))
-                .filter(p -> p.toString().equals("files"))
+                .filter(p -> !p.getFileName().toString().equals(ConfigurationDirectory.FILES))
                 .collect(Collectors.toList());
     }
 

--- a/src/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
+++ b/src/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
@@ -30,6 +30,9 @@ import ee.ria.xroad.common.util.ExpectedCodedException;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.nio.file.Path;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -94,5 +97,43 @@ public class ConfigurationDirectoryTest {
 
         assertNull(dir.getPrivate("foo"));
         assertNull(dir.getShared("foo"));
+    }
+
+    /**
+     * Test to ensure that the list of available configuration files excluding metadata and directories
+     * is read properly.
+     *
+     * @throws Exception in case of any unexpected errors
+     */
+    @Test
+    public void readConfigurationFilesV2() throws Exception {
+        String rootDir = "src/test/resources/globalconf_good_v2";
+        ConfigurationDirectoryV2 dir = new ConfigurationDirectoryV2(rootDir);
+
+        List<Path> configurationFiles = dir.getConfigurationFiles();
+
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/instance-identifier"));
+
+        assertEquals(true, pathExists(configurationFiles, rootDir + "/bar/shared-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/bar/shared-params.xml.metadata"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/bar/private-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/bar/private-params.xml.metadata"));
+
+        assertEquals(true, pathExists(configurationFiles, rootDir + "/EE/shared-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/EE/shared-params.xml.metadata"));
+        assertEquals(true, pathExists(configurationFiles, rootDir + "/EE/private-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/EE/private-params.xml.metadata"));
+
+        assertEquals(true, pathExists(configurationFiles, rootDir + "/foo/shared-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/foo/shared-params.xml.metadata"));
+        assertEquals(true, pathExists(configurationFiles, rootDir + "/foo/private-params.xml"));
+        assertEquals(false, pathExists(configurationFiles, rootDir + "/foo/private-params.xml.metadata"));
+    }
+
+    private boolean pathExists(List<Path> paths, String path) {
+        return null != paths.stream()
+                .filter(p -> (p.getParent() + "/" + p.getFileName()).equals(path))
+                .findAny()
+                .orElse(null);
     }
 }

--- a/src/packages/src/xroad/redhat/SPECS/xroad-confclient.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-confclient.spec
@@ -93,6 +93,13 @@ chmod 0775 /var/lib/xroad
 chown -R xroad:xroad /etc/xroad/services/* /etc/xroad/conf.d/*
 chmod -R o=rwX,g=rX,o= /etc/xroad/services/* /etc/xroad/conf.d/*
 
+if [ $1 -gt 1 ] ; then
+    # upgrade
+    if [ -e /etc/xroad/globalconf/files ]; then
+        rm -f /etc/xroad/globalconf/files
+    fi
+fi
+
 %systemd_post xroad-confclient.service
 
 %preun

--- a/src/packages/src/xroad/ubuntu/generic/xroad-confclient.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-confclient.postinst
@@ -4,6 +4,7 @@ umask 027
 if [ "$1" = configure ]; then
     chown xroad:xroad /etc/xroad/backup.d/??_xroad-confclient
     chmod 0440 /etc/xroad/backup.d/??_xroad-confclient
+    test -e /etc/xroad/globalconf/files && rm -f /etc/xroad/globalconf/files
 fi
 
 if [ "$1" = abort-upgrade ]; then


### PR DESCRIPTION
- Fix the file 'files' is missing from global configuration by generating the file list dynamically when requested.
- Remove the existing `/etc/xroad/globalconf/files` file on configuration client upgrade.
- Update unit tests.
- The bug was originally created by the refactoring task implemented in commit e3e5312e4ad4a5083ab3aae3e84bbeb732b0e193.
- The logic to generate the file list dynamically was taken from [here](https://github.com/nordic-institute/X-Road/blob/d07dfeb774a50c60d7dee1523afd5efefbdd3930/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/DownloadedFiles.java#L79-L84).

JIRA: https://nordic-institute.atlassian.net/browse/XRDDEV-2117