### PR TITLE
Xrddev 2130

### DIFF
--- a/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
+++ b/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
@@ -30,11 +30,13 @@ import com.codeborne.selenide.Selenide;
 import io.cucumber.java.en.Given;
 import org.openqa.selenium.By;
 
+import java.time.Duration;
+
 import static com.codeborne.selenide.Selenide.$;
 
 public class CommonUiStepDefs extends BaseUiStepDefs {
     public static final By BTN_CLOSE_SNACKBAR = By.xpath("//button[@data-test=\"close-snackbar\"]");
-    public static final int MILLISECONDS_IN_SECOND = 1000;
+    public static final int MAX_WAIT_IN_SECONDS = 120;
 
     @Given("logout button is being clicked")
     public void logoutButtonIsClicked() {
@@ -44,18 +46,16 @@ public class CommonUiStepDefs extends BaseUiStepDefs {
                 .click();
     }
 
-    @Given("{int} seconds of inactivity is passed")
-    public void secondsOfInactivityIsPassed(Integer int1) {
-
-        Selenide.sleep(int1 * MILLISECONDS_IN_SECOND);
-
+    @Given("User becomes idle")
+    public void userBecomesIdle() {
+        Selenide.sleep(1);
     }
 
 
-    @Given("Error message about timeout appears")
+    @Given("after 120 seconds, session timeout popup appears")
     public void errorMessageAboutTimeoutAppears() {
         $(By.xpath("//button[@data-test='session-expired-ok-button']"))
-                .shouldBe(Condition.visible);
+                .shouldBe(Condition.visible, Duration.ofSeconds(MAX_WAIT_IN_SECONDS));
 
     }
 

--- a/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
+++ b/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
@@ -61,6 +61,46 @@ public class CommonUiStepDefs extends BaseUiStepDefs {
                 .click();
     }
 
+    @Given("Error message for incorrect credentials is shown")
+    public void errorMessageIsShown() {
+
+        $(By.xpath("//div[text()[contains(.,'Wrong username or password')]]"))
+                .shouldBe(Condition.visible, Duration.ofSeconds(20));
+    }
+
+     @Given("logout button is being clicked")
+        public void logoutButtonIsClicked() {
+         $(By.xpath("//button[@data-test='username-button']"))
+                        .shouldBe(Condition.visible)
+                        .shouldBe(Condition.enabled)
+                        .click();
+        }
+
+     @Given("{int} seconds of inactivity is passed")
+        public void seconds_of_inactivity_is_passed(Integer int1) {
+        try
+        {
+            Thread.sleep(int1 * 1000);
+        }
+        catch(InterruptedException e) {}
+        }
+
+
+    @Given("Error message about timeout appears")
+    public void error_message_about_timeout_appears() {
+        $(By.xpath("//button[@data-test='session-expired-ok-button']"))
+            .shouldBe(Condition.visible);
+
+    }
+
+     @Given("OK is clicked on timeout notification popup")
+    public void ok_is_clicked_on_timeout_notification_popup() {
+      $(By.xpath("//button[@data-test='session-expired-ok-button']"))
+            .shouldBe(Condition.visible)
+            .shouldBe(Condition.enabled)
+            .click();
+    }
+
     @Given("Page is prepared to be tested")
     public void preparePage() {
         Selenide.executeJavaScript("window.e2eTestingMode = true;\n"

--- a/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
+++ b/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/CommonUiStepDefs.java
@@ -30,42 +30,41 @@ import com.codeborne.selenide.Selenide;
 import io.cucumber.java.en.Given;
 import org.openqa.selenium.By;
 
-import java.time.Duration;
-
 import static com.codeborne.selenide.Selenide.$;
 
 public class CommonUiStepDefs extends BaseUiStepDefs {
     public static final By BTN_CLOSE_SNACKBAR = By.xpath("//button[@data-test=\"close-snackbar\"]");
+    public static final int MILLISECONDS_IN_SECOND = 1000;
 
-     @Given("logout button is being clicked")
-        public void logoutButtonIsClicked() {
-         $(By.xpath("//button[@data-test='username-button']"))
-                        .shouldBe(Condition.visible)
-                        .shouldBe(Condition.enabled)
-                        .click();
-        }
+    @Given("logout button is being clicked")
+    public void logoutButtonIsClicked() {
+        $(By.xpath("//button[@data-test='username-button']"))
+                .shouldBe(Condition.visible)
+                .shouldBe(Condition.enabled)
+                .click();
+    }
 
-     @Given("{int} seconds of inactivity is passed")
-        public void seconds_of_inactivity_is_passed(Integer int1) {
+    @Given("{int} seconds of inactivity is passed")
+    public void secondsOfInactivityIsPassed(Integer int1) {
 
-            Selenide.sleep(int1 * 1000);
-
-        }
-
-
-    @Given("Error message about timeout appears")
-    public void error_message_about_timeout_appears() {
-        $(By.xpath("//button[@data-test='session-expired-ok-button']"))
-            .shouldBe(Condition.visible);
+        Selenide.sleep(int1 * MILLISECONDS_IN_SECOND);
 
     }
 
-     @Given("OK is clicked on timeout notification popup")
-    public void ok_is_clicked_on_timeout_notification_popup() {
-      $(By.xpath("//button[@data-test='session-expired-ok-button']"))
-            .shouldBe(Condition.visible)
-            .shouldBe(Condition.enabled)
-            .click();
+
+    @Given("Error message about timeout appears")
+    public void errorMessageAboutTimeoutAppears() {
+        $(By.xpath("//button[@data-test='session-expired-ok-button']"))
+                .shouldBe(Condition.visible);
+
+    }
+
+    @Given("OK is clicked on timeout notification popup")
+    public void okIsClickedOnTimeoutNotificationPopup() {
+        $(By.xpath("//button[@data-test='session-expired-ok-button']"))
+                .shouldBe(Condition.visible)
+                .shouldBe(Condition.enabled)
+                .click();
     }
 
     @Given("Page is prepared to be tested")

--- a/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/FrontPageStepDefs.java
+++ b/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/FrontPageStepDefs.java
@@ -36,6 +36,7 @@ import static com.codeborne.selenide.Selenide.$;
 
 public class FrontPageStepDefs extends BaseUiStepDefs {
     public static final By BTN_CLOSE_SNACKBAR = By.xpath("//button[@data-test=\"close-snackbar\"]");
+    public static final int WAIT_DURATION = 20;
 
     @Given("SecurityServer login page is open")
     public void openPage() {
@@ -64,7 +65,7 @@ public class FrontPageStepDefs extends BaseUiStepDefs {
     @Given("Error message for incorrect credentials is shown")
     public void errorMessageIsShown() {
         $(By.xpath("//div[text()[contains(.,'Wrong username or password')]]"))
-                .shouldBe(Condition.visible, Duration.ofSeconds(20));
+                .shouldBe(Condition.visible, Duration.ofSeconds(WAIT_DURATION));
     }
 
 }

--- a/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/FrontPageStepDefs.java
+++ b/src/e2e-tests/src/intTest/java/org/niis/xroad/test/ui/glue/FrontPageStepDefs.java
@@ -34,50 +34,37 @@ import java.time.Duration;
 
 import static com.codeborne.selenide.Selenide.$;
 
-public class CommonUiStepDefs extends BaseUiStepDefs {
+public class FrontPageStepDefs extends BaseUiStepDefs {
     public static final By BTN_CLOSE_SNACKBAR = By.xpath("//button[@data-test=\"close-snackbar\"]");
 
-     @Given("logout button is being clicked")
-        public void logoutButtonIsClicked() {
-         $(By.xpath("//button[@data-test='username-button']"))
-                        .shouldBe(Condition.visible)
-                        .shouldBe(Condition.enabled)
-                        .click();
-        }
-
-     @Given("{int} seconds of inactivity is passed")
-        public void seconds_of_inactivity_is_passed(Integer int1) {
-
-            Selenide.sleep(int1 * 1000);
-
-        }
-
-
-    @Given("Error message about timeout appears")
-    public void error_message_about_timeout_appears() {
-        $(By.xpath("//button[@data-test='session-expired-ok-button']"))
-            .shouldBe(Condition.visible);
-
+    @Given("SecurityServer login page is open")
+    public void openPage() {
+        Selenide.open(testProperties.getSecurityServerUrl());
     }
 
-     @Given("OK is clicked on timeout notification popup")
-    public void ok_is_clicked_on_timeout_notification_popup() {
-      $(By.xpath("//button[@data-test='session-expired-ok-button']"))
-            .shouldBe(Condition.visible)
-            .shouldBe(Condition.enabled)
-            .click();
+    @Given("User {} logs in to SecurityServer with password {}")
+    public void doLogin(final String username, final String password) {
+
+        $(By.xpath("//div[@id='app']"))
+                .shouldBe(Condition.visible, Duration.ofSeconds(1));
+
+        $(By.id("username"))
+                .shouldBe(Condition.visible)
+                .setValue(username);
+        $(By.id("password"))
+                .shouldBe(Condition.visible)
+                .setValue(password);
+
+        $(By.id("submit-button"))
+                .shouldBe(Condition.visible)
+                .shouldBe(Condition.enabled)
+                .click();
     }
 
-    @Given("Page is prepared to be tested")
-    public void preparePage() {
-        Selenide.executeJavaScript("window.e2eTestingMode = true;\n"
-                + "      const style = `\n"
-                + "      <style>\n"
-                + "        *, ::before, ::after {\n"
-                + "            transition:none !important;\n"
-                + "        }\n"
-                + "      </style>`;\n"
-                + "      document.head.insertAdjacentHTML('beforeend', style);");
+    @Given("Error message for incorrect credentials is shown")
+    public void errorMessageIsShown() {
+        $(By.xpath("//div[text()[contains(.,'Wrong username or password')]]"))
+                .shouldBe(Condition.visible, Duration.ofSeconds(20));
     }
 
 }

--- a/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogin.feature
+++ b/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogin.feature
@@ -1,0 +1,23 @@
+@SecurityServer
+@Login
+
+Feature: It is possible to login to secure site via frontpage
+
+  Background:
+    Given SecurityServer login page is open
+    And Page is prepared to be tested
+
+  Scenario: Correct password and username grant access
+    When User xrd logs in to SecurityServer with password secret
+    Then Clients tab is selected
+
+  Scenario: Invalid password is rejected
+    When User xrd logs in to SecurityServer with password INVALID
+    Then Error message for incorrect credentials is shown
+    And SecurityServer login page is open
+
+  Scenario: Invalid username is rejected
+    When User INVALID logs in to SecurityServer with password secret
+    Then Error message for incorrect credentials is shown
+    And SecurityServer login page is open
+

--- a/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogout.feature
+++ b/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogout.feature
@@ -1,0 +1,19 @@
+@SecurityServer
+@Logout
+Feature: It is possible to login to secure site via frontpage
+
+  Background:
+    Given SecurityServer login page is open
+    And Page is prepared to be tested
+    And User xrd logs in to SecurityServer with password secret
+
+  Scenario: User is able to log out from security server
+    When logout button is being clicked
+    Then SecurityServer login page is open
+
+  Scenario: Automatic logout happens when timeout passes
+    When 120 seconds of inactivity is passed
+    Then Error message about timeout appears
+    When OK is clicked on timeout notification popup
+    Then  SecurityServer login page is open
+

--- a/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogout.feature
+++ b/src/e2e-tests/src/intTest/resources/behavior/ui/ssLogout.feature
@@ -12,8 +12,8 @@ Feature: It is possible to login to secure site via frontpage
     Then SecurityServer login page is open
 
   Scenario: Automatic logout happens when timeout passes
-    When 120 seconds of inactivity is passed
-    Then Error message about timeout appears
+    When User becomes idle
+    Then after 120 seconds, session timeout popup appears
     When OK is clicked on timeout notification popup
     Then  SecurityServer login page is open
 


### PR DESCRIPTION
I am trying to recreate tests from Nightwatch to new stack and here are results regarding login and logout suites.

Most obvious issues:
-  I made steps to file `CommonUIStepDefs.java`, I see that naming scheme refers it as "commonUI", which in my understanding refers to pages before login. Now issue is that in logout case, functionalities refering to elements after login (namely session timeout popup and logout-button) are also inside of CommonUIsteps, which is bit incorrrect location-wise, although they seem to work.
- I have understanding that ```@Given("Something is done)```  in step definitions should match usecase in feature-files, eg. if we use it as "Given" then it's created with "Given" step definitions. However, this doesn't seem work, if I use "Then" tests fail on error. 
- Issue is that when you run undefined steps, error log is kind enough to output you basic code create snippet with exception and they really generated with "Then" and "When" respectively, it which doesn't work in my tests - hence i might have missed something semantics of how these steps are supposed to work.
- There is also artificial wait period created to account for inactivity in session timeout -case, it might be better to come up with dynamic wait so there wouldn't be such overhead and safety margin that is taken everytime when test is run. I am not completely sure how to make that syntax wise.
- Might also be worthwhile to explore possibility to make common browser-session for all tests, since now browser is closed and reopened for each case generating large overhead timewise where we just wait for browser to open. In permission tests, this same issue is even more prominent since there is login sequence before each test as well.