### PR TITLE
fix(cs:api): fixes for member adding to global group to be consistent with old version

### DIFF
--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMemberEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMemberEntity.java
@@ -61,7 +61,7 @@ public class GlobalGroupMemberEntity extends AuditableEntity {
     @Setter
     private GlobalGroupEntity globalGroup;
 
-    @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "group_member_id")
     @Getter
     @Setter
@@ -74,11 +74,6 @@ public class GlobalGroupMemberEntity extends AuditableEntity {
     public GlobalGroupMemberEntity(GlobalGroupEntity globalGroup, ee.ria.xroad.common.identifier.ClientId identifier) {
         this.globalGroup = globalGroup;
         this.identifier = ClientIdEntity.ensure(identifier);
-    }
-
-    public GlobalGroupMemberEntity(GlobalGroupEntity globalGroup, ClientIdEntity identifier) {
-        this.globalGroup = globalGroup;
-        this.identifier = identifier;
     }
 
     @Override

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImpl.java
@@ -174,7 +174,7 @@ public class GlobalGroupServiceImpl implements GlobalGroupService {
 
         auditDataHelper.addListPropertyItem(RestApiAuditProperty.MEMBER_IDENTIFIERS, clientId);
         if (isNotMemberOfGroup(group, clientIdEntity)) {
-            var groupMember = new GlobalGroupMemberEntity(group, clientIdEntity);
+            var groupMember = new GlobalGroupMemberEntity(group, clientId);
             globalGroupMemberRepository.save(groupMember);
             return true;
         }


### PR DESCRIPTION
create copy of identifier when adding new member to group, filter possible members by instance/class/member[/subsystem] of already added members

Refs: XRDDEV-2342