### PR TITLE
chore: success icon for software token pin on CS initialization page wasn't showing

### DIFF
--- a/src/central-server/admin-service/ui/src/views/InitialConfiguration/InitialConfiguration.vue
+++ b/src/central-server/admin-service/ui/src/views/InitialConfiguration/InitialConfiguration.vue
@@ -142,6 +142,7 @@
               >
                 <xrd-icon-base
                   v-if="passed"
+                  slot="append"
                   :color="colors.Success100"
                   data-test="confirm-pin-append-input-icon"
                 >


### PR DESCRIPTION
Fixes e2e tests

Refs: XRDDEV-2321