### PR TITLE
fix: configuration signing keys lookup by tokenId replaced to search …

### DIFF
--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationSigningKeysService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationSigningKeysService.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.cs.admin.api.service;
 
+import ee.ria.xroad.signer.protocol.dto.TokenInfo;
+
 import org.niis.xroad.cs.admin.api.domain.ConfigurationSigningKey;
 import org.niis.xroad.cs.admin.api.domain.ConfigurationSigningKeyWithDetails;
 
@@ -36,7 +38,7 @@ public interface ConfigurationSigningKeysService {
     String SOURCE_TYPE_INTERNAL = "internal";
     String SOURCE_TYPE_EXTERNAL = "external";
 
-    List<ConfigurationSigningKey> findByTokenIdentifier(String tokenId);
+    List<ConfigurationSigningKey> findByTokenIdentifier(TokenInfo tokenInfo);
 
     ConfigurationSigningKeyWithDetails addKey(String sourceType, String tokenId, String keyLabel);
 

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ConfigurationSigningKeyRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ConfigurationSigningKeyRepository.java
@@ -28,14 +28,15 @@ package org.niis.xroad.cs.admin.core.repository;
 
 import org.niis.xroad.cs.admin.core.entity.ConfigurationSigningKeyEntity;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ConfigurationSigningKeyRepository extends GenericRepository<ConfigurationSigningKeyEntity, Integer> {
 
-    List<ConfigurationSigningKeyEntity> findByTokenIdentifier(String tokenIdentifier);
-
     Optional<ConfigurationSigningKeyEntity> findByKeyIdentifier(String keyIdentifier);
+
+    List<ConfigurationSigningKeyEntity> findByKeyIdentifierIn(Collection<String> keyIds);
 
     void deleteByKeyIdentifier(String identifier);
 

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/TokensServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/TokensServiceImpl.java
@@ -108,7 +108,7 @@ public class TokensServiceImpl extends AbstractTokenConsumer implements TokensSe
             throw new ValidationFailureException(TOKEN_PIN_LOCKED);
         }
 
-        tokenActionsResolver.requireAction(LOGIN, token, configurationSigningKeysService.findByTokenIdentifier(token.getId()));
+        tokenActionsResolver.requireAction(LOGIN, token, configurationSigningKeysService.findByTokenIdentifier(token));
         validatePinMeetsTheTokenRequirements(token, tokenLoginRequest.getPassword());
 
         try {
@@ -132,7 +132,7 @@ public class TokensServiceImpl extends AbstractTokenConsumer implements TokensSe
     public TokenInfo logout(String tokenId) {
         final ee.ria.xroad.signer.protocol.dto.TokenInfo token = getToken(tokenId);
         addAuditData(token);
-        tokenActionsResolver.requireAction(LOGOUT, token, configurationSigningKeysService.findByTokenIdentifier(token.getId()));
+        tokenActionsResolver.requireAction(LOGOUT, token, configurationSigningKeysService.findByTokenIdentifier(token));
         try {
             signerProxyFacade.deactivateToken(tokenId);
         } catch (CodedException codedException) {


### PR DESCRIPTION
…by key identifiers.

Token identifier might be the same in cluster env.

Refs: XRDDEV-2324