### PR TITLE
Xrddev 2217 Make healthcheck endpoint not return jetty version in header

### DIFF
--- a/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
+++ b/doc/Manuals/LoadBalancing/ig-xlb_x-road_external_load_balancer_installation_guide.md
@@ -420,7 +420,6 @@ this node:
 $ curl -i localhost:5588
    HTTP/1.1 200 OK
    Content-Length: 0
-   Server: Jetty(8.y.z-SNAPSHOT)
 ```
 
 And a health check service response on the same node when the service `xroad-signer` is not running:
@@ -428,7 +427,6 @@ And a health check service response on the same node when the service `xroad-sig
 $ curl -i localhost:5588
 HTTP/1.1 500 Server Error
 Transfer-Encoding: chunked
-Server: Jetty(8.y.z-SNAPSHOT)
 
 Fetching health check response timed out for: Authentication key OCSP status
 ```

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
@@ -31,6 +31,8 @@ import ee.ria.xroad.common.util.StartStop;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -63,7 +65,6 @@ public class HealthCheckPort implements StartStop {
     private static final int THREAD_POOL_SIZE = 8;
     private static final int ACCEPTOR_THREAD_COUNT = 1;
     private static final int SELECTOR_THREAD_COUNT = 1;
-    private static final int SO_LINGER = -1; //disable linger
 
     private final Server server;
     private final StoppableHealthCheckProvider stoppableHealthCheckProvider;
@@ -88,13 +89,15 @@ public class HealthCheckPort implements StartStop {
     }
 
     private void createHealthCheckConnector() {
-
-        ServerConnector connector = new ServerConnector(server, ACCEPTOR_THREAD_COUNT, SELECTOR_THREAD_COUNT);
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setSendServerVersion(false);
+        HttpConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfiguration);
+        ServerConnector connector = new ServerConnector(server, ACCEPTOR_THREAD_COUNT, SELECTOR_THREAD_COUNT,
+                                                        connectionFactory);
         connector.setName("HealthCheckPort");
         connector.setHost(SystemProperties.getHealthCheckInterface());
         connector.setPort(portNumber);
         connector.setIdleTimeout(SOCKET_MAX_IDLE_MILLIS);
-        connector.setSoLingerTime(SO_LINGER);
         server.addConnector(connector);
 
         HandlerCollection handlerCollection = new HandlerCollection();


### PR DESCRIPTION
https://nordic-institute.atlassian.net/browse/XRDDEV-2217

Also removed socket linger time from the connector since it's deprecated at not used anymore in jetty 9