### PR TITLE
chore: Workaround for rhel java 11.0.20.0.8-2

### DIFF
--- a/ansible/roles/xroad-base/tasks/rhel.yml
+++ b/ansible/roles/xroad-base/tasks/rhel.yml
@@ -49,3 +49,4 @@
       - cronie
       - tar
       - acl
+      - tzdata-java


### PR DESCRIPTION
tzdata-java dependency is missing in this particular version, until this is fixed we can just install it through ansible.