### PR TITLE
fix: add tzdata-java dependency for rpm packages

### DIFF
--- a/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
+++ b/src/packages/src/xroad/redhat/SPECS/xroad-base.spec
@@ -19,7 +19,7 @@ Requires:  systemd
 %if 0%{?el7}
 Requires:  rlwrap
 %endif
-Requires:  jre-11-headless
+Requires:  jre-11-headless, tzdata-java
 Requires:  crudini, hostname, sudo, openssl
 
 %define src %{_topdir}/..


### PR DESCRIPTION
tzdata-java is no longer a dependency for java-11-openjdk-11.0.20.0.8-2 rpm package, but it is still required to run java. As a workaround, tzdata-java is added as dependency to xroad-base package. See https://access.redhat.com/solutions/7025428

refs: XRDDEV-2458