### PR TITLE
chore: update database properties in manuals

### DIFF
--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -728,7 +728,7 @@ The default values can be found in [Annex A Central Server Default Database Prop
 
 ```properties
 spring.datasource.username=<database_user>
-spring.datasource.password=<database_user password>
+spring.datasource.password=<database_user_password>
 spring.datasource.hikari.data-source-properties.currentSchema=<database_schema>
 spring.datasource.url=jdbc:postgresql://<database_host>:<database_port>/<database>
 skip_migrations=<false by default, set to true to skip migrations>

--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server Installation Guide <!-- omit in toc -->
 
-Version: 2.33  
+Version: 2.34  
 Doc. ID: IG-CS
 
 ---
@@ -51,6 +51,7 @@ Doc. ID: IG-CS
 | 05.05.2023 | 2.31    | Minor updates                                                                                                                                                                                 | Justas Samuolis    |
 | 23.05.2023 | 2.32    | Backup Encryption Configuration                                                                                                                                                               | Eneli Reimets      |
 | 31.05.2023 | 2.33    | Add Central Server network diagram                                                                                                                                                            | Petteri Kivimäki |
+| 28.06.2023 | 2.34    | Update database properties to the new Spring datasource version                                                                                                                               | Raido Kaju       |
 
 ## Table of Contents <!-- omit in toc -->
 

--- a/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
+++ b/doc/Manuals/ig-cs_x-road_6_central_server_installation_guide.md
@@ -601,12 +601,10 @@ apt upgrade xroad-centralserver
 `/etc/xroad/db.properties`
 
 ```properties
-username=centerui
-password=<randomly generated password stored is stored here>
-database=centerui_production
-schema=centerui
-host=127.0.0.1
-port=5432
+spring.datasource.username=centerui
+spring.datasource.password=<randomly generated password stored is stored here>
+spring.datasource.hikari.data-source-properties.currentSchema=centerui
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/centerui_production
 skip_migrations=false
 ```
 
@@ -728,12 +726,10 @@ Edit `/etc/xroad/db.properties` file and add/update the following connection pro
 The default values can be found in [Annex A Central Server Default Database Properties](#annex-a-central-server-default-database-properties).
 
 ```properties
-username=<database_user>
-password=<database_user password>
-database=<database>
-host=<database_host>
-port=<database_port>
-schema=<database_schema>
+spring.datasource.username=<database_user>
+spring.datasource.password=<database_user password>
+spring.datasource.hikari.data-source-properties.currentSchema=<database_schema>
+spring.datasource.url=jdbc:postgresql://<database_host>:<database_port>/<database>
 skip_migrations=<false by default, set to true to skip migrations>
 ```
 

--- a/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
+++ b/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
@@ -399,10 +399,10 @@ See [Central Server User Guide](ug-cs_x-road_6_central_server_user_guide.md#17-m
 
 Edit `/etc/xroad/db.properties` and change the connection properties:
 ```properties
-spring.datasource.username=centerui
+spring.datasource.username=<database_user>
 spring.datasource.password=<password>
-spring.datasource.url=jdbc:postgresql://<master host>:<master port>/centerui_production
-secondary_hosts=<standby host>
+spring.datasource.url=jdbc:postgresql://<master_host>:<master_port>/<database>
+secondary_hosts=<standby_host>
 ```
 
 Restart Central Servers and verify that the cluster is working (see [5 Monitoring HA State on a Node](#5-monitoring-ha-state-on-a-node)).

--- a/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
+++ b/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
@@ -1,7 +1,7 @@
 # Central Server High Availability Installation Guide <!-- omit in toc -->
 **X-ROAD 7**
 
-Version: 1.18  
+Version: 1.20
 Doc. ID: IG-CSHA
 
 ---
@@ -32,6 +32,7 @@ Doc. ID: IG-CSHA
 | 19.04.2023 | 1.17    | Removed unused properties from db.properties                                                         | Mikk-Erik Bachmann |
 | 02.06.2023 | 1.18    | Minor updates                                                                                        | Justas Samuolis    |
 | 05.06.2023 | 1.19    | Update HA cluster status endpoint path                                                               | Andres Rosenthal   |
+| 28.06.2023 | 1.20    | Update database properties to follow new Spring datasource style                                     | Raido Kaju         |
 
 
 ## Table of Contents <!-- omit in toc -->

--- a/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
+++ b/doc/Manuals/ig-csha_x-road_6_ha_installation_guide.md
@@ -398,10 +398,9 @@ See [Central Server User Guide](ug-cs_x-road_6_central_server_user_guide.md#17-m
 
 Edit `/etc/xroad/db.properties` and change the connection properties:
 ```properties
-username=centerui
-password=<password>
-database=centerui_production
-host=<master host>
+spring.datasource.username=centerui
+spring.datasource.password=<password>
+spring.datasource.url=jdbc:postgresql://<master host>:<master port>/centerui_production
 secondary_hosts=<standby host>
 ```
 

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1611,12 +1611,10 @@ pg_restore -h <remote-db-url> -p <remote-db-port> -U centerui_admin -O -n center
 8. Update `/etc/xroad/db.properties` contents with correct database host URLs and passwords.
 
 ```properties
-    username=centerui
-    password=<centerui password>
-    database=centerui_production
-    host=<database host>
-    port=<database port>
-    schema=centerui
+    spring.datasource.username=centerui
+    spring.datasource.password=<centerui password>
+    spring.datasource.hikari.data-source-properties.currentSchema=centerui
+    spring.datasource.url=jdbc:postgresql://<database host>:<database port>/centerui_production
 ```
 
 9. Start again the X-Road services.

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1612,10 +1612,10 @@ pg_restore -h <remote-db-url> -p <remote-db-port> -U centerui_admin -O -n center
 8. Update `/etc/xroad/db.properties` contents with correct database host URLs and passwords.
 
 ```properties
-    spring.datasource.username=centerui
-    spring.datasource.password=<centerui password>
-    spring.datasource.hikari.data-source-properties.currentSchema=centerui
-    spring.datasource.url=jdbc:postgresql://<database host>:<database port>/centerui_production
+    spring.datasource.username=<database_username>
+    spring.datasource.password=<database_password>
+    spring.datasource.hikari.data-source-properties.currentSchema=<database_schema>
+    spring.datasource.url=jdbc:postgresql://<database_host>:<database_port>/<database>
 ```
 
 9. Start again the X-Road services.

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server User Guide <!-- omit in toc --> 
 
-Version: 2.30
+Version: 2.31
 Doc. ID: UG-CS
 
 ## Version history <!-- omit in toc --> 
@@ -56,6 +56,7 @@ Doc. ID: UG-CS
 | 02.06.2023 | 2.28    | Added security hardening paragraph                                                                                                                                                                                                                                                                                                                                                                                                      | Ričardas Bučiūnas   |
 | 09.06.2023 | 2.29    | Added REST API paragraph                                                                                                                                                                                                                                                                                                                                                                                                                | Vytautas Paliliūnas |
 | 19.06.2023 | 2.30    | Remove table schema_migrations                                                                                                                                                                                                                                                                                                                                                                                                          | Eneli Reimets       |
+| 28.06.2023 | 2.31    | Update database properties to match new Spring datasource style                                                                                                                                                                                                                                                                                                                                                                         | Raido Kaju          |
 
 ## Table of Contents <!-- omit in toc --> 
 <!-- toc -->


### PR DESCRIPTION
Updates database properties in Central Server manuals to correspond with the new style set in [XRDDEV-2422](https://nordic-institute.atlassian.net/browse/XRDDEV-2422).

[XRDDEV-2422]: https://nordic-institute.atlassian.net/browse/XRDDEV-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ