### PR TITLE
fix: incorrect central server anchor filename

### DIFF
--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/ConfigurationAnchorWithFile.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/ConfigurationAnchorWithFile.java
@@ -26,14 +26,23 @@
  */
 package org.niis.xroad.cs.admin.api.dto;
 
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
 import java.time.Instant;
 
-@Data
-@RequiredArgsConstructor
-public class ConfigurationAnchor {
-    private final String anchorFileHash;
-    private final Instant anchorGeneratedAt;
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ConfigurationAnchorWithFile extends ConfigurationAnchor {
+
+    private final byte[] anchorFile;
+    private final String anchorFileName;
+
+    public ConfigurationAnchorWithFile(String anchorFileHash, Instant anchorGeneratedAt, byte[] anchorFile, String anchorFileName) {
+        super(anchorFileHash, anchorGeneratedAt);
+        this.anchorFile = anchorFile;
+        this.anchorFileName = anchorFileName;
+    }
 }

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationAnchorService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationAnchorService.java
@@ -29,13 +29,14 @@ package org.niis.xroad.cs.admin.api.service;
 
 import org.niis.xroad.cs.admin.api.domain.ConfigurationSourceType;
 import org.niis.xroad.cs.admin.api.dto.ConfigurationAnchor;
+import org.niis.xroad.cs.admin.api.dto.ConfigurationAnchorWithFile;
 
 import java.util.Optional;
 
 public interface ConfigurationAnchorService {
     Optional<ConfigurationAnchor> getConfigurationAnchor(ConfigurationSourceType sourceType);
 
-    Optional<ConfigurationAnchor> getConfigurationAnchorWithFile(ConfigurationSourceType sourceType);
+    Optional<ConfigurationAnchorWithFile> getConfigurationAnchorWithFile(ConfigurationSourceType sourceType);
 
     ConfigurationAnchor recreateAnchor(ConfigurationSourceType configurationType);
 }

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImplTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.niis.xroad.common.exception.ServiceException;
 import org.niis.xroad.cs.admin.api.dto.ConfigurationAnchor;
+import org.niis.xroad.cs.admin.api.dto.ConfigurationAnchorWithFile;
 import org.niis.xroad.cs.admin.api.dto.HAConfigStatus;
 import org.niis.xroad.cs.admin.api.service.SystemParameterService;
 import org.niis.xroad.cs.admin.core.entity.ConfigurationSigningKeyEntity;
@@ -110,7 +111,7 @@ public class ConfigurationAnchorServiceImplTest {
 
             final Optional<ConfigurationAnchor> optResult = configurationAnchorService.getConfigurationAnchor(INTERNAL);
 
-            assertThat(optResult.isPresent()).isTrue();
+            assertThat(optResult).isPresent();
 
             final var result = optResult.get();
             assertThat(result.getAnchorFileHash()).isEqualTo(HASH);
@@ -123,7 +124,7 @@ public class ConfigurationAnchorServiceImplTest {
             when(configurationSourceRepository.findBySourceTypeAndHaNodeName(INTERNAL_CONFIGURATION, HA_NODE_NAME))
                     .thenReturn(Optional.of(configurationSourceEntityWithFile()));
 
-            final Optional<ConfigurationAnchor> optResult = configurationAnchorService.getConfigurationAnchorWithFile(INTERNAL);
+            final Optional<ConfigurationAnchorWithFile> optResult = configurationAnchorService.getConfigurationAnchorWithFile(INTERNAL);
 
             assertThat(optResult.isPresent()).isTrue();
 
@@ -139,7 +140,7 @@ public class ConfigurationAnchorServiceImplTest {
                     .thenReturn(Optional.of(configurationSourceEntity()));
 
             final Optional<ConfigurationAnchor> optResult = configurationAnchorService.getConfigurationAnchor(EXTERNAL);
-            assertThat(optResult.isPresent()).isTrue();
+            assertThat(optResult).isPresent();
 
             final var result = optResult.get();
             assertThat(result.getAnchorFileHash()).isEqualTo(HASH);
@@ -151,7 +152,7 @@ public class ConfigurationAnchorServiceImplTest {
             when(configurationSourceRepository.findBySourceTypeAndHaNodeName(EXTERNAL_CONFIGURATION, HA_NODE_NAME))
                     .thenReturn(Optional.of(configurationSourceEntityWithFile()));
 
-            final Optional<ConfigurationAnchor> optResult = configurationAnchorService.getConfigurationAnchorWithFile(EXTERNAL);
+            final Optional<ConfigurationAnchorWithFile> optResult = configurationAnchorService.getConfigurationAnchorWithFile(EXTERNAL);
             assertThat(optResult.isPresent()).isTrue();
 
             final var result = optResult.get();

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationInfoApiStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationInfoApiStepDefs.java
@@ -178,15 +178,15 @@ public class ConfigurationInfoApiStepDefs extends BaseStepDefs {
                 .downloadAnchor(ConfigurationTypeDto.fromValue(configurationType));
     }
 
-    @Step("it should return internal configuration source anchor file")
-    public void validateInternalDownloadedAnchor() throws IOException {
+    @Step("it should return internal configuration source anchor file with filename {string}")
+    public void validateInternalDownloadedAnchor(String filename) throws IOException {
         String expectedAnchorContent = IOUtils.resourceToString("/test-data/internal-configuration-anchor.xml",
                 StandardCharsets.UTF_8);
         validate(downloadedAnchor)
                 .assertion(equalsStatusCodeAssertion(OK))
                 .assertion(equalsAssertion(EXPECTED_INTERNAL_CONFIGURATION_ANCHOR_CONTENT_LENGTH, "body.contentLength",
                         "Response contains configuration anchor has correct content length"))
-                .assertion(equalsAssertion("configuration_anchor_UTC_2022-01-01_01_00_00.xml", "body.filename",
+                .assertion(equalsAssertion(filename, "body.filename",
                         "Configuration anchor file has correct name"))
                 .assertion(equalsAssertion(expectedAnchorContent,
                         "T(org.apache.commons.io.IOUtils).toString(body.inputStream, 'UTF-8')",
@@ -194,15 +194,15 @@ public class ConfigurationInfoApiStepDefs extends BaseStepDefs {
                 .execute();
     }
 
-    @Step("it should return external configuration source anchor file")
-    public void validateExternalDownloadedAnchor() throws IOException {
+    @Step("it should return external configuration source anchor file with filename {string}")
+    public void validateExternalDownloadedAnchor(String filename) throws IOException {
         String expectedAnchorContent = IOUtils.resourceToString("/test-data/external-configuration-anchor.xml",
                 StandardCharsets.UTF_8);
         validate(downloadedAnchor)
                 .assertion(equalsStatusCodeAssertion(OK))
                 .assertion(equalsAssertion(EXPECTED_EXTERNAL_CONFIGURATION_ANCHOR_CONTENT_LENGTH, "body.contentLength",
                         "Response contains configuration anchor has correct content length"))
-                .assertion(equalsAssertion("configuration_anchor_UTC_2022-01-01_01_00_00.xml", "body.filename",
+                .assertion(equalsAssertion(filename, "body.filename",
                         "Configuration anchor file has correct name"))
                 .assertion(equalsAssertion(expectedAnchorContent,
                         "T(org.apache.commons.io.IOUtils).toString(body.inputStream, 'UTF-8')",

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationSourceAnchorApiStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationSourceAnchorApiStepDefs.java
@@ -93,15 +93,4 @@ public class ConfigurationSourceAnchorApiStepDefs extends BaseStepDefs {
                 .assertion(equalsAssertion(hash, "body.anchor.hash", "must be same as from previous step"))
                 .execute();
     }
-
-    @Step("recreated anchor is downloaded and filename matches {string}")
-    public void downloadRecreatedAnchor(String filename) {
-        final var response = configurationSourceAnchorsApi.downloadAnchor(configurationTypeDto);
-
-        validate(response)
-                .assertion(equalsStatusCodeAssertion(OK))
-                .assertion(equalsAssertion(createdAt, "body.filename", "must match"))
-                .assertion(equalsAssertion(hash, "body.anchor.hash", "must be same as from previous step"))
-                .execute();
-    }
 }

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationSourceAnchorApiStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ConfigurationSourceAnchorApiStepDefs.java
@@ -93,4 +93,15 @@ public class ConfigurationSourceAnchorApiStepDefs extends BaseStepDefs {
                 .assertion(equalsAssertion(hash, "body.anchor.hash", "must be same as from previous step"))
                 .execute();
     }
+
+    @Step("recreated anchor is downloaded and filename matches {string}")
+    public void downloadRecreatedAnchor(String filename) {
+        final var response = configurationSourceAnchorsApi.downloadAnchor(configurationTypeDto);
+
+        validate(response)
+                .assertion(equalsStatusCodeAssertion(OK))
+                .assertion(equalsAssertion(createdAt, "body.filename", "must match"))
+                .assertion(equalsAssertion(hash, "body.anchor.hash", "must be same as from previous step"))
+                .execute();
+    }
 }

--- a/src/central-server/admin-service/int-test/src/intTest/resources/behavior/api/configurationInfoApis.feature
+++ b/src/central-server/admin-service/int-test/src/intTest/resources/behavior/api/configurationInfoApis.feature
@@ -16,11 +16,11 @@ Feature: Configuration Info API
 
   Scenario: Download internal configuration anchor
     When user downloads INTERNAL configuration source anchor
-    Then it should return internal configuration source anchor file
+    Then it should return internal configuration source anchor file with filename "configuration_anchor_CS_internal_UTC_2022-01-01_01_00_00.xml"
 
   Scenario: Download external configuration anchor
     When user downloads EXTERNAL configuration source anchor
-    Then it should return external configuration source anchor file
+    Then it should return external configuration source anchor file with filename "configuration_anchor_CS_external_UTC_2022-01-01_01_00_00.xml"
 
   Scenario: Download configuration part
     * User can download EXTERNAL configuration part SHARED-PARAMETERS version 2


### PR DESCRIPTION
https://nordic-institute.atlassian.net/browse/XRDDEV-2367

Configuration anchor file name generated by the Central Server is missing instance identifier and configuration anchor type (internal/external)