### PR TITLE
fix: change rubygems to https address

### DIFF
--- a/src/center-common/Gemfile
+++ b/src/center-common/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in center-common.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/src/center-common/Gemfile.lock
+++ b/src/center-common/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       transaction_isolation (~> 1.0.3)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.22.5)
       actionpack (= 3.2.22.5)

--- a/src/center-ui/Gemfile.lock
+++ b/src/center-ui/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: vendor/engines/center-common
+  remote: ../center-common
   specs:
     center-common (0.0.1)
       foreigner (~> 1.7.0)
@@ -8,7 +8,7 @@ PATH
       transaction_isolation (~> 1.0.3)
 
 PATH
-  remote: vendor/engines/common-ui
+  remote: ../common-ui
   specs:
     common-ui (0.0.1)
       addressable (= 2.8.0)
@@ -110,7 +110,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (1.4.1)
     transaction_isolation (1.0.5)
       activerecord (>= 3.0.11)

--- a/src/common-ui/Gemfile
+++ b/src/common-ui/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in common-ui.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/src/common-ui/Gemfile.lock
+++ b/src/common-ui/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       rails (~> 3.2.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.22.5)
       actionpack (= 3.2.22.5)


### PR DESCRIPTION
http endpoint is unreliable and during dependency api deprecation it throws network errors.