### PR TITLE
Fix: Rename configuration parameter wal_keep_segments to wal_keep_size

### DIFF
--- a/ansible/ss_cluster/roles/master/tasks/serverconf_master_db.yml
+++ b/ansible/ss_cluster/roles/master/tasks/serverconf_master_db.yml
@@ -13,7 +13,7 @@
       - { option: 'listen_addresses', value: "'*'" }
       - { option: 'wal_level', value: "'hot_standby'" }
       - { option: 'max_wal_senders', value: '10' }
-      - { option: 'wal_keep_segments', value: '8' }
+      - { option: 'wal_keep_size', value: '128' }
 
 - name: enable replication connections
   lineinfile:

--- a/ansible/ss_cluster/roles/slave/tasks/serverconf_slave_db.yml
+++ b/ansible/ss_cluster/roles/slave/tasks/serverconf_slave_db.yml
@@ -48,7 +48,7 @@
       - {option: 'listen_addresses', value: "'localhost'"}
       - {option: 'wal_level', value: "'hot_standby'"}
       - {option: 'max_wal_senders', value: '10'}
-      - {option: 'wal_keep_segments', value: '8'}
+      - {option: 'wal_keep_size', value: '128'}
       - {option: 'hot_standby', value: 'on'}
       - {option: 'hot_standby_feedback', value: 'on'}
 # listen_addresses = 'localhost' for security, but changing it to '*' if the


### PR DESCRIPTION
Starting from Postgresql 13, there has been a parameter rename and value change. 
https://www.postgresql.org/docs/13/release-13.html

wal_keep_size = wal_keep_segments * wal_segment_size (typically 16MB)

Latest X-Road is using Postgresql 14 and also needs to rename this parameter.