### PR TITLE
fix: add strict liquibase jar selector

### DIFF
--- a/src/packages/src/xroad/common/base/usr/share/xroad/db/liquibase.sh
+++ b/src/packages/src/xroad/common/base/usr/share/xroad/db/liquibase.sh
@@ -20,34 +20,13 @@ if [ ! -n "${LIQUIBASE_HOME+x}" ]; then
 
   # make it fully qualified
   LIQUIBASE_HOME=`cd "$LIQUIBASE_HOME" && pwd`
-  # echo "Liquibase Home: $LIQUIBASE_HOME"
 fi
 
-
-# build classpath from all jars in lib
-if [ -f /usr/bin/cygpath ]; then
-  CP=.
-  for i in "$LIQUIBASE_HOME"/liquibase*.jar; do
-    i=`cygpath --windows "$i"`
-    CP="$CP;$i"
-  done
-  for i in "$LIQUIBASE_HOME"/lib/*.jar; do
-    i=`cygpath --windows "$i"`
-    CP="$CP;$i"
-  done
-else
-  CP=.
-  for i in "$LIQUIBASE_HOME"/liquibase*.jar; do
-    CP="$CP":"$i"
-  done
-  for i in "$LIQUIBASE_HOME"/lib/*.jar; do
-    CP="$CP":"$i"
-  done
-fi
-
+CLASSPATH=/usr/share/xroad/db/liquibase-core.jar
 # add any JVM options here
 JAVA_OPTS="${JAVA_OPTS-}"
 
-java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+echo "Liquibase Home: $LIQUIBASE_HOME"
+java -cp "$CLASSPATH" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
 
 

--- a/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
@@ -52,6 +52,7 @@ mkdir -p %{buildroot}/etc/xroad/backup.d
 
 ln -s /usr/share/xroad/jlib/common-db-1.0.jar %{buildroot}/usr/share/xroad/jlib/common-db.jar
 ln -s /usr/share/xroad/jlib/postgresql-42.5.2.jar %{buildroot}/usr/share/xroad/jlib/postgresql.jar
+ln -s /usr/share/xroad/db/liquibase-core-4.19.0.jar %{buildroot}/usr/share/xroad/db/liquibase-core.jar
 
 cp -p %{_sourcedir}/base/xroad-base.service %{buildroot}%{_unitdir}
 cp -p %{srcdir}/../../../common-db/build/libs/common-db-1.0.jar %{buildroot}/usr/share/xroad/jlib/

--- a/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
@@ -96,7 +96,8 @@ rm -rf %{buildroot}
 /usr/share/xroad/scripts/serverconf_migrations/add_acl.xsl
 /usr/share/xroad/scripts/_setup_db.sh
 /usr/share/xroad/scripts/xroad-base.sh
-/usr/share/xroad/db/liquibase-core-4.19.0.jar
+/usr/share/xroad/db/liquibase-core.jar
+/usr/share/xroad/db/liquibase-core-*.jar
 /usr/share/xroad/db/liquibase.sh
 %doc /usr/share/doc/%{name}/LICENSE.txt
 %doc /usr/share/doc/%{name}/3RD-PARTY-NOTICES.txt

--- a/src/packages/src/xroad/ubuntu/generic/xroad-base.links
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-base.links
@@ -1,2 +1,3 @@
 usr/share/xroad/jlib/common-db-1.0.jar usr/share/xroad/jlib/common-db.jar
 usr/share/xroad/jlib/postgresql-42.5.2.jar usr/share/xroad/jlib/postgresql.jar
+usr/share/xroad/db/liquibase-core-4.19.0.jar usr/share/xroad/db/liquibase-core.jar


### PR DESCRIPTION
liquibase.sh was capable of selecting multiple jars to use. This is not intended behavior as single jar is sufficient. This simplifies selection process and makes it safer.

Refs: XRDDEV-2283