### PR TITLE
XRDDEV-2160: Deprecate SkEsteIdCertificateProfileInfoProvider and related tests

### DIFF
--- a/src/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteIdCertificateProfileInfoProvider.java
+++ b/src/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteIdCertificateProfileInfoProvider.java
@@ -45,7 +45,12 @@ import java.security.cert.X509Certificate;
 
 /**
  * Certificate profile for SK ESTEID.
+ *
+ * @deprecated
+ * No longer used to the best of our knowledge, deprecated as of X-Road 7.2.0.
+ * Will be removed in a future version.
  */
+@Deprecated
 public class SkEsteIdCertificateProfileInfoProvider
         implements CertificateProfileInfoProvider {
 

--- a/src/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteidCertificateProfileInfoProviderTest.java
+++ b/src/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteidCertificateProfileInfoProviderTest.java
@@ -40,7 +40,12 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the implementation of SkEsteidCertificateProfileInfoProvider.
+ *
+ * @deprecated
+ * No longer used to the best of our knowledge, deprecated as of X-Road 7.2.0.
+ * Will be removed in a future version.
  */
+@Deprecated
 public class SkEsteidCertificateProfileInfoProviderTest {
 
     /**

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityServiceTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityServiceTest.java
@@ -88,6 +88,8 @@ public class CertificateAuthorityServiceTest extends AbstractServiceTestContext 
         List<ApprovedCAInfo> approvedCAInfos = new ArrayList<>();
         approvedCAInfos.add(new ApprovedCAInfo("fi-not-auth-only", false,
                 "ee.ria.xroad.common.certificateprofile.impl.FiVRKCertificateProfileInfoProvider"));
+        // @deprecated The {@link SkEsteIdCertificateProfileInfoProvider} profile has been marked deprecated starting
+        // from X-Road 7.2.0 and will be removed in a future version. This test should then also be cleaned up.
         approvedCAInfos.add(new ApprovedCAInfo("est-auth-only", true,
                 "ee.ria.xroad.common.certificateprofile.impl.SkEsteIdCertificateProfileInfoProvider"));
         approvedCAInfos.add(new ApprovedCAInfo("mock-top-ca", false,


### PR DESCRIPTION
Marking anything related to the SkEsteIdCertificateProfileInfoProvider as deprecated. 