### PR TITLE
Fix documentation for finding xroad id for cmd conf restore

### DIFF
--- a/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
+++ b/doc/Manuals/ug-ss_x-road_6_security_server_user_guide.md
@@ -2050,7 +2050,7 @@ To restore configuration from the command line, the following data must be avail
 
 To find the X-Road ID of the security server, the following command can be used:
 
-    tar -tf /var/lib/xroad/backup/<security server conf backup file> | head -1
+    cat /etc/xroad/gpghome/openpgp-revocs.d/<file-name>.rev | grep uid
 
 It is expected that the restore command is run by the xroad user.
 


### PR DESCRIPTION
This change will replace command in documentation regarding finding the X-Road Securityserver ID for command line restore section.

It's necessary since ID cannot be extracted from backup(gpg) files anymore.