### PR TITLE
chore: change community issue and change request reporting practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,12 +87,12 @@ by post:
 
 X-Road enhancement requests and error reports can be submitted directly to this GitHub repository:
 
-* For enhancement requests, please create a discussion containing your proposal in the specific softwares repository in
+* For enhancement requests, please create a discussion containing your proposal in the specific software repository in
   the `Ideas` category:
   * [X-Road](https://github.com/nordic-institute/X-Road/discussions/new?category=ideas)
   * [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/discussions/new?category=ideas)
   * [MISP2](https://github.com/nordic-institute/misp2/discussions/new?category=ideas)
-* To report an error, please create an issue in the specific softwares repository:
+* To report an error, please create an issue in the specific software repository:
   * [X-Road](https://github.com/nordic-institute/X-Road/issues/new/choose)
   * [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues/new/choose)
   * [MISP2](https://github.com/nordic-institute/misp2/issues/new/choose)
@@ -163,7 +163,8 @@ Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4) usin
 get access to the [X-Road Service Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4).
 
 Another alternative to report security issues and vulnerabilities is the X-Road bug bounty program that is run on the
-Intigrity platform. [Visit the program details](https://app.intigriti.com/programs/niis/x-road/detail) to get started.
+Intigrity platform. [Visit the program details](https://nordic-institute.atlassian.net/wiki/spaces/XRDBUGBOUNTY) to get
+started.
 
 ### Your First Code Contribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,24 +12,24 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-  - [Legal Notice](#legal-notice)
-    - [Review the CLA document](#review-the-cla-document)
-    - [Sign the CLA](#sign-the-cla)
-  - [Enhancement Requests and Error Reports](#enhancement-requests-and-error-reports)
-    - [Submitting a Bug](#submitting-a-bug)
-    - [Submitting an Enhancement Request](#submitting-an-enhancement-request)
-  - [Security Issues And Vulnerabilities](#security-issues-and-vulnerabilities)
-  - [Your First Code Contribution](#your-first-code-contribution)
-  - [Submitting a Pull Request](#submitting-a-pull-request)
-    - [Pull Request Checklist](#pull-request-checklist)
-- [Styleguides](#styleguides)
-  - [Branching Pattern](#branching-pattern)
-  - [Pull Requests](#pull-requests)
-  - [Commit Messages](#commit-messages)
-  - [Tagging](#tagging)
-  - [Java](#java)
+* [I Have a Question](#i-have-a-question)
+* [I Want To Contribute](#i-want-to-contribute)
+  * [Legal Notice](#legal-notice)
+    * [Review the CLA document](#review-the-cla-document)
+    * [Sign the CLA](#sign-the-cla)
+  * [Enhancement Requests and Error Reports](#enhancement-requests-and-error-reports)
+    * [Submitting a Bug](#submitting-a-bug)
+    * [Submitting an Enhancement Request](#submitting-an-enhancement-request)
+  * [Security Issues And Vulnerabilities](#security-issues-and-vulnerabilities)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Submitting a Pull Request](#submitting-a-pull-request)
+    * [Pull Request Checklist](#pull-request-checklist)
+* [Styleguides](#styleguides)
+  * [Branching Pattern](#branching-pattern)
+  * [Pull Requests](#pull-requests)
+  * [Commit Messages](#commit-messages)
+  * [Tagging](#tagging)
+  * [Java](#java)
 
 ## I Have a Question
 
@@ -85,49 +85,74 @@ by post:
 
 ### Enhancement Requests and Error Reports
 
-X-Road enhancement requests and error reports can be submitted to the [X-Road Service
-Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4). In order 
-to access the X-Road Service Desk, [sign up](https://id.atlassian.com/signup) for an 
-account and request access to the [X-Road Backlog](https://nordic-institute.atlassian.net/jira/software/c/projects/XRDDEV/boards/6/backlog).
-Alternatively, you can use your existing account, sign in and request for access. Once 
-your request has been approved, you're able to access the [X-Road Service Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4) 
-and the [X-Road Backlog](https://nordic-institute.atlassian.net/jira/software/c/projects/XRDDEV/boards/6/backlog). 
-Approving the  request typically requires 1-2 business days.
+X-Road enhancement requests and error reports can be submitted directly to this GitHub repository:
+
+* For enhancement requests, please create a discussion containing your proposal in the specific softwares repository in
+  the `Ideas` category:
+  * [X-Road](https://github.com/nordic-institute/X-Road/discussions/new?category=ideas)
+  * [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/discussions/new?category=ideas)
+  * [MISP2](https://github.com/nordic-institute/misp2/discussions/new?category=ideas)
+* To report an error, please create an issue in the specific softwares repository:
+  * [X-Road](https://github.com/nordic-institute/X-Road/issues/new/choose)
+  * [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues/new/choose)
+  * [MISP2](https://github.com/nordic-institute/misp2/issues/new/choose)
 
 #### Submitting a Bug
 
 Before submitting a bug:
 
-- Make sure that you are using the latest version.
-- Check the [Knowledge Base](https://nordic-institute.atlassian.net/wiki/spaces/XRDKB) for a list of common questions and problems.
-- Ask the community on the [X-Road community Slack](https://jointxroad.slack.com/) if the problem is a known issue or a feature. Also, check the Slack history for previous questions on the same topic.
-- Perform a cursory search on the [X-Road](https://nordic-institute.atlassian.net/browse/XRDDEV),
-  [X-Road Metrics](https://nordic-institute.atlassian.net/browse/OPMONDEV) or [MISP2](https://nordic-institute.atlassian.net/browse/MISPDEV) backlogs depending on the software, 
-  to see if the problem has already been reported. If it has and the issue is still open, add a comment to the existing issue instead of opening a new one.
+* Make sure that you are using the latest version.
+* Check the [Knowledge Base](https://nordic-institute.atlassian.net/wiki/spaces/XRDKB) for a list of common questions
+  and problems.
+* Ask the community on the [X-Road community Slack](https://jointxroad.slack.com/) if the problem is a known issue or a
+  feature. Also, check the Slack history for previous questions on the same topic.
+* Perform a cursory search on the [X-Road](https://nordic-institute.atlassian.net/browse/XRDDEV),
+  [X-Road Metrics](https://nordic-institute.atlassian.net/browse/OPMONDEV) or
+  [MISP2](https://nordic-institute.atlassian.net/browse/MISPDEV) backlogs depending on the software, to see if the
+  problem has already been reported. If it has and the issue is still open, add a comment to the existing issue instead
+  of opening a new one.
+* Perform a cursory search on the [X-Road](https://github.com/nordic-institute/X-Road/issues),
+  [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues) or
+  [MISP2](https://github.com/nordic-institute/misp2/issues) GitHub issues depending on the software, to see if the 
+  problem has already been reported. If it has and the issue is still open, add a comment to the existing issue instead
+  of opening a new one.
 
 When submitting a bug, explain the problem and include additional details to help maintainers reproduce the problem:
 
-- Summary of the problem.
-- Software version.
-- Host OS and version.
-- More detailed description of the problem that includes:
-  - Steps to reproduce the issue.
-  - Expected result.
-  - Actual result.
-- Related log files.
+* Summary of the problem.
+* Software version.
+* Host OS and version.
+* More detailed description of the problem that includes:
+  * Steps to reproduce the issue.
+  * Expected result.
+  * Actual result.
+* Related log files.
 
 #### Submitting an Enhancement Request
 
 Before submitting an enhancement request:
 
-- Make sure that you are using the latest version.
-- Read the software specific documentation for [X-Road](https://docs.x-road.global), [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/tree/master/docs)
-  or [MISP2](https://github.com/nordic-institute/misp2/tree/develop/docs) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a search on the [X-Road](https://nordic-institute.atlassian.net/browse/XRDDEV), [X-Road Metrics](https://nordic-institute.atlassian.net/browse/OPMONDEV) or
-  [MISP2](https://nordic-institute.atlassian.net/browse/MISPDEV) backlogs to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
-- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on or an extension.
+* Make sure that you are using the latest version.
+* Read the software specific documentation for [X-Road](https://docs.x-road.global),
+  [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/tree/master/docs)
+  or [MISP2](https://github.com/nordic-institute/misp2/tree/develop/docs) carefully and find out if the functionality
+  is already covered, maybe by an individual configuration.
+* Perform a search on the [X-Road](https://nordic-institute.atlassian.net/browse/XRDDEV),
+  [X-Road Metrics](https://nordic-institute.atlassian.net/browse/OPMONDEV) or
+  [MISP2](https://nordic-institute.atlassian.net/browse/MISPDEV) backlogs to see if the enhancement has already been
+  suggested. If it has, add a comment to the existing issue instead of opening a new one.
+* Perform a search on the [X-Road](https://github.com/nordic-institute/X-Road/discussions/categories/ideas),
+  [X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/discussions/categories/ideas) or
+  [MISP2](https://github.com/nordic-institute/misp2/discussions/categories/ideas) discussion boards ideas category to
+  see if the enhancement has already been suggested. If it has, add a comment to the existing discussion instead of
+  opening a new one.
+* Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to
+  convince the project's developers of the merits of this feature. Keep in mind that we want features that will be
+  useful to the majority of our users and not just a small subset. If you're just targeting a minority of users,
+  consider writing an add-on or an extension.
 
-The evaluation process of the enhancement requests is described [here](https://github.com/nordic-institute/X-Road-development/blob/master/DEVELOPMENT_MODEL.md#3-change-management).
+The evaluation process of the enhancement requests is described
+[here](https://github.com/nordic-institute/X-Road-development/blob/master/DEVELOPMENT_MODEL.md#3-change-management).
 
 ### Security Issues And Vulnerabilities
 
@@ -137,16 +162,18 @@ Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4) usin
 [Sign up](https://id.atlassian.com/signup) for an account and
 get access to the [X-Road Service Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4).
 
-Another alternative to report security issues and vulnerabilities is the X-Road bug bounty program that is run on the Intigrity platform. [Visit the program details](https://app.intigriti.com/programs/niis/x-road/detail) to get started.
+Another alternative to report security issues and vulnerabilities is the X-Road bug bounty program that is run on the
+Intigrity platform. [Visit the program details](https://app.intigriti.com/programs/niis/x-road/detail) to get started.
 
 ### Your First Code Contribution
 
-Unsure where to begin contributing to X-Road? You can start by looking through these `good first issue` and `help wanted` issues:
+Unsure where to begin contributing to X-Road? You can start by looking through these `good first issue` and
+`help wanted` issues:
 
-- [Good first issues for X-Road](https://github.com/nordic-institute/X-Road/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [Help wanted issues for X-Road](https://github.com/nordic-institute/X-Road/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-- [Good first issues for X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [Help wanted issues for X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+* [Good first issues for X-Road](https://github.com/nordic-institute/X-Road/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+* [Help wanted issues for X-Road](https://github.com/nordic-institute/X-Road/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+* [Good first issues for X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+* [Help wanted issues for X-Road Metrics](https://github.com/nordic-institute/X-Road-Metrics/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 
 X-Road can be developed locally. For instructions on how to do this, see the [build instructions](src/BUILD.md). Also,
 completing the X-Road Academy [Core Developer training](https://academy.x-road.global/courses/x-road-core-developer) is
@@ -154,69 +181,86 @@ strongly recommended.
 
 ### Submitting a Pull Request
 
-To ease the review work and to make clearer what changes are done, a pull request should contain one feature or bug fix. The larger the pull request is, the more complex it is to review. Pull requests are generally reviewed and accepted on first-come, first-served (FCFS) basis. Also, it's recommended to start the [CLA process](#sign-the-cla) already before opening a pull request.
+To ease the review work and to make clearer what changes are done, a pull request should contain one feature or bug
+fix. The larger the pull request is, the more complex it is to review. Pull requests are generally reviewed and
+accepted on first-come, first-served (FCFS) basis. Also, it's recommended to start the [CLA process](#sign-the-cla)
+already before opening a pull request.
 
-If a pull request implements a new feature or a bigger change in an existing feature, it's strongly recommended to submit an enhancement request in advance and indicate in the enhancement request that the implementation will be provided too. In that way, it's possible to ensure in advance that the pull request will be approved.
+If a pull request implements a new feature or a bigger change in an existing feature, it's strongly recommended to
+submit an enhancement request in advance and indicate in the enhancement request that the implementation will be
+provided too. In that way, it's possible to ensure in advance that the pull request will be approved.
 
-Also, in case you're planning to implement an existing backlog item, let NIIS know about your plans in advance to avoid duplicate work.
+Also, in case you're planning to implement an existing backlog item, let NIIS know about your plans in advance to avoid
+duplicate work.
 
-In case a pull request includes changes in the architecture, it's strongly recommended to discuss the changes with NIIS in advance. Agreeing on the details of the changes upfront will likely speed up the approval process.
+In case a pull request includes changes in the architecture, it's strongly recommended to discuss the changes with NIIS
+in advance. Agreeing on the details of the changes upfront will likely speed up the approval process.
 
 #### Pull Request Checklist
 
-Before opening a pull request, it's recommended to review the following checklist and make sure that all the requirements are met.
+Before opening a pull request, it's recommended to review the following checklist and make sure that all the
+requirements are met.
 
-- Are the features OK to be accepted to the project?
-- Does the PR meet the style guides?
-- Is the source code available?
-- Are all the required dependencies available?
-- No merge conflicts?
-- Is there enough test coverage?
-  - During the pull request review process it's checked that the test coverage is equal or higher than in the previous version.
-- SonarQube checks pass?
-  - During the pull request review process it's checked that SonarQube shows no bugs or code smells of severity blocker or critical.
-- Does the build and the test cases work?
-- Does the packaging work (Ubuntu & RHEL)?
-- Can the software be installed on a clean system (Ubuntu & RHEL)?
-- Can the software version be upgraded from two previous versions?
-- Has the documentation been updated?
-- Is the code licensing OK?
-- Has the contributor delivered a signed CLA?
+* Are the features OK to be accepted to the project?
+* Does the PR meet the style guides?
+* Is the source code available?
+* Are all the required dependencies available?
+* No merge conflicts?
+* Is there enough test coverage?
+  * During the pull request review process it's checked that the test coverage is equal or higher than in the previous
+    version.
+* SonarQube checks pass?
+  * During the pull request review process it's checked that SonarQube shows no bugs or code smells of severity blocker
+    or critical.
+* Does the build and the test cases work?
+* Does the packaging work (Ubuntu & RHEL)?
+* Can the software be installed on a clean system (Ubuntu & RHEL)?
+* Can the software version be upgraded from two previous versions?
+* Has the documentation been updated?
+* Is the code licensing OK?
+* Has the contributor delivered a signed CLA?
 
 ## Styleguides
 
 ### Branching Pattern
 
-Branching pattern follows the [Gitflow model](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). 
-Two long-running, perpetual branches – `master` and `develop` – together with additional branches – `feature`, `beta`, `released minor version` and `bugfix` – are used.
+Branching pattern follows the
+[Gitflow model](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). 
+Two long-running, perpetual branches – `master` and `develop` – together with additional branches – `feature`, `beta`,
+`released minor version` and `bugfix` – are used.
 
-- `master` branch is used to release X-Road software into production.
-- `develop` branch is used to accumulate features for the next big release.
-- `feature` branches are used to work on features (or closely related sets of features) to enhance X-Road core software.
-  - `feature` branches are named using the id of the feature's backlog item, e.g., `XRDDEV-123` for JIRA tickets or
+* `master` branch is used to release X-Road software into production.
+* `develop` branch is used to accumulate features for the next big release.
+* `feature` branches are used to work on features (or closely related sets of features) to enhance X-Road core software.
+  * `feature` branches are named using the id of the feature's backlog item, e.g., `XRDDEV-123` for JIRA tickets or
     `ISSUE123` for GitHub issues.
-- `beta` branches are used to prepare new production releases.
-- `released minor version` branches are used to track all patch versions released related to a specific minor version.
-  - for example, `release-7.0` branch contains version `7.0.0` and all its bugfix releases (e.g., `7.0.1`, `7.0.2`, ..., `7.0.5`, etc.).
-- `bugfix` branches are used to prepare patch releases.
+* `beta` branches are used to prepare new production releases.
+* `released minor version` branches are used to track all patch versions released related to a specific minor version.
+  * for example, `release-7.0` branch contains version `7.0.0` and all its bugfix releases (e.g., `7.0.1`, `7.0.2`,
+    ..., `7.0.5`, etc.).
+* `bugfix` branches are used to prepare patch releases.
 
-The latest development version is always available in the `develop` branch and the latest stable version in the `master` branch.
+The latest development version is always available in the `develop` branch and the latest stable version in the
+`master` branch.
 
 ### Pull Requests
 
 Pull requests made against the `X-Road/develop` branch MUST follow these conventions:
 
-- Pull request name format is `<TYPE>: <ISSUE_ID> <SHORT_DESCRIPTION>`, for example: `feat: XRDDEV-1669 Allow overriding startup parameters`
-  - `TYPE` = conventional commit type. One of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
-  - `ISSUE_ID` = id of the feature's / bug's backlog item. If the pull request is not related to any backlog item,
+* Pull request name format is `<TYPE>: <ISSUE_ID> <SHORT_DESCRIPTION>`, for example:
+  `feat: XRDDEV-1669 Allow overriding startup parameters`
+  * `TYPE` = conventional commit type. One of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
+  * `ISSUE_ID` = id of the feature's / bug's backlog item. If the pull request is not related to any backlog item,
     `ISSUE_ID` can be omitted. If the issue is a GitHub issue, it can be `ISSUE1669 Allow overriding startup parameters`
     instead.
-  - `SHORT_DESCRIPTION` = short description of the changes included in the pull request.
-- The pull request's description field must contain more detailed information about the changes. Any relevant additional information should also be provided here.
+  * `SHORT_DESCRIPTION` = short description of the changes included in the pull request.
+* The pull request's description field must contain more detailed information about the changes. Any relevant
+  additional information should also be provided here.
 
 ### Commit Messages
 
-Git commit messages MUST follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
+Git commit messages MUST follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+guidelines.
 
 The commit message should be structured as follows:
 
@@ -230,12 +274,13 @@ The commit message should be structured as follows:
 
 The message should be formatted as follows:
 
-- Separate subject from body with a blank line.
-- Do not end the subject line with a period.
-- Capitalize the subject line and each paragraph.
-- Use the imperative mood in the subject line.
-- Wrap lines at 72 characters.
-- Use the body to explain what and why you have done something. In most cases, you can leave out details about how a change has been implemented.
+* Separate subject from body with a blank line.
+* Do not end the subject line with a period.
+* Capitalize the subject line and each paragraph.
+* Use the imperative mood in the subject line.
+* Wrap lines at 72 characters.
+* Use the body to explain what and why you have done something. In most cases, you can leave out details about how a
+  change has been implemented.
 
 If a commit refers to an issue, the issue ID must be referenced. For example:
 

--- a/sidecar/SIDECAR.md
+++ b/sidecar/SIDECAR.md
@@ -1,47 +1,53 @@
 # X-Road Security Server Sidecar
 
-[![Go to X-Road Community Slack](https://img.shields.io/badge/Go%20to%20Community%20Slack-grey.svg)](https://jointxroad.slack.com/)
-[![Get invited](https://img.shields.io/badge/No%20Slack-Get%20invited-green.svg)](https://x-road.global/community)
-
-![X-Road logo](../doc/Sidecar/img/xroad_logo_small.png) 
-
-X-Road Security Server Sidecar is a containerized version of the Security Server that supports production use. The Sidecar is a Docker container that runs in the same virtual context (virtual host, Kubernetes Pod, etc.) with an information system. The Sidecar can be used for both consuming and producing services.
+X-Road Security Server Sidecar is a containerized version of the Security Server that supports production use. The
+Sidecar is a Docker container that runs in the same virtual context (virtual host, Kubernetes Pod, etc.) with an
+information system. The Sidecar can be used for both consuming and producing services.
 
 ![Security Server Sidecar](../doc/Sidecar/img/security_server_sidecar.png) 
 
 ## What Is a Sidecar?
 
-In general, sidecar is a design pattern commonly used in a microservices architecture. A sidecar is an additional component that is attached to a parent application to extend its functionalities. The original idea of the sidecar pattern is that multiple copies of the same sidecar are attached to the application so that each instance of the application has its own sidecar.
+In general, sidecar is a design pattern commonly used in a microservices architecture. A sidecar is an additional
+component that is attached to a parent application to extend its functionalities. The original idea of the sidecar
+pattern is that multiple copies of the same sidecar are attached to the application so that each instance of the
+application has its own sidecar.
 
-Despite its name, the original sidecar pattern does not work very well with the Security Server Sidecar since the Sidecar requires the same configuration and registration process as the regular Security Server. Also, even if the Security Server is containerized, the footprint of the Sidecar container is still relatively massive compared to the footprint of average containers. Therefore, it’s recommended that a single Sidecar container is shared between multiple instances of an application, and it may also be shared between different applications too. For high availability and scalability, a Sidecar cluster consisting of a primary node and multiple secondary nodes can be considered.
+Despite its name, the original sidecar pattern does not work very well with the Security Server Sidecar since the
+Sidecar requires the same configuration and registration process as the regular Security Server. Also, even if the
+Security Server is containerized, the footprint of the Sidecar container is still relatively massive compared to the
+footprint of average containers. Therefore, it’s recommended that a single Sidecar container is shared between multiple
+instances of an application, and it may also be shared between different applications too. For high availability and
+scalability, a Sidecar cluster consisting of a primary node and multiple secondary nodes can be considered.
 
 ## Sidecar Docker Image
 
 X-Road Security Server Sidecar Docker image contains a custom set of modules instead of `xroad-securityserver`:
 
-- xroad-proxy
-- xroad-addon-metaservices
-- xroad-addon-wsdlvalidator
-- xroad-autologin.
+* xroad-proxy
+* xroad-addon-metaservices
+* xroad-addon-wsdlvalidator
+* xroad-autologin.
 
-The image is built from pre-built X-Road software packages downloaded from the official [X-Road repository](https://artifactory.niis.org/xroad-release-deb).
+The image is built from pre-built X-Road software packages downloaded from the official
+[X-Road repository](https://artifactory.niis.org/xroad-release-deb).
 
 ## Security Server Sidecar Installation
 
-See the [User guide](../doc/Sidecar/security_server_sidecar_user_guide.md) for information about how to install and configure Sidecar.
+See the [User guide](../doc/Sidecar/security_server_sidecar_user_guide.md) for information about how to install and
+configure Sidecar.
 
-The Security Server Sidecar Docker image (`niis/xroad-security-server-sidecar`) has been published on [Docker Hub](https://hub.docker.com/r/niis/xroad-security-server-sidecar).
+The Security Server Sidecar Docker image (`niis/xroad-security-server-sidecar`) has been published on
+[Docker Hub](https://hub.docker.com/r/niis/xroad-security-server-sidecar).
 
 ## Key Points and Limitations for X-Road Security Server Sidecar Deployment
 
-- The Security Server Sidecar `slim` version does not support message logging, operational monitoring nor environmental monitoring functionality, which is recommended for a service provider's Security Server role.
-- The Security Server Sidecar creates and manages its own internal TLS keys and certificates and does TLS termination by itself. In a cluster setup with an external load balancer, the load balancer must use SSL passthrough so that SSL termination is done by the Sidecar.
-- The `xroad` services are run inside the container using supervisord as root, although the processes it starts are not. To avoid potential security issues, it is possible to set up Docker so that it uses Linux user namespaces, in which case root inside the container is not root (user id 0) on the host. For more information, see <https://docs.docker.com/engine/security/userns-remap/>.
-
-## How to Contribute?
-
-Submit a pull request to the [Sidecar source code Github repository](https://github.com/nordic-institute/X-Road)
-or an enhancement request to the [X-Road Service Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4).
-[Sign up](https://id.atlassian.com/signup) for an account and
-get access to the [X-Road Service Desk](https://nordic-institute.atlassian.net/servicedesk/customer/portal/4) and
-[X-Road Backlog](https://nordic-institute.atlassian.net/browse/XRDDEV).
+* The Security Server Sidecar `slim` version does not support message logging, operational monitoring nor environmental
+  monitoring functionality, which is recommended for a service provider's Security Server role.
+* The Security Server Sidecar creates and manages its own internal TLS keys and certificates and does TLS termination
+  by itself. In a cluster setup with an external load balancer, the load balancer must use SSL passthrough so that SSL
+  termination is done by the Sidecar.
+* The `xroad` services are run inside the container using supervisord as root, although the processes it starts are
+  not. To avoid potential security issues, it is possible to set up Docker so that it uses Linux user namespaces, in
+  which case root inside the container is not root (user id 0) on the host. For more information, see
+  <https://docs.docker.com/engine/security/userns-remap/>.


### PR DESCRIPTION
I changed the descriptions so that most service desk reports should go to either GitHub's issues or discussions.

Security reports should still go to the private service desk on JIRA.

Also did some minor formatting changes to the documents I touched and removed some portions from the Sidecar main readme that didn't seem relevant to be there now that it is a part of the core repository.