### PR TITLE
feat: API for getting the details of an authentication certificate related to a Security Server

### DIFF
--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SecurityServersApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SecurityServersApiController.java
@@ -27,7 +27,6 @@
 package org.niis.xroad.cs.admin.rest.api.openapi;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.NotImplementedException;
 import org.niis.xroad.cs.admin.api.exception.ErrorMessage;
 import org.niis.xroad.cs.admin.api.exception.NotFoundException;
 import org.niis.xroad.cs.admin.api.service.SecurityServerService;
@@ -37,7 +36,6 @@ import org.niis.xroad.cs.admin.rest.api.converter.SecurityServerConverter;
 import org.niis.xroad.cs.admin.rest.api.converter.db.ClientDtoConverter;
 import org.niis.xroad.cs.admin.rest.api.converter.db.SecurityServerDtoConverter;
 import org.niis.xroad.cs.openapi.SecurityServersApi;
-import org.niis.xroad.cs.openapi.model.CertificateDetailsDto;
 import org.niis.xroad.cs.openapi.model.ClientDto;
 import org.niis.xroad.cs.openapi.model.PagedSecurityServersDto;
 import org.niis.xroad.cs.openapi.model.PagingSortingParametersDto;
@@ -126,11 +124,6 @@ public class SecurityServersApiController implements SecurityServersApi {
                 .map(securityServerDtoConverter::toDto)
                 .map(ResponseEntity::ok)
                 .getOrElseThrow(() -> new NotFoundException(SECURITY_SERVER_NOT_FOUND));
-    }
-
-    @Override
-    public ResponseEntity<CertificateDetailsDto> getSecurityServerAuthCert(String id, Integer certificateId) {
-        throw new NotImplementedException("getSecurityServerAuthCert not implemented yet");
     }
 
     @Override

--- a/src/central-server/openapi-model/src/main/resources/openapi-definition.yaml
+++ b/src/central-server/openapi-model/src/main/resources/openapi-definition.yaml
@@ -2797,46 +2797,6 @@ paths:
       summary: delete a security server's authentication certificate
       tags:
         - security-servers
-    get:
-      description: <h3>CS administrator views a Security Server's authentication certificate.</h3>
-      operationId: getSecurityServerAuthCert
-      parameters:
-        - description: id of the security server
-          in: path
-          name: id
-          required: true
-          schema:
-            format: text
-            maxLength: 1023
-            minLength: 1
-            type: string
-        - description: unique identifier of the certificate
-          in: path
-          name: certificateId
-          required: true
-          schema:
-            format: int32
-            type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CertificateDetails'
-          description: auth cert
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-      summary: get a security server's authentication certificate
-      tags:
-        - security-servers
   /security-servers/{id}/clients:
     get:
       description: <h3>CS administrator views a Security Server's clients.</h3>


### PR DESCRIPTION
Removed the get security server authentication certificate detail endpoint as this was not needed. The list query already returned all the required information.

Refs: XRDDEV-2260