### PR TITLE
Add SonarCloud support

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         working-directory: ./src
-        run: ./gradlew -Dorg.gradle.jvmargs=-Xmx6g -PxroadBuildType=RELEASE --stacktrace build sonar test intTest runProxyTest runMetaserviceTest runProxymonitorMetaserviceTest jacocoTestReport dependencyCheckAggregate -Pfrontend-npm-audit
+        run: ./gradlew -Dorg.gradle.jvmargs=-Xmx6g -PsonarqubeHost=https://sonarcloud.io -PsonarqubeProjectKey=nordic-institute_X-Road -PsonarqubeOrganization=nordic-institute -PxroadBuildType=RELEASE --stacktrace build sonar test intTest runProxyTest runMetaserviceTest runProxymonitorMetaserviceTest jacocoTestReport dependencyCheckAggregate -Pfrontend-npm-audit
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,14 +29,23 @@ jobs:
           distribution: 'temurin'
       - name: Ensure required packages
         run: sudo apt-get install -y curl software-properties-common build-essential unzip debhelper devscripts
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
           gradle-home-cache-cleanup: true
       - name: Build and test source
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         working-directory: ./src
-        run: ./gradlew -Dorg.gradle.jvmargs=-Xmx6g -PxroadBuildType=RELEASE --stacktrace build test intTest runProxyTest runMetaserviceTest runProxymonitorMetaserviceTest jacocoTestReport dependencyCheckAggregate -Pfrontend-npm-audit
+        run: ./gradlew -Dorg.gradle.jvmargs=-Xmx6g -PxroadBuildType=RELEASE --stacktrace build sonar test intTest runProxyTest runMetaserviceTest runProxymonitorMetaserviceTest jacocoTestReport dependencyCheckAggregate -Pfrontend-npm-audit
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: 'true'
+          fetch-depth: 0  # SonarCloud: Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11 
         uses: actions/setup-java@v3
         with:
@@ -72,8 +72,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - name: Set up JDK 11 
         uses: actions/setup-java@v3
         with:
@@ -111,8 +109,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
       - name: Set up JDK 11 
         uses: actions/setup-java@v3
         with:

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -26,9 +26,9 @@ repositories {
 
 sonarqube {
     properties {
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.projectKey", "nordic-institute_X-Road"
-        property "sonar.organization", "nordic-institute"
+        property "sonar.host.url", "${sonarqubeHost}"
+        property "sonar.projectKey", "${sonarqubeProjectKey}"
+        property "sonar.organization", "${sonarqubeOrganization}"
         property "sonar.projectName", "X-Road"
         property "sonar.projectDescription", "Data Exchange Layer"
         property "sonar.projectVersion", xroadVersion

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.sonarqube' version '3.3'
+    id 'org.sonarqube' version '4.2.1.3168'
     id 'org.owasp.dependencycheck' version '8.0.2'
     id 'jacoco'
     id 'java'
@@ -26,8 +26,9 @@ repositories {
 
 sonarqube {
     properties {
-        property "sonar.host.url", "https://sonarqube.niis.org"
-        property "sonar.projectKey", "xroad"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.projectKey", "nordic-institute_X-Road"
+        property "sonar.organization", "nordic-institute"
         property "sonar.projectName", "X-Road"
         property "sonar.projectDescription", "Data Exchange Layer"
         property "sonar.projectVersion", xroadVersion

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -3,6 +3,11 @@ org.gradle.jvmargs=-Xmx1024m
 xroadVersion=7.4.0
 xroadBuildType=SNAPSHOT
 
+# SonarQube defaults
+sonarqubeHost=https://sonarqube.niis.org
+sonarqubeProjectKey=xroad
+sonarqubeOrganization=
+
 # common dependency versions
 akkaVersion=2.13:2.6.20
 scalaLibraryVersion=2.13.10


### PR DESCRIPTION
Added support for running SonarQube tests in the SonarCloud environment, which required defining the related properties inside `gradle.properties` instead of `build.gradle`. This allows us to override them via the command line. The defaults were left to our internal SonarQube so that Jenkins pipelines would continue to work for now.

Also introduced scanning with SonarCloud to the X-Road testing workflow on GitHub.