### PR TITLE
chore: replace /** to /* in licence header

### DIFF
--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleManagerImpl.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleWorker.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareToken.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenInfo.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA), Nordic Institute

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenType.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenUtil.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenWorker.java
+++ b/src/addons/hwtoken/src/main/java/ee/ria/xroad/signer/tokenmanager/token/HardwareTokenWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerClientRequestProcessor.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerClientRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerHandler.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/AbstractTimestampRequest.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/AbstractTimestampRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/BatchTimestampRequest.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/BatchTimestampRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogManager.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogRecordManager.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogRecordManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/MessageBodyManipulator.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/MessageBodyManipulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/MessageLogDatabaseCtx.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/MessageLogDatabaseCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SetTimestampingStatusMessage.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SetTimestampingStatusMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SingleTimestampRequest.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SingleTimestampRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/Task.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/Timestamper.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/Timestamper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TimestamperUtil.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TimestamperUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TimestamperWorker.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TimestamperWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AbstractMessageLogTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AbstractMessageLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AsicContainerClientRequestProcessorTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/AsicContainerClientRequestProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/DummyTSP.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/DummyTSP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/EmptyServerConf.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/EmptyServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/LogManagerTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/LogManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageBodyManipulatorTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageBodyManipulatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogIntegrationTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogPerformanceTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageRecordingLogManager.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageRecordingLogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/ShellCommandOutput.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/ShellCommandOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogArchiver.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogArchiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogCleaner.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogCleaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogManager.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestLogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTaskQueue.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTaskQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTimestamper.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTimestamper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTimestamperWorker.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestTimestamperWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestUtil.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogArchiver.java
+++ b/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogArchiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogArchiverMain.java
+++ b/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogArchiverMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogCleaner.java
+++ b/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogCleaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/MessageLogDatabaseCtx.java
+++ b/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/MessageLogDatabaseCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/MessageRecordEncryption.java
+++ b/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/MessageRecordEncryption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/InternalSslSocketFactory.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/InternalSslSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataClientRequestProcessor.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataClientRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataHandler.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/common/WsdlRequestData.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/common/WsdlRequestData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerImpl.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/Openapi3Anonymiser.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/Openapi3Anonymiser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/OverwriteAttributeFilter.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/OverwriteAttributeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerImpl.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataClientRequestProcessorTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataClientRequestProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AllowedMethodsMessage.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AllowedMethodsMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/GetListClientsMessage.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/GetListClientsMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/GetWSDLMessage.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/GetWSDLMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ListMethodsMessage.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ListMethodsMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBuffer.java
+++ b/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringDaemonSender.java
+++ b/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringDaemonSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/serverproxy/OpMonitoringServiceHandlerImpl.java
+++ b/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/serverproxy/OpMonitoringServiceHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferMemoryUsage.java
+++ b/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferMemoryUsage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferTest.java
+++ b/src/addons/op-monitoring/src/test/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoringBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerImpl.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/StdinValidator.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/StdinValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/ProxyMonitor.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/ProxyMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/MetricTypes.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/MetricTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/MonitorClient.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/MonitorClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/ProxyMonitorAgent.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxymonitor/util/ProxyMonitorAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/MetricsQueryBuilder.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/MetricsQueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerMetricsTest.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerMetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerTest.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SecurityServerMetricsMessage.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SecurityServerMetricsMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxymonitor/RestoreMonitorClientAfterTest.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxymonitor/RestoreMonitorClientAfterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/wsdlvalidator/src/main/java/ee/ria/xroad/wsdlvalidator/WSDLValidator.java
+++ b/src/addons/wsdlvalidator/src/main/java/ee/ria/xroad/wsdlvalidator/WSDLValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/addons/wsdlvalidator/src/test/java/ee/ria/xroad/wsdlvalidator/WSDLValidatorTest.java
+++ b/src/addons/wsdlvalidator/src/test/java/ee/ria/xroad/wsdlvalidator/WSDLValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainer.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerEntries.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerEntries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerNameGenerator.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerNameGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerVerifier.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicContainerVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicHelper.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicManifestBuilder.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicManifestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicUtils.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/AsicUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/OpenDocumentManifestBuilder.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/OpenDocumentManifestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/main/java/ee/ria/xroad/common/asic/TimestampData.java
+++ b/src/asic-util/src/main/java/ee/ria/xroad/common/asic/TimestampData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicContainerNameGeneratorTest.java
+++ b/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicContainerNameGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicContainerTest.java
+++ b/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicUtilsTest.java
+++ b/src/asic-util/src/test/java/ee/ria/xroad/common/asic/AsicUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asicverifier/src/main/java/ee/ria/xroad/asicverifier/AsicVerifierMain.java
+++ b/src/asicverifier/src/main/java/ee/ria/xroad/asicverifier/AsicVerifierMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/asicverifier/src/test/java/ee/ria/xroad/asicverifier/AsicContainerVerifierTest.java
+++ b/src/asicverifier/src/test/java/ee/ria/xroad/asicverifier/AsicContainerVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/ApiValidationResult.java
+++ b/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/ApiValidationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/ApiValidationResults.java
+++ b/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/ApiValidationResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3Validator.java
+++ b/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3Validator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorExtension.java
+++ b/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorGradlePlugin.java
+++ b/src/buildSrc/src/main/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorGradlePlugin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/buildSrc/src/test/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorTest.java
+++ b/src/buildSrc/src/test/java/org/niis/xroad/oasvalidatorplugin/Oas3ValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/FeignRestErrorDecoder.java
+++ b/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/FeignRestErrorDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/configuration/AdminServiceClientConfiguration.java
+++ b/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/configuration/AdminServiceClientConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/configuration/AdminServiceClientPropertyProvider.java
+++ b/src/central-server/admin-service/api-client/src/main/java/org/niis/xroad/cs/admin/client/configuration/AdminServiceClientPropertyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/application/src/main/java/org/niis/xroad/cs/admin/application/Main.java
+++ b/src/central-server/admin-service/application/src/main/java/org/niis/xroad/cs/admin/application/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/application/src/test/java/org/niis/xroad/cs/admin/application/ApplicationIpRateLimitTest.java
+++ b/src/central-server/admin-service/application/src/test/java/org/niis/xroad/cs/admin/application/ApplicationIpRateLimitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/converter/GenericBiDirectionalMapper.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/converter/GenericBiDirectionalMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/converter/GenericUniDirectionalMapper.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/converter/GenericUniDirectionalMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ApprovedCa.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ApprovedCa.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ApprovedTsa.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ApprovedTsa.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Auditable.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Auditable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthCert.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateDeletionRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateDeletionRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateRegistrationRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateRegistrationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateRegistrationRequestProcessing.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/AuthenticationCertificateRegistrationRequestProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/CaInfo.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/CaInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientDeletionRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientDeletionRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientRegistrationRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientRegistrationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientRegistrationRequestProcessing.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ClientRegistrationRequestProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKey.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKeyWithDetails.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKeyWithDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSource.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSourceType.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSourceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/DistributedFile.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/DistributedFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/FlattenedSecurityServerClientView.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/FlattenedSecurityServerClientView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroup.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroupMember.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroupMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroupMemberView.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/GlobalGroupMemberView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/HAClusterNode.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/HAClusterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/HAClusterNodeStatus.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/HAClusterNodeStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementRequestStatus.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementRequestStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementRequestView.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementRequestView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementServicesConfiguration.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ManagementServicesConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/MemberClass.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/MemberClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/MemberId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/MemberId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OcspInfo.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OcspInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Origin.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Origin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OwnerChangeRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OwnerChangeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OwnerChangeRequestProcessing.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/OwnerChangeRequestProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Request.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/RequestProcessing.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/RequestProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/RequestWithProcessing.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/RequestWithProcessing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServer.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServerClient.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServerClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServerId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SecurityServerId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ServerClient.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ServerClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ServiceId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ServiceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Subsystem.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Subsystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SubsystemId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SubsystemId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SystemParameter.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/SystemParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/TrustedAnchor.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/TrustedAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/UiUser.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/UiUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/XRoadId.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/XRoadId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/XRoadMember.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/XRoadMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/CertificationService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/CertificationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/GlobalGroupUpdateDto.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/GlobalGroupUpdateDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/HAConfigStatus.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/HAConfigStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/InitialServerConfDto.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/InitialServerConfDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/InitializationStatusDto.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/InitializationStatusDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/MemberCreationRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/MemberCreationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/OcspResponder.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/OcspResponder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/SubsystemCreationRequest.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/SubsystemCreationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/TokenInitStatus.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/dto/TokenInitStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/exception/ErrorMessage.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/exception/ErrorMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/facade/GlobalConfFacade.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/facade/GlobalConfFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/paging/Page.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/paging/Page.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/paging/PageRequestDto.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/paging/PageRequestDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/CertificationServicesService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/CertificationServicesService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ClientService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/GlobalConfGenerationService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/GlobalConfGenerationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/GlobalGroupService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/GlobalGroupService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/HAClusterStatusService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/HAClusterStatusService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/InitializationService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/InitializationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/IntermediateCasService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/IntermediateCasService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ManagementRequestService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ManagementRequestService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ManagementServicesService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ManagementServicesService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/MemberClassService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/MemberClassService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/MemberService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/MemberService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/OcspRespondersService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/OcspRespondersService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/SecurityServerService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/SecurityServerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/SubsystemService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/SubsystemService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/TokenPinValidator.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/TokenPinValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/AdminServiceProperties.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/AdminServiceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/BootstrapConfiguration.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/BootstrapConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/CentralServerSystemPropertiesInitializer.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/CentralServerSystemPropertiesInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/CurrentHAConfigStatus.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/CurrentHAConfigStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/DatabasePropertiesEnvironmentPostProcessor.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/DatabasePropertiesEnvironmentPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/JacksonConfiguration.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/JacksonConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/MvcConfig.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/MvcConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/SignerIpAddressConfiguration.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/SignerIpAddressConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/StringDeserializerModifier.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/StringDeserializerModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/TimeConfig.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/config/TimeConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/CaInfoConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/CaInfoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/CertificateConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/CertificateConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/KeyUsageConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/KeyUsageConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/OcspResponderConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/OcspResponderConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/PageConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/PageConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/PageRequestDtoConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/converter/PageRequestDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AnchorUrlCertEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AnchorUrlCertEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AnchorUrlEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AnchorUrlEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ApprovedCaEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ApprovedCaEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ApprovedTsaEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ApprovedTsaEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuditableEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuditableEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthCertEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthCertEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateDeletionRequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateDeletionRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateRegistrationRequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateRegistrationRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateRegistrationRequestProcessingEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuthenticationCertificateRegistrationRequestProcessingEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/CaInfoEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/CaInfoEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientDeletionRequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientDeletionRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientRegistrationRequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientRegistrationRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientRegistrationRequestProcessingEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ClientRegistrationRequestProcessingEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ConfigurationSigningKeyEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ConfigurationSigningKeyEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ConfigurationSourceEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ConfigurationSourceEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/DistributedFileEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/DistributedFileEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/EntityExistsAwareEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/EntityExistsAwareEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/FlattenedSecurityServerClientViewEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/FlattenedSecurityServerClientViewEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/FlattenedServerClientEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/FlattenedServerClientEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMemberEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMemberEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMembersViewEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GlobalGroupMembersViewEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GroupMemberCount.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/GroupMemberCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/HAClusterStatusViewEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/HAClusterStatusViewEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ManagementRequestViewEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ManagementRequestViewEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/MemberClassEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/MemberClassEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/MemberIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/MemberIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OcspInfoEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OcspInfoEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OwnerChangeRequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OwnerChangeRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OwnerChangeRequestProcessingEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/OwnerChangeRequestProcessingEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestProcessingEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestProcessingEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestWithProcessingEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/RequestWithProcessingEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerClientEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerClientEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SecurityServerIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ServerClientEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ServerClientEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ServiceIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/ServiceIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SubsystemEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SubsystemEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SubsystemIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SubsystemIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SystemParameterEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/SystemParameterEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/TrustedAnchorEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/TrustedAnchorEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/UiUserEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/UiUserEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/XRoadIdEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/XRoadIdEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/XRoadMemberEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/XRoadMemberEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/ClientIdConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/ClientIdConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/ManagementRequestStatusConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/ManagementRequestStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/XRoadObjectTypeConverter.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/converter/XRoadObjectTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ClientIdMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ClientIdMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/DistributedFileMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/DistributedFileMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/FlattenedSecurityServerClientViewMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/FlattenedSecurityServerClientViewMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberViewMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberViewMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ManagementRequestViewMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/ManagementRequestViewMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/MemberClassMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/MemberClassMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/RequestMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/RequestMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerClientMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerClientMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerIdMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerIdMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SystemParameterMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/SystemParameterMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/validation/EntityIdentifier.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/validation/EntityIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/facade/GlobalConfFacadeImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/facade/GlobalConfFacadeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AnchorUrlCertRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AnchorUrlCertRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AnchorUrlRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AnchorUrlRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ApprovedCaRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ApprovedCaRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AuthCertRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AuthCertRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AuthenticationCertificateRegistrationRequestRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/AuthenticationCertificateRegistrationRequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/CaInfoRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/CaInfoRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ClientRegistrationRequestRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ClientRegistrationRequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ConfigurationSourceRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ConfigurationSourceRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/DistributedFileRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/DistributedFileRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/FindOrCreateAwareRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/FindOrCreateAwareRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/FlattenedSecurityServerClientRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/FlattenedSecurityServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GenericRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GenericRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupMemberRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupMemberRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupMembersViewRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupMembersViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/GlobalGroupRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/HAClusterStatusViewRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/HAClusterStatusViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/IdentifierRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/IdentifierRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ManagementRequestViewRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ManagementRequestViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/MemberClassRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/MemberClassRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/OcspInfoRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/OcspInfoRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/RequestRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/RequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SecurityServerClientRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SecurityServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SecurityServerRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SecurityServerRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ServerClientRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/ServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SubsystemRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SubsystemRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SystemParameterRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/SystemParameterRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/XRoadMemberRepository.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/XRoadMemberRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/paging/PageDto.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/paging/PageDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/paging/StableSortHelper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/repository/paging/StableSortHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/AbstractTokenConsumer.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/AbstractTokenConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationBackupGenerator.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationBackupGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationRestorationService.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationRestorationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ClientServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ClientServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/HAClusterStatusServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/HAClusterStatusServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ManagementServicesServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ManagementServicesServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/MemberClassServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/MemberClassServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/MemberServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/MemberServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SubsystemServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SubsystemServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SystemParameterServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SystemParameterServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/TokenPinValidatorImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/TokenPinValidatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateDeletionRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateDeletionRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientDeletionRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientDeletionRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ManagementRequestServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ManagementRequestServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/RequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/RequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/validation/CertificateProfileInfoValidator.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/validation/CertificateProfileInfoValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/converter/OcspResponderConverterTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/converter/OcspResponderConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/EntityExistsAwareEntityTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/EntityExistsAwareEntityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ClientIdMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ClientIdMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyWithDetailsMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyWithDetailsMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/FlattenedSecurityServerClientViewMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/FlattenedSecurityServerClientViewMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/GlobalGroupMemberMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/MemberClassMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/MemberClassMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/RequestMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/RequestMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerIdMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/SecurityServerIdMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/SystemParameterMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/SystemParameterMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/validation/EntityIdentifierValidatorTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/validation/EntityIdentifierValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationRestorationServiceTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationRestorationServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ClientServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ClientServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/GlobalGroupServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/HaClusterStatusServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/HaClusterStatusServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ManagementServicesServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ManagementServicesServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/MemberClassServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/MemberClassServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/MemberServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/MemberServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SigningKeyActionsResolverTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SigningKeyActionsResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/StableSortHelperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/StableSortHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SubsystemServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SubsystemServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SystemParameterServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SystemParameterServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/TokenPinValidatorImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/TokenPinValidatorImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/ManagementRequestServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/ManagementRequestServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/util/DeviationTestUtils.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/util/DeviationTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/validation/CertificateProfileInfoValidatorTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/validation/CertificateProfileInfoValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/ConfGeneratorException.java
+++ b/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/ConfGeneratorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/ApprovedCertificationServiceDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/ApprovedCertificationServiceDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GlobalGroupConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GlobalGroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberFilterModelConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberFilterModelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberViewConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/GroupMemberViewConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/HAClusterNodeDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/HAClusterNodeDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/ManagementServicesConfigurationMapper.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/ManagementServicesConfigurationMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/MemberCreationRequestMapper.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/MemberCreationRequestMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/OcspResponderDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/OcspResponderDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PageRequestConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PageRequestConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedClientsConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedClientsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedGroupMemberConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedGroupMemberConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedManagementRequestsConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagedManagementRequestsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagingMetadataConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/PagingMetadataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/SecurityServerConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/SecurityServerConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/SubsystemCreationRequestMapper.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/SubsystemCreationRequestMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientIdDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientIdDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ManagementRequestDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/ManagementRequestDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/MemberClassDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/MemberClassDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/SecurityServerDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/SecurityServerDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/SubsystemDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/db/SubsystemDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ClientTypeDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ClientTypeDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/InitialServerConfDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/InitialServerConfDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/InitializationStatusDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/InitializationStatusDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestDtoTypeConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestDtoTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestOriginDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestOriginDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestStatusConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/ManagementRequestStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/SecurityServerIdDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/SecurityServerIdDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/XRoadObjectTypeDtoConverter.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/converter/model/XRoadObjectTypeDtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/BackupsApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/BackupsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/CertificationServicesController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/CertificationServicesController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ClientsApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ClientsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ControllerConfiguration.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ControllerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/GlobalGroupsApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/GlobalGroupsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/InitializationApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/InitializationApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ManagementRequestsApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ManagementRequestsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ManagementServicesController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/ManagementServicesController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/MemberClassesApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/MemberClassesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/MembersApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/MembersApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/OcspRespondersController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/OcspRespondersController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SecurityServersApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SecurityServersApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SubsystemsApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SubsystemsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SystemApiController.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/SystemApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/HostAddressValidator.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/HostAddressValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidHostAddress.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidHostAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidX509Certificate.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidX509Certificate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidXRoadId.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/ValidXRoadId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/X509CertificateValidator.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/X509CertificateValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/XRoadIdValidator.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/openapi/validator/XRoadIdValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/AdminServicePermissionEvaluator.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/AdminServicePermissionEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/ManagementRequestTypeResolver.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/ManagementRequestTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/TargetTypeResolver.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/TargetTypeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/AbstractDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/AbstractDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/GlobalGroupConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/GlobalGroupConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientIdDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ClientIdDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ManagementRequestDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/ManagementRequestDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/MemberClassDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/MemberClassDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/SecurityServerDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/SecurityServerDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/SubsystemDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/db/SubsystemDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/model/SecurityServerIdDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/model/SecurityServerIdDtoConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/openapi/BackupsApiControllerTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/openapi/BackupsApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/config/JpaConfiguration.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/config/JpaConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/ExampleExt.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/ExampleExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/ExampleMatcherExt.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/ExampleMatcherExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/TypedExampleExt.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/TypedExampleExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/TypedExampleMatcherExt.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/example/TypedExampleMatcherExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAnchorUrlCertRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAnchorUrlCertRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAnchorUrlRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAnchorUrlRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaApprovedCaRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaApprovedCaRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAuthCertRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAuthCertRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAuthenticationCertificateRegistrationRequestRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaAuthenticationCertificateRegistrationRequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaCaInfoRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaCaInfoRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaClientRegistrationRequestRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaClientRegistrationRequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaConfigurationSourceRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaConfigurationSourceRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaDistributedFileRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaDistributedFileRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaFindOrCreateAwareRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaFindOrCreateAwareRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaFlattenedSecurityServerClientRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaFlattenedSecurityServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupMemberRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupMemberRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupMembersViewRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupMembersViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaGlobalGroupRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaHAClusterStatusViewRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaHAClusterStatusViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaIdentifierRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaIdentifierRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaManagementRequestViewRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaManagementRequestViewRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaMemberClassRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaMemberClassRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaOcspInfoRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaOcspInfoRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaRequestRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaRequestRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSecurityServerClientRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSecurityServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSecurityServerRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSecurityServerRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaServerClientRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaServerClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSubsystemRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSubsystemRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSystemParameterRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaSystemParameterRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaXRoadMemberRepository.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/JpaXRoadMemberRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/util/CriteriaBuilderUtil.java
+++ b/src/central-server/admin-service/infra-jpa/src/main/java/org/niis/xroad/cs/admin/jpa/repository/util/CriteriaBuilderUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignClientsApi.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignClientsApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignInitializationApi.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignInitializationApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignManagementServicesApi.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/api/FeignManagementServicesApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/container/database/LiquibaseExecutor.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/container/database/LiquibaseExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/BackupStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/BackupStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ClientsStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ClientsStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/InitializationStepDefs.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/InitializationStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/CentralServerInitializationHook.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/CentralServerInitializationHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/ClearBackupsHook.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/ClearBackupsHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/DatabaseResetBeforeScenarioHook.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/DatabaseResetBeforeScenarioHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/DefaultServerStateInitializationHook.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/DefaultServerStateInitializationHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/MockServerResetHook.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/MockServerResetHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/CentralServerInitializer.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/CentralServerInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/ScenarioValueEvaluator.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/ScenarioValueEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/TargetHostUrlProvider.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/TargetHostUrlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/constants/Constants.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/constants/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/InitializationStepDefs.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/InitializationStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/LoginStepDefs.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/LoginStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/NavigationStepDefs.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/NavigationStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/mappers/ParameterMappers.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/glue/mappers/ParameterMappers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/CertificateViewPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/CertificateViewPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/CommonPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/CommonPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalConfigurationPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalConfigurationPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalConfigurationTrustedAnchorsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalConfigurationTrustedAnchorsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalGroupDetailsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/GlobalGroupDetailsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/InitializationPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/InitializationPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/IntermediateCasPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/IntermediateCasPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/LoginPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/LoginPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/ManagementRequestsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/ManagementRequestsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberDetailsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberDetailsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberSubsystemsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/MemberSubsystemsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/OcspRespondersPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/OcspRespondersPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerAuthCertificatesPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerAuthCertificatesPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerClientsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerClientsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerDetailsPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerDetailsPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerNavigationObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServerNavigationObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServersPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SecurityServersPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsApiKeysPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsApiKeysPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsGlobalResourcesPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsGlobalResourcesPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsMemberClassesPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SettingsMemberClassesPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SystemSettingsParametersPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/SystemSettingsParametersPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/TimestampingServicesPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/TimestampingServicesPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/TrustServicesPageObj.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/page/TrustServicesPageObj.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/SeleniumUtils.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/SeleniumUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/VuetifyHelper.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/VuetifyHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/ManagementServiceMain.java
+++ b/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/ManagementServiceMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/configuration/TraceIdFilter.java
+++ b/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/configuration/TraceIdFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/configuration/WebServerCustomizer.java
+++ b/src/central-server/management-service/application/src/main/java/org/niis/xroad/cs/management/application/configuration/WebServerCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/application/src/test/java/org/niis/xroad/cs/management/application/ApplicationIpRateLimitTest.java
+++ b/src/central-server/management-service/application/src/test/java/org/niis/xroad/cs/management/application/ApplicationIpRateLimitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/management-service/core-api/src/main/java/org/niis/xroad/cs/management/core/api/ManagementRequestService.java
+++ b/src/central-server/management-service/core-api/src/main/java/org/niis/xroad/cs/management/core/api/ManagementRequestService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/configuration/ManagementServiceConfiguration.java
+++ b/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/configuration/ManagementServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/configuration/ManagementServiceProperties.java
+++ b/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/configuration/ManagementServiceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/service/GlobalConfUpdater.java
+++ b/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/service/GlobalConfUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/service/ManagementRequestServiceImpl.java
+++ b/src/central-server/management-service/core/src/main/java/org/niis/xroad/cs/management/core/service/ManagementRequestServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/core/src/test/java/org/niis/xroad/cs/management/core/service/ManagementRequestServiceImplTest.java
+++ b/src/central-server/management-service/core/src/test/java/org/niis/xroad/cs/management/core/service/ManagementRequestServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/infra-api-soap/src/main/java/org/niis/xroad/cs/management/api/ManagementRequestController.java
+++ b/src/central-server/management-service/infra-api-soap/src/main/java/org/niis/xroad/cs/management/api/ManagementRequestController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/constants/CommonTestData.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/constants/CommonTestData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/AdminApiMockStepDefs.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/AdminApiMockStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/DeletionManagementRequestStepDefs.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/DeletionManagementRequestStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/mapper/ParameterMappers.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/mapper/ParameterMappers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/MockServerResetHook.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/hook/MockServerResetHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/Main.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/RegistrationServiceConfiguration.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/RegistrationServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/RegistrationServiceProperties.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/RegistrationServiceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/TraceIdFilter.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/TraceIdFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/WebServerCustomizer.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/config/WebServerCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestController.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/AdminApiService.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/AdminApiService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/AdminApiServiceImpl.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/AdminApiServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/GlobalConfUpdater.java
+++ b/src/central-server/registration-service/src/main/java/org/niis/xroad/cs/registrationservice/service/GlobalConfUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/ApplicationIpRateLimitTest.java
+++ b/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/ApplicationIpRateLimitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestApiTest.java
+++ b/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestApiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestControllerTest.java
+++ b/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/testutil/TestGlobalConf.java
+++ b/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/testutil/TestGlobalConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/ApiKeyAuthenticationHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/ApiKeyAuthenticationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/ApiKeyAuthenticationManager.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/ApiKeyAuthenticationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/AuthenticationHeaderDecoder.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/AuthenticationHeaderDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/AuthenticationIpWhitelist.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/AuthenticationIpWhitelist.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/GrantedAuthorityMapper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/GrantedAuthorityMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/Http401AuthenticationEntryPoint.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/Http401AuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PamAuthenticationProvider.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PamAuthenticationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PamAuthenticationProviderConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PamAuthenticationProviderConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PasswordEncoderConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/PasswordEncoderConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/SaltlessPasswordEncoder.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/SaltlessPasswordEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/ApiWebSecurityConfigurerAdapter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/ApiWebSecurityConfigurerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/CookieAndSessionCsrfTokenRepository.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/CookieAndSessionCsrfTokenRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/FormLoginWebSecurityConfigurerAdapter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/FormLoginWebSecurityConfigurerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/ManageApiKeysWebSecurityConfigurerAdapter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/ManageApiKeysWebSecurityConfigurerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/MultiAuthWebSecurityConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/MultiAuthWebSecurityConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/StaticAssetsWebSecurityConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/auth/securityconfigurer/StaticAssetsWebSecurityConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/dto/BackupFile.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/dto/BackupFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/repository/BackupRepository.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/repository/BackupRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupRestoreEvent.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupRestoreEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupService.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupValidator.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BackupValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BaseConfigurationBackupGenerator.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/BaseConfigurationBackupGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/ConfigurationRestorationService.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/common/backup/service/ConfigurationRestorationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/AddCorrelationIdFilter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/AddCorrelationIdFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/FileUploadEndpointsConfiguration.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/FileUploadEndpointsConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/LimitRequestSizesFilter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/LimitRequestSizesFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/NotificationApiDisableSessionTimeoutFilter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/NotificationApiDisableSessionTimeoutFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/PropertyFileReadingEnvironmentPostProcessor.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/PropertyFileReadingEnvironmentPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/UserRoleConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/UserRoleConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditDataHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditDataHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventHandlerInterceptor.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventHandlerInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventLoggingFacade.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventLoggingFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventLoggingFacadeImpl.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventLoggingFacadeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventMethod.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditEventMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditedApplicationEventListener.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/AuditedApplicationEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedAuditDataHolder.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedAuditDataHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedAuditEventData.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedAuditEventData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedLoggedAuditEvents.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RequestScopedLoggedAuditEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RestApiAuditEvent.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RestApiAuditEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RestApiAuditProperty.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/RestApiAuditProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/WebMvcConfig.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/config/audit/WebMvcConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/ApiKeysController.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/ApiKeysController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/CommonModuleEndpointPaths.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/CommonModuleEndpointPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/NotificationsSessionStatusApiController.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/controller/NotificationsSessionStatusApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/converter/PublicApiKeyDataConverter.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/converter/PublicApiKeyDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/dao/PersistentApiKeyDAOImpl.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/dao/PersistentApiKeyDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/InvalidRoleNameException.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/InvalidRoleNameException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/PersistentApiKeyType.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/PersistentApiKeyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/PublicApiKeyData.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/PublicApiKeyData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/Role.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/domain/Role.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/dto/PlaintextApiKeyDto.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/dto/PlaintextApiKeyDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ApplicationExceptionHandler.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ApplicationExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ExceptionTranslator.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ExceptionTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/LimitRequestSizesException.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/LimitRequestSizesException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ResponseStatusUtil.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ResponseStatusUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/SpringInternalExceptionHandler.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/SpringInternalExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ValidationErrorHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/exceptions/ValidationErrorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/ControllerUtil.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/ControllerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/UserApiController.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/UserApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/IdentifierChars.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/IdentifierChars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/NoControlChars.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/NoControlChars.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/NoControlCharsValidator.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/openapi/validator/NoControlCharsValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/ApiKeyService.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/ApiKeyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/FileVerifier.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/FileVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/SignerNotReachableException.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/SignerNotReachableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/UnhandledWarningsException.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/service/UnhandledWarningsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/PersistenceUtils.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/PersistenceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/RequestHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/RequestHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/SecurityHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/SecurityHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/UsernameHelper.java
+++ b/src/common/common-admin-api/src/main/java/org/niis/xroad/restapi/util/UsernameHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/AuthenticationHeaderDecoderTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/AuthenticationHeaderDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/AuthenticationIpWhitelistTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/AuthenticationIpWhitelistTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/GrantedAuthorityMapperTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/GrantedAuthorityMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/RoleTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/auth/RoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/common/backup/service/BackupServiceTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/common/backup/service/BackupServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/common/backup/service/BackupValidatorTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/common/backup/service/BackupValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/config/audit/AuditLoggingTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/config/audit/AuditLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/controller/ApiKeysControllerTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/controller/ApiKeysControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/service/ApiKeyServiceCachingIntegrationTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/service/ApiKeyServiceCachingIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/service/ApiKeyServiceIntegrationTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/service/ApiKeyServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/test/AbstractSpringMvcTest.java
+++ b/src/common/common-admin-api/src/test/java/org/niis/xroad/restapi/test/AbstractSpringMvcTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/CustomPostgreSQLDialect.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/CustomPostgreSQLDialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/DatabaseCtx.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/DatabaseCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/HibernateUtil.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/HibernateUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres10FixedImplicitSequenceDialect.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres10FixedImplicitSequenceDialect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres10FixedImplicitSequenceDialectResolver.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres10FixedImplicitSequenceDialectResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres12FixedImplicitSequenceDialectResolver.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres12FixedImplicitSequenceDialectResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres14FixedImplicitSequenceDialectResolver.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/Postgres14FixedImplicitSequenceDialectResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-db/src/main/java/ee/ria/xroad/common/db/TransactionCallback.java
+++ b/src/common/common-db/src/main/java/ee/ria/xroad/common/db/TransactionCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/DataIntegrityException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/DataIntegrityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/NotFoundException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/SecurityServerNotFoundException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/SecurityServerNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/ServiceException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/ServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/ValidationFailureException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/ValidationFailureException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/util/CommonDeviationMessage.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/util/CommonDeviationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/AbstractConverter.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/AbstractConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/ClientIdConverter.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/ClientIdConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/DtoConverter.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/DtoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/SecurityServerIdConverter.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/converter/SecurityServerIdConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/Deviation.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/Deviation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAware.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAwareException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAwareException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAwareRuntimeException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationAwareRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationCodes.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationProvider.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/DeviationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/ErrorDeviation.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/ErrorDeviation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/WarningDeviation.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/WarningDeviation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/WrappedStatusCarryingException.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/exceptions/WrappedStatusCarryingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/test/java/org/niis/xroad/restapi/converter/ClientIdConverterTest.java
+++ b/src/common/common-domain/src/test/java/org/niis/xroad/restapi/converter/ClientIdConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-domain/src/test/java/org/niis/xroad/restapi/converter/SecurityServerIdConverterTest.java
+++ b/src/common/common-domain/src/test/java/org/niis/xroad/restapi/converter/SecurityServerIdConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestBuilder.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestClient.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestSender.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestSoapExecutor.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/ManagementRequestSoapExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ClientRegRequest.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ClientRegRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ManagementRequest.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ManagementRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ManagementRequestType.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/ManagementRequestType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/OwnerChangeRequest.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/model/OwnerChangeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestParser.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestUtil.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestVerifier.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/ManagementRequestVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertDeletionRequestDecoderCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertDeletionRequestDecoderCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertRegRequestDecoderCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertRegRequestDecoderCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/BaseClientRequestCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/BaseClientRequestCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ClientDeletionRequestCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ClientDeletionRequestCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ClientRegRequestCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ClientRegRequestCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ManagementRequestDecoderCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/ManagementRequestDecoderCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/OwnerChangeRequestCallback.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/OwnerChangeRequestCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/util/ManagementRequestVerificationUtils.java
+++ b/src/common/common-management-request/src/main/java/org/niis/xroad/common/managementrequest/verify/decode/util/ManagementRequestVerificationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/ManagementRequestSenderTest.java
+++ b/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/ManagementRequestSenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertDeletionRequestDecoderCallbackTest.java
+++ b/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/AuthCertDeletionRequestDecoderCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/ClientDeletionRequestCallbackTest.java
+++ b/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/ClientDeletionRequestCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/ManagementRequestDecoderCallbackTest.java
+++ b/src/common/common-management-request/src/test/java/org/niis/xroad/common/managementrequest/verify/decode/ManagementRequestDecoderCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestAuthRegTypeRequest.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestAuthRegTypeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestBaseManagementRequest.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestBaseManagementRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestGenericClientRequest.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestGenericClientRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestGenericClientRequestBuilder.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestGenericClientRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestManagementRequestBuilder.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestManagementRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestManagementRequestPayload.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestManagementRequestPayload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestSimpleManagementRequest.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestSimpleManagementRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestSimpleManagementRequestBuilder.java
+++ b/src/common/common-management-request/src/testFixtures/java/org/niis/xroad/common/managemenetrequest/test/TestSimpleManagementRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/AbstractLogManager.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/AbstractLogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/AbstractLogRecord.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/AbstractLogRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/FindByQueryId.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/FindByQueryId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/Hash.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/Hash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/LogMessage.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/LogMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/LogRecord.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/LogRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageLogProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageRecord.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/MessageRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/RestLogMessage.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/RestLogMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/SoapLogMessage.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/SoapLogMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/TimestampMessage.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/TimestampMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/TimestampRecord.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/TimestampRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/ArchiveDigest.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/ArchiveDigest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/DigestEntry.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/DigestEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionConfig.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionConfigProvider.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionConfigProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionMember.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/EncryptionMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/GPGOutputStream.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/GPGOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/Grouping.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/Grouping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/GroupingStrategy.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/GroupingStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/JsonUtils.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/JsonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LinkingInfoBuilder.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LinkingInfoBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveBase.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCache.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveWriter.java
+++ b/src/common/common-messagelog/src/main/java/ee/ria/xroad/common/messagelog/archive/LogArchiveWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/HashTest.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/HashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/GPGInputStream.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/GPGInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/GPGOutputStreamTest.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/GPGOutputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCacheTest.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveTest.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/LogArchiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/MemberEncryptionConfigProviderTest.java
+++ b/src/common/common-messagelog/src/test/java/ee/ria/xroad/common/messagelog/archive/MemberEncryptionConfigProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/AbstractOpMonitoringBuffer.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/AbstractOpMonitoringBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringDaemonEndpoints.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringDaemonEndpoints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringDaemonHttpClient.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringDaemonHttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringData.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringRequests.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringRequests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringSystemProperties.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/OpMonitoringSystemProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/StoreOpMonitoringDataRequest.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/StoreOpMonitoringDataRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/StoreOpMonitoringDataResponse.java
+++ b/src/common/common-op-monitoring/src/main/java/ee/ria/xroad/common/opmonitoring/StoreOpMonitoringDataResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/BigAttachmentWriter.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/BigAttachmentWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/CustomAttachmentWriter.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/CustomAttachmentWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/ExpectedCodedException.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/ExpectedCodedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/HttpUtils.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/HttpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/MultipartWriter.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/MultipartWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/OcspTestUtils.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/OcspTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/Request.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputData.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputDataMultipart.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputDataMultipart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputDataSimple.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestInputDataSimple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestNames.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestProps.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/RequestProps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/SingleRequestSender.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/SingleRequestSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/SoapMessageUtils.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/SoapMessageUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/TestCertUtil.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/TestCertUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/TestRequest.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/TestRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/TestSecurityUtil.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/TestSecurityUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/certificateprofile/impl/TestCertificateProfileInfoProvider.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/certificateprofile/impl/TestCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/conf/globalconf/EmptyGlobalConf.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/conf/globalconf/EmptyGlobalConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/conf/globalconf/TestGlobalConfImpl.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/conf/globalconf/TestGlobalConfImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/junit/helper/WithInOrder.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/junit/helper/WithInOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-test/src/test/java/ee/ria/xroad/common/RequestTest.java
+++ b/src/common/common-test/src/test/java/ee/ria/xroad/common/RequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/OptionalConfPart.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/OptionalConfPart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/OptionalPartsConf.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/OptionalPartsConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/SessionTimeoutFilter.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/SessionTimeoutFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/UIServices.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/UIServices.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/AuthFilter.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/AuthFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/JAASPrincipal.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/JAASPrincipal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/JAASRole.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/JAASRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/PAMLoginModule.java
+++ b/src/common/common-ui/src/main/java/ee/ria/xroad/commonui/jaas/PAMLoginModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-ui/src/test/java/ee/ria/xroad/commonui/OptionalPartsConfBehavior.java
+++ b/src/common/common-ui/src/test/java/ee/ria/xroad/commonui/OptionalPartsConfBehavior.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/AddOnStatusDiagnostics.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/AddOnStatusDiagnostics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/AuditLogger.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/AuditLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/BackupEncryptionStatusDiagnostics.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/BackupEncryptionStatusDiagnostics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/CertificationServiceDiagnostics.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/CertificationServiceDiagnostics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/CertificationServiceStatus.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/CertificationServiceStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/CodedException.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/CodedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/CodedExceptionWithHttpStatus.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/CodedExceptionWithHttpStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/CommonMessages.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/CommonMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/DefaultFilepaths.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/DefaultFilepaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsErrorCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/ErrorCodes.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/ErrorCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/MessageLogArchiveEncryptionMember.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/MessageLogArchiveEncryptionMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/MessageLogEncryptionStatusDiagnostics.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/MessageLogEncryptionStatusDiagnostics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/OcspResponderStatus.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/OcspResponderStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/PortNumbers.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/PortNumbers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/SystemPropertiesLoader.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/SystemPropertiesLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/Version.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/AuthCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/AuthCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/CertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/CertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/CertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/CertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/DnFieldDescription.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/DnFieldDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/DnFieldValue.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/DnFieldValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/GetCertificateProfile.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/GetCertificateProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/SignCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/SignCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/AbstractCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/AbstractCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/AuthCertificateProfileInfoParameters.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/AuthCertificateProfileInfoParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/BasicCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/BasicCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldDescriptionImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldDescriptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldLabelLocalizationKey.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldLabelLocalizationKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldValueImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/DnFieldValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaAuthCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaAuthCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaSignCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaSignCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EnumLocalizedFieldDescriptionImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/EnumLocalizedFieldDescriptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKAuthCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKAuthCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKSignCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKSignCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoAuthCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoAuthCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoSignCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/FoSignCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsAuthCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsAuthCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsSignCertificateProfileInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/IsSignCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/LocalizedFieldDescriptionImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/LocalizedFieldDescriptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SignCertificateProfileInfoParameters.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SignCertificateProfileInfoParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteIdCertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteIdCertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkKlass3CertificateProfileInfoProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/certificateprofile/impl/SkKlass3CertificateProfileInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/AbstractXmlConf.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/AbstractXmlConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/ConfProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/ConfProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/InternalSSLKey.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/InternalSSLKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/AbstractConfigurationPart.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/AbstractConfigurationPart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/Configuration.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationAnchorV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationAnchorV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationConstants.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectory.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationFile.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationLocation.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationParser.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadata.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationSignature.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationSignature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationSource.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/FileConsumer.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/FileConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/PrivateParametersSchemaValidatorV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/PrivateParametersSchemaValidatorV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/PrivateParametersV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/PrivateParametersV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersSchemaValidatorV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersSchemaValidatorV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/DigestList.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/DigestList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/DigestValue.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/DigestValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainBuilder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainReferenceResolver.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainReferenceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainVerifier.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/hashchain/HashChainVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/AbstractGroupId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/AbstractGroupId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/ClientId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/ClientId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/GlobalGroupId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/GlobalGroupId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierTypeConverter.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierXmlNodeParser.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierXmlNodeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierXmlNodePrinter.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/IdentifierXmlNodePrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/LocalGroupId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/LocalGroupId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/SecurityServerId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/SecurityServerId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/ServiceId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/ServiceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/XRoadId.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/XRoadId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/XRoadObjectType.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/identifier/XRoadObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/AbstractSoapMessage.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/AbstractSoapMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/CheckConsistency.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/CheckConsistency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/JaxbUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/JaxbUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/MultipartOutputStream.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/MultipartOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/MultipartSoapMessageEncoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/MultipartSoapMessageEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/ProtocolVersion.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/ProtocolVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RepresentedParty.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RepresentedParty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RequestHash.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RequestHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RequiredHeaderFieldsChecker.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RequiredHeaderFieldsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestMessage.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestRequest.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestResponse.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/RestResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SaxSoapParserImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SaxSoapParserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SimpleSoapEncoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SimpleSoapEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/Soap.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/Soap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapBuilder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapFault.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapHeader.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessage.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageConsumer.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageDecoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageEncoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapMessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapNamespacePrefixMapper.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapNamespacePrefixMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapParser.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapParserImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapParserImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/SoapUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/message/ValidatableField.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/message/ValidatableField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/metadata/MetadataRequests.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/metadata/MetadataRequests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/DefaultMonitorAgentImpl.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/DefaultMonitorAgentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/FaultInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/FaultInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MessageInfo.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MessageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MonitorAgent.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MonitorAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MonitorAgentProvider.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/MonitorAgentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/ServerProxyFailed.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/ServerProxyFailed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/SuccessfulMessage.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/monitoring/SuccessfulMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/Helper.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/Helper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/IdResolver.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/IdResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/MessagePart.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/MessagePart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/Signature.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/Signature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureData.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureManifest.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureManifest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureSchemaValidator.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SignatureSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SigningRequest.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/signature/SigningRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AbstractHttpSender.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AbstractHttpSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AdminPort.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AdminPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AsyncHttpSender.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AsyncHttpSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AtomicSave.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/AtomicSave.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CacheInputStream.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CacheInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CachingStream.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CachingStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertHashBasedOcspResponderClient.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertHashBasedOcspResponderClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CpuStats.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CpuStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CryptoUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CryptoUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FISubjectClientIdDecoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FISubjectClientIdDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FileContentChangeChecker.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FileContentChangeChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/Fn.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/Fn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FoSubjectClientIdDecoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/FoSubjectClientIdDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HashCalculator.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HashCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HttpHeaders.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HttpHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HttpSender.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/HttpSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/IdlePercentCalculator.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/IdlePercentCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/IsSubjectClientIdDecoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/IsSubjectClientIdDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/JobManager.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/JobManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/JsonUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/JsonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MessageFileNames.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MessageFileNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MessageSendingJob.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MessageSendingJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MimeTypes.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MimeTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MimeUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MimeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MultipartEncoder.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/MultipartEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/NetStats.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/NetStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/NoCoverage.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/NoCoverage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/OpenapiDescriptionFiletype.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/OpenapiDescriptionFiletype.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PasswordStore.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PasswordStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PerformanceLogger.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PerformanceLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PeriodicJob.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PeriodicJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PrefixedProperties.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/PrefixedProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/ResourceUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/ResourceUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SchemaValidator.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SkCprKlass3.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SkCprKlass3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/StartStop.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/StartStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SystemMetrics.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/SystemMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TokenPinPolicy.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TokenPinPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/UriUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/UriUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/Validation.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/Validation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/XmlUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/XmlUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatchListener.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatchListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcher.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunner.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcherStartupListener.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/filewatcher/FileWatcherStartupListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ExternalProcessRunner.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ExternalProcessRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ProcessFailedException.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ProcessFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ProcessNotExecutableException.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/process/ProcessNotExecutableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/validation/StringValidationUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/validation/StringValidationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/AuditLoggerTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/AuditLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/OcspResponderStatusSerializationTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/OcspResponderStatusSerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/SystemPropertiesLoaderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/SystemPropertiesLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/BasicCertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/BasicCertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaCertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/EjbcaCertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKCertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/FiVRKCertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/FoCertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/FoCertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteidCertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkEsteidCertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkKlass3CertificateProfileInfoProviderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/certificateprofile/impl/SkKlass3CertificateProfileInfoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationAnchorTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationAnchorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationLocationTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationLocationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadataTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/hashchain/HashChainBuilderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/hashchain/HashChainBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/hashchain/HashChainVerifierTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/hashchain/HashChainVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/ClientIdTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/ClientIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/IdentifierEqualsAndHashCodeTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/IdentifierEqualsAndHashCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/IdentifierTypeConverterTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/IdentifierTypeConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/XRoadIdTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/XRoadIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/XRoadObjectTypeTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/identifier/XRoadObjectTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/message/RestRequestTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/message/RestRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/message/RestResponseTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/message/RestResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/message/SoapMessageTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/message/SoapMessageTest.java
@@ -1,4 +1,4 @@
-/**\
+/*\
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/message/SoapMessageTestUtil.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/message/SoapMessageTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/AtomicSaveTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/AtomicSaveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/CertUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/CertUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/ExpectedCodedException.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/ExpectedCodedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/FISubjectClientIdDecoderTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/FISubjectClientIdDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/FileContentChangeCheckerTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/FileContentChangeCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/IdlePercentCalculatorBehavior.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/IdlePercentCalculatorBehavior.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/JsonUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/JsonUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/MimeUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/MimeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/NetStatsBehavior.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/NetStatsBehavior.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/PasswordStoreTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/PasswordStoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/PrefixedPropertiesTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/PrefixedPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SchemaValidatorTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SkCprKlass3Test.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SkCprKlass3Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SystemMetricsBehavior.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/SystemMetricsBehavior.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/TokenPinPolicyTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/TokenPinPolicyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/UriUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/UriUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/XmlUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/XmlUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2015 Estonian Information System Authority (RIA), Population Register Centre (VRK)
  *

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunnerTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/filewatcher/FileWatcherRunnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/process/ExternalProcessRunnerTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/process/ExternalProcessRunnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertChain.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertChainVerifier.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertChainVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertHelper.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/cert/CertHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/ApprovedCAInfo.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/ApprovedCAInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/AuthKey.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/AuthKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/AuthTrustManager.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/AuthTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfProvider.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfUpdater.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalGroupInfo.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalGroupInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/MemberInfo.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/MemberInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/GlobalConfExtensions.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/GlobalConfExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchInterval.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchInterval.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalSchemaValidator.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalStdinValidator.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalStdinValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdate.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdateSchemaValidator.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdateSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/StdinValidator.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconfextension/StdinValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspCache.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspVerifier.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspVerifierOptions.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/ocsp/OcspVerifierOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/DefaultHashChainReferenceResolver.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/DefaultHashChainReferenceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/SignatureVerifier.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/SignatureVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/TimestampVerifier.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/signature/TimestampVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/cert/CertChainTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/cert/CertChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/cert/CertHelperTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/cert/CertHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconf/GlobalConfTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconf/GlobalConfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalSchemaValidatorTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconfextension/OcspFetchIntervalSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdateSchemaValidatorTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconfextension/OcspNextUpdateSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspCacheTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/signature/SignatureVerifierTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/signature/SignatureVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/signature/TimestampVerifierTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/signature/TimestampVerifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClient.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientJob.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientUtils.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDownloader.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/DownloadResult.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/DownloadResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilter.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilterImpl.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FileNameProvider.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FileNameProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FileNameProviderImpl.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/FileNameProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/org/niis/xroad/schedule/RetryingQuartzJob.java
+++ b/src/configuration-client/src/main/java/org/niis/xroad/schedule/RetryingQuartzJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/main/java/org/niis/xroad/schedule/backup/ProxyConfigurationBackupJob.java
+++ b/src/configuration-client/src/main/java/org/niis/xroad/schedule/backup/ProxyConfigurationBackupJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientTest.java
+++ b/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDownloaderTest.java
+++ b/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDownloaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationParserTest.java
+++ b/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilterImplTest.java
+++ b/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/FederationConfigurationSourceFilterImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/GenerateTestData.java
+++ b/src/configuration-client/src/test/java/ee/ria/xroad/common/conf/globalconf/GenerateTestData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-client/src/test/java/org/niis/xroad/schedule/backup/ProxyConfigurationBackupJobTest.java
+++ b/src/configuration-client/src/test/java/org/niis/xroad/schedule/backup/ProxyConfigurationBackupJobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxy.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxyMain.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxyMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxyProperties.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/ConfProxyProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtil.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilCreateInstance.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilCreateInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilGenerateAnchor.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilGenerateAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilMain.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilViewConf.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/ConfProxyUtilViewConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/package-info.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/commandline/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/package-info.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/ConfProxyHelper.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/ConfProxyHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/package-info.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/configuration-proxy/src/test/java/ee/ria/xroad/confproxy/ConfProxyTest.java
+++ b/src/configuration-proxy/src/test/java/ee/ria/xroad/confproxy/ConfProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/StatsRequest.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/StatsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/StatsResponse.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/StatsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricNames.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricsRequest.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricsResponse.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/SystemMetricsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/HistogramDto.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/HistogramDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/MetricDto.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/MetricDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/MetricSetDto.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/MetricSetDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/SimpleMetricDto.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/SimpleMetricDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/ClientActor.java
+++ b/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/ClientActor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/MonitorTest.java
+++ b/src/monitor-test/src/main/java/ee/ria/xroad/monitor/test/MonitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/AbstractSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/AbstractSensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/CertificateMonitoringInfo.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/CertificateMonitoringInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/DiskSpaceSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/DiskSpaceSensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/ExecListingSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/ExecListingSensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/JmxStringifiedData.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/JmxStringifiedData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/MetricRegistryHolder.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/MetricRegistryHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/MetricsProviderActor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/MetricsProviderActor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/MonitorMain.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/MonitorMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/SensorException.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/SensorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/SimpleSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/SimpleSensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/SystemMetricsSensor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/SystemMetricsSensor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/UnhandledListenerActor.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/UnhandledListenerActor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/AbstractExecLister.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/AbstractExecLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ExecListingFailedException.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ExecListingFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/OsInfoLister.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/OsInfoLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/PackageInfo.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/PackageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/PackageLister.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/PackageLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ProcessInfo.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ProcessInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ProcessLister.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/ProcessLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/XroadProcessLister.java
+++ b/src/monitor/src/main/java/ee/ria/xroad/monitor/executablelister/XroadProcessLister.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/CertificateInfoSensorTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/CertificateInfoSensorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/EmptyServerConf.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/EmptyServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/MetricRegistryHolderTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/MetricRegistryHolderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/MetricsProviderActorTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/MetricsProviderActorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/SystemMetricsSensorTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/SystemMetricsSensorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/executablelister/PackageListerTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/executablelister/PackageListerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitor/src/test/java/ee/ria/xroad/monitor/executablelister/ProcessListerTest.java
+++ b/src/monitor/src/test/java/ee/ria/xroad/monitor/executablelister/ProcessListerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringConf.java
+++ b/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParameters.java
+++ b/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParametersSchemaValidator.java
+++ b/src/monitoring-conf/src/main/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParametersSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/monitoring-conf/src/test/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParametersSchemaValidatorTest.java
+++ b/src/monitoring-conf/src/test/java/ee/ria/xroad/common/conf/monitoringconf/MonitoringParametersSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataMetrics.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataMetricsUtil.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataMetricsUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/HealthDataRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemon.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonDatabaseCtx.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonDatabaseCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonMain.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorSslKeyManager.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorSslKeyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorSslTrustManager.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorSslTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataOutputSpecFields.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataOutputSpecFields.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecord.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordCleaner.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordCleaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordManager.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordQuery.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecords.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecords.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/QueryRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/QueryRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/QueryRequestProcessor.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/QueryRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/SecurityServerTypeTypeAdapter.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/SecurityServerTypeTypeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/SlidingTimeWindowCounter.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/SlidingTimeWindowCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/StoreRequestProcessor.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/StoreRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/BaseTestUsingDB.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/BaseTestUsingDB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/HealthDataMetricsUtilTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/HealthDataMetricsUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordManagerTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordsGenerator.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordsGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordsTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRequestHandlerTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataRequestHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataTestUtil.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/OperationalDataTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/QueryRequestHandlerTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/QueryRequestHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/SecurityServerTypeTypeAdapterTest.java
+++ b/src/op-monitor-daemon/src/test/java/ee/ria/xroad/opmonitordaemon/SecurityServerTypeTypeAdapterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureBuilder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureCtx.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureXmlBuilder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/signature/SignatureXmlBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckProvider.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckResult.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthCheckResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthChecks.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/HealthChecks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/StoppableCombinationHealthCheckProvider.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/StoppableCombinationHealthCheckProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/StoppableHealthCheckProvider.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/common/util/healthcheck/StoppableHealthCheckProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/addon/AddOn.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/addon/AddOn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConfiguration.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConnectionManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConnector.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/AntiDosConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/SocketChannelWrapper.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/SocketChannelWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/SocketChannelWrapperImpl.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/antidos/SocketChannelWrapperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientMessageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientProxyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AuthTrustVerifier.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AuthTrustVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientException.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientProxy.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientSslKeyManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientSslKeyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactory.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestSocketSelector.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestSocketSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/HandlerLoader.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/HandlerLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AbstractDateValidatableInfo.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AbstractDateValidatableInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AuthKeyInfo.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AuthKeyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AuthKeyManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/AuthKeyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConf.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConfProvider.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConfProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningCtx.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningCtxImpl.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningCtxImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningInfo.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/SigningInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/messagelog/MessageLog.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/messagelog/MessageLog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/messagelog/NullLogManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/messagelog/NullLogManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/opmonitoring/NullOpMonitoringBuffer.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/opmonitoring/NullOpMonitoringBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoring.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/opmonitoring/OpMonitoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessage.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageConsumer.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageEncoder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/CustomSSLSocketFactory.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/CustomSSLSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/HttpClientCreator.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/HttpClientCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/IdleConnectionMonitorThread.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/IdleConnectionMonitorThread.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandlerLoader.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandlerLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxy.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerRestMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerRestMessageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandlerLoader.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandlerLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceTrustManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SignResult.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SignResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/Signer.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/Signer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SignerSigningKey.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SignerSigningKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SigningKey.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/SigningKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/Verifier.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/signedmessage/Verifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/InternalKeyManager.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/InternalKeyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/MessageProcessorBase.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/MessageProcessorBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/SSLContextUtil.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/SSLContextUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/ServerConfStatsLogger.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/ServerConfStatsLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/common/signature/BatchSignerIntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/signature/BatchSignerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/common/signature/SignatureBuilderTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/signature/SignatureBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/common/signature/TestSigningKey.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/signature/TestSigningKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/util/healthcheck/MaintenanceModeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/AbstractProxyIntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/AbstractProxyIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/RestProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/TestProxyMain.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/TestProxyMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/AntiDosConnectionManagerTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/AntiDosConnectionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestConfiguration.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestConnectionManager.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestSocketChannel.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestSocketChannel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestSystemMetrics.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/antidos/TestSystemMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactoryConnectionCacheTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactoryConnectionCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactoryIntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactoryIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/conf/CachingKeyConfImplTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/conf/CachingKeyConfImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2015 Estonian Information System Authority (RIA), Population Register Centre (VRK)
  *

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoderTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/protocol/ProxyMessageEncoderTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/protocol/ProxyMessageEncoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummyServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummyServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummyService.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummySslServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/DummySslServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/EmptyKeyConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/EmptyKeyConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/EmptyServerConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/EmptyServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/IsolatedSslMessageTestCase.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/IsolatedSslMessageTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/Message.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/MessageTestCase.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/MessageTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/MonitorAgentMessageTestCase.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/MonitorAgentMessageTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/ProxyTestSuite.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/ProxyTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/SslMessageTestCase.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/SslMessageTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteGlobalConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteGlobalConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteKeyConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteKeyConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteMonitorAgent.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteMonitorAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteServerConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestcaseLoader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestcaseLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Attachment.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Attachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Attachment2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Attachment2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentBig.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentBig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaulty.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaulty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaultySoap.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaultySoap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaultySoapResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentFaultySoapResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentMTOM.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentMTOM.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentNoSoap.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentNoSoap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentNoSoapResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentNoSoapResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentSmallMantis.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/AttachmentSmallMantis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/CDATAMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/CDATAMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/CommentMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/CommentMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/DefaultNamespaceMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/DefaultNamespaceMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyMultipartRequest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyMultipartRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyMultipartResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyMultipartResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyQuery.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/EmptyResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeader2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeader2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeaderResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyHeaderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyRequestContentType.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyRequestContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyResponseContentType.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/FaultyResponseContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidContentTypeFromClientProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidContentTypeFromClientProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidContentTypeFromServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidContentTypeFromServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress3.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidProviderAddress3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidServiceAddress.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidServiceAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidServiceAddress2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/InvalidServiceAddress2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody1.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody3.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBody3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBodyResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedBodyResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedProtocolVersionHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MalformedProtocolVersionHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MimeSoap.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MimeSoap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingBody.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingBodyResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingBodyResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingHeaderResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingHeaderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingObjectTypeMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingObjectTypeMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingOrg.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingOrg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingProtocolVersionHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingProtocolVersionHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingUserIdHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MissingUserIdHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MonitorAgentNormalMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MonitorAgentNormalMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MonitorAgentServerProxyFailed.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/MonitorAgentServerProxyFailed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoSignatureToServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoSignatureToServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoSoapToServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoSoapToServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoWhitespaceMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NoWhitespaceMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NonUtf8ResponseContentType.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NonUtf8ResponseContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NormalMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NormalMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NormalSubsystem.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NormalSubsystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NotAllowed.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/NotAllowed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ResponseWithRequestHash.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ResponseWithRequestHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerClientInconsistency.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerClientInconsistency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyAttachmentError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyAttachmentError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted3.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionAborted3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionRefused.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyConnectionRefused.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyEmptyFault.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyEmptyFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyEmptyResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyEmptyResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyFaultyAttachment.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyFaultyAttachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyHttpError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyHttpError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyInvalidFault.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyInvalidFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyMissingBody.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyMissingBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyNoBoundary.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyNoBoundary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyProcessingError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServerProxyProcessingError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceConnectionAborted.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceConnectionAborted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceConnectionRefused.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceConnectionRefused.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceDisabled.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceDisabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceFaultyFault.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceFaultyFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceFaultyMultipart.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceFaultyMultipart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceHttpError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceHttpError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceReturnsFault.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/ServiceReturnsFault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SeveralAttachments.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SeveralAttachments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SeveralAttachmentsResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SeveralAttachmentsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SigningFailsInClientProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SigningFailsInClientProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SigningFailsInServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SigningFailsInServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionEmptyHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionEmptyHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionMalformedHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapActionMalformedHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapFaultInMultipartResponse.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapFaultInMultipartResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapFaultToClientProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SoapFaultToClientProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SplitHeaderMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SplitHeaderMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslAuthCertNotMatchesOrg.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslAuthCertNotMatchesOrg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslAuthTrustManagerError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslAuthTrustManagerError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuth.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthExpiredISCert.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthExpiredISCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthNoISCert.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthNoISCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthWrongISCert.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientAuthWrongISCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientCertVerificationError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientCertVerificationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientCipherSuiteSetupError.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslClientCipherSuiteSetupError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslNormalMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslNormalMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxyNoConnections.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslSelectFastestProxyNoConnections.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceAuth.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceNoAuth.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceNoAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceNoISCerts.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceNoISCerts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceWrongISCert.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/SslToServiceWrongISCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnknownService.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnknownService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnsignedMessageFromClientProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnsignedMessageFromClientProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnsignedMessageFromServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/UnsignedMessageFromServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Utf8BomAttachment2.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Utf8BomAttachment2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Utf8BomNormalSubsystem.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/Utf8BomNormalSubsystem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongHttpMethod.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongHttpMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongHttpMethodServerProxy.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongHttpMethodServerProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongProtocolVersionHeader.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/WrongProtocolVersionHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/XmlEncodedMessage.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/testcases/XmlEncodedMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/IntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/IntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestGlobalConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestGlobalConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestKeyConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestKeyConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestServerConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestService.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/util/IdentifierValidatorTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/util/IdentifierValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/util/MetaserviceTestUtil.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/util/MetaserviceTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/util/SSLContextUtilTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/util/SSLContextUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/util/TestUtil.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/util/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/util/ValidateSoapActionTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/util/ValidateSoapActionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/BadRequestException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/BadRequestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/ConflictException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/ConflictException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/InternalServerErrorException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/InternalServerErrorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/ResourceNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/openapi/ResourceNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/service/NotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/service/NotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/service/ServiceException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/restapi/service/ServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/DatabaseContextHelper.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/DatabaseContextHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/RestApiApplication.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/RestApiApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerId.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerSignCertificates.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/cache/CurrentSecurityServerSignCertificates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AdminServiceProperties.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AdminServiceProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CommonPropertyEnvironmentPostProcessor.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CommonPropertyEnvironmentPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CustomErrorAttributes.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CustomErrorAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/DatabasePropertiesEnvironmentPostProcessor.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/DatabasePropertiesEnvironmentPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/JacksonConfiguration.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/JacksonConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/MvcConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/MvcConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/PropertyFileReadingHibernateCustomizer.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/PropertyFileReadingHibernateCustomizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/RollbackCheckedTransactionManagementConfiguration.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/RollbackCheckedTransactionManagementConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SchedulingConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SchedulingConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SecurityServerSystemPropertiesInitializer.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SecurityServerSystemPropertiesInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SignerIpAddressConfiguration.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SignerIpAddressConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SsDeprecatedPropsChecker.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SsDeprecatedPropsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SslPropertiesEnvironmentPostProcessor.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/SslPropertiesEnvironmentPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/StartStopListener.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/StartStopListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/StringDeserializerModifier.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/StringDeserializerModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/UsernameSettingTransactionManager.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/UsernameSettingTransactionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/ControllerConfiguration.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/ControllerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/ServiceClientHelper.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/ServiceClientHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AccessRightConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AccessRightConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AddOnStatusConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AddOnStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AnchorConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/AnchorConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/BackupConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/BackupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/BackupEncryptionStatusConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/BackupEncryptionStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateAuthorityConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateAuthorityConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateAuthorityOcspResponseMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateAuthorityOcspResponseMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateDetailsConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateDetailsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CertificateStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ClientConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ClientConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ClientStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ClientStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ConfigurationStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ConfigurationStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ConnectionTypeMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ConnectionTypeMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CsrFormatMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CsrFormatMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CsrSubjectFieldDescriptionConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/CsrSubjectFieldDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/DiagnosticStatusClassMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/DiagnosticStatusClassMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/EndpointConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/EndpointConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/GlobalConfDiagnosticConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/GlobalConfDiagnosticConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/GlobalGroupConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/GlobalGroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageTypeMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageTypeMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/LocalGroupConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/LocalGroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/MessageLogEncryptionStatusConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/MessageLogEncryptionStatusConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/NodeTypeMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/NodeTypeMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/OcspResponderDiagnosticConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/OcspResponderDiagnosticConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/OcspStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/OcspStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/SecurityServerConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/SecurityServerConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientIdentifierConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientIdentifierConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientTypeMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientTypeMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceDescriptionConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceTypeMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/ServiceTypeMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TimestampingStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateSigningRequestConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateSigningRequestConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenInitStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenInitStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenStatusMapping.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenStatusMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/VersionConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/VersionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/comparator/ClientSortingComparator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/comparator/ClientSortingComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/comparator/ServiceClientSortingComparator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/comparator/ServiceClientSortingComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/domain/AlertData.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/domain/AlertData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/AlertStatus.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/AlertStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/AnchorFile.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/AnchorFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ApprovedCaDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ApprovedCaDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/InitializationStatusDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/InitializationStatusDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/OcspResponderDiagnosticsStatus.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/OcspResponderDiagnosticsStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientAccessRightDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientAccessRightDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientIdentifierDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/ServiceClientIdentifierDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/TokenInitStatusInfo.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/TokenInitStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/VersionInfoDto.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dto/VersionInfoDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/facade/GlobalConfFacade.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/facade/GlobalConfFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CertificateAuthoritiesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CertificateAuthoritiesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/DiagnosticsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/DiagnosticsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/InitializationApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/InitializationApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/LocalGroupsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/LocalGroupsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberNamesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberNamesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/OpenapiApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/OpenapiApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/SecurityServersApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/SecurityServersApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ServiceDescriptionsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ServiceDescriptionsApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/SystemApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/SystemApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TimestampingServicesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TimestampingServicesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TokenCertificatesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TokenCertificatesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TokensApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/TokensApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/XroadInstancesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/XroadInstancesApiController.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/AnchorRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/AnchorRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ClientRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ClientRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/EndpointRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/EndpointRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/InternalTlsCertificateRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/InternalTlsCertificateRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/LocalGroupRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/LocalGroupRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServiceDescriptionRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServiceDescriptionRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServiceRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServiceRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfCheckerHelper.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfCheckerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AccessRightService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AccessRightService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ActionNotPossibleException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ActionNotPossibleException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AnchorNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AnchorNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAlreadyExistsException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAlreadyExistsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateProfileInstantiationException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateProfileInstantiationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClearCacheService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClearCacheService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ConfigurationDownloadException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ConfigurationDownloadException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CsrNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CsrNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/DiagnosticService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/DiagnosticService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/DnFieldHelper.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/DnFieldHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointAlreadyExistsException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointAlreadyExistsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/EndpointService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/GlobalConfOutdatedException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/GlobalConfOutdatedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/GlobalConfService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/GlobalConfService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InitializationService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InitializationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InternalServerTestService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InternalServerTestService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InternalTlsCertificateService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InternalTlsCertificateService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidCertificateException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidCertificateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidCharactersException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidCharactersException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidDistinguishedNameException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidDistinguishedNameException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidHttpsUrlException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidHttpsUrlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidServiceUrlException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidServiceUrlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidUrlException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InvalidUrlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/KeyNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/KeyNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/KeyService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/KeyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ManagementRequestSenderService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ManagementRequestSenderService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ManagementRequestSendingFailedException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ManagementRequestSendingFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/MissingParameterException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/MissingParameterException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/PossibleActionEnum.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/PossibleActionEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/PossibleActionsRuleEngine.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/PossibleActionsRuleEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGenerator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationRestorationService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationRestorationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServerConfService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServerConfService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceChangeChecker.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceChangeChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceClientNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceClientNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceClientService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServiceNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SystemService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SystemService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TimestampingServiceNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TimestampingServiceNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenNotFoundException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenPinValidator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenPinValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/TokenService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/VersionService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/VersionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/WeakPinException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/WeakPinException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/WrongKeyUsageException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/WrongKeyUsageException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/ClientUtils.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/ClientUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/EndpointHelper.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/EndpointHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/OcspUtils.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/OcspUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/SecurityServerFormatUtils.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/util/SecurityServerFormatUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/ClientSslKeyManager.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/ClientSslKeyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/HostnameVerifiers.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/HostnameVerifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/HttpUrlConnectionConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/HttpUrlConnectionConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/InvalidWsdlException.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/InvalidWsdlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/OpenApiParser.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/OpenApiParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlParser.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/restapi/config/audit/AuditLogMockingConfiguration.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/restapi/config/audit/AuditLogMockingConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/restapi/config/audit/MockableAuditEventLoggingFacade.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/restapi/config/audit/MockableAuditEventLoggingFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/ApplicationTests.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/ApplicationTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/auth/CsrfWebMvcTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/auth/CsrfWebMvcTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AbstractFacadeMockingTestContext.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AbstractFacadeMockingTestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/SignerProxyMockingConfiguration.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/SignerProxyMockingConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AbstractConverterTestContext.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AbstractConverterTestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AnchorConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AnchorConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupEncryptionStatusConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupEncryptionStatusConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ClientConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ClientConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/GlobalConfDiagnosticConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/GlobalConfDiagnosticConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/KeyConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/KeyConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/KeyUsageConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/LocalGroupConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/LocalGroupConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/MessageLogEncryptionStatusConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/MessageLogEncryptionStatusConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/OcspResponderDiagnosticConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/OcspResponderDiagnosticConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PublicApiKeyDataConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PublicApiKeyDataConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/SecurityServerConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/SecurityServerConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientIdentifierConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ServiceClientIdentifierConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ServiceConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/ServiceConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateSigningRequestConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateSigningRequestConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TokenConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/VersionConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/VersionConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/comparator/ClientSortingComparatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/comparator/ClientSortingComparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/comparator/ServiceClientSortingComparatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/comparator/ServiceClientSortingComparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/AbstractApiControllerTestContext.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/AbstractApiControllerTestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ApiValidationRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ApiValidationRestTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/AuditLoggingRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/AuditLoggingRestTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/CertificateAuthoritiesApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/CertificateAuthoritiesApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/InitializationApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/InitializationApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/KeysApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/KeysApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/LocalGroupsApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/LocalGroupsApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/OpenapiApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/OpenapiApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/SecurityServersApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/SecurityServersApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ServiceDescriptionsApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ServiceDescriptionsApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ServicesApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ServicesApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/StringTrimmerRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/StringTrimmerRestTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/SystemApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/SystemApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TimestampingServiceApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TimestampingServiceApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TokensApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TokensApiControllerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TransactionHandlingRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TransactionHandlingRestTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/UserApiControllerRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/UserApiControllerRestTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/XroadInstancesApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/XroadInstancesApiControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ClientRepositoryIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ClientRepositoryIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ExampleJpaTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ExampleJpaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/IdentifierRepositoryIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/IdentifierRepositoryIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepositoryIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepositoryIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AbstractServiceIntegrationTestContext.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AbstractServiceIntegrationTestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AbstractServiceTestContext.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AbstractServiceTestContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ClientServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ClientServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DnFieldHelperTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DnFieldHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DnFieldTestCertificateProfileInfo.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DnFieldTestCertificateProfileInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DummyTransactionRollingbackService.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/DummyTransactionRollingbackService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/EndpointServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/EndpointServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/InitializationServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/InitializationServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/InternalTlsCertificateServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/InternalTlsCertificateServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/KeyServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/KeyServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/LocalGroupServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/LocalGroupServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/PossibleActionsRuleEngineTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/PossibleActionsRuleEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGeneratorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationRestorationServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationRestorationServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServerConfServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServerConfServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServiceChangeCheckerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServiceChangeCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ServiceDescriptionServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SystemServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/SystemServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenPinValidatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenPinValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TransactionRollbackIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TransactionRollbackIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/VersionServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/VersionServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/CertificateTestUtils.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/CertificateTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/ClientUtilsTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/ClientUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/DeviationTestUtils.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/DeviationTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/PersistenceTestUtil.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/PersistenceTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TestUtils.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TokenTestUtils.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TokenTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/OpenApiParserTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/OpenApiParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/api/FeignInitializationApi.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/api/FeignInitializationApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/container/database/LiquibaseExecutor.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/container/database/LiquibaseExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/ClearBackupsHook.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/ClearBackupsHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/DatabaseResetBeforeScenarioHook.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/DatabaseResetBeforeScenarioHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/DefaultServerStateInitializationHook.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/DefaultServerStateInitializationHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/MockServerResetHook.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/hook/MockServerResetHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * <p>
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)

--- a/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/utils/ScenarioValueEvaluator.java
+++ b/src/security-server/admin-service/int-test/src/intTest/java/org/niis/xroad/ss/test/utils/ScenarioValueEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/CachingServerConfImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/CachingServerConfImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthentication.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthentication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthenticationData.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/IsAuthenticationData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/PathGlob.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/PathGlob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConf.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfDatabaseCtx.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfDatabaseCtx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfProvider.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/ServerConfProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/AbstractDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/AbstractDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/CertificateDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/CertificateDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ClientDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ClientDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/IdentifierDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/IdentifierDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/LocalGroupDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/LocalGroupDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServerConfDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServerConfDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServiceDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServiceDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServiceDescriptionDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/ServiceDescriptionDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/UiUserDAOImpl.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/dao/UiUserDAOImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/AccessRightType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/AccessRightType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/CertificateType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/CertificateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ClientType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ClientType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/DescriptionType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/DescriptionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/EndpointType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/EndpointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/GroupMemberType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/GroupMemberType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/LocalGroupType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/LocalGroupType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServerConfType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServerConfType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServiceDescriptionType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServiceDescriptionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServiceType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/ServiceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/TspType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/TspType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/UiUserType.java
+++ b/src/serverconf/src/main/java/ee/ria/xroad/common/conf/serverconf/model/UiUserType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/CachingServerConfTest.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/CachingServerConfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/DAOImplTest.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/DAOImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/IdentifierDAOImplTest.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/IdentifierDAOImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/PathGlobTest.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/PathGlobTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/ServerConfTest.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/ServerConfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/TestUtil.java
+++ b/src/serverconf/src/test/java/ee/ria/xroad/proxy/conf/TestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-console/src/main/java/ee/ria/xroad/signer/console/AuditLogEventsAndParams.java
+++ b/src/signer-console/src/main/java/ee/ria/xroad/signer/console/AuditLogEventsAndParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-console/src/main/java/ee/ria/xroad/signer/console/Utils.java
+++ b/src/signer-console/src/main/java/ee/ria/xroad/signer/console/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/ComponentNames.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/ComponentNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/SignerClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/AuthKeyInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/AuthKeyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/CertRequestInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/CertRequestInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/CertificateInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/CertificateInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/KeyInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/KeyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/KeyUsageInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/KeyUsageInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/MemberSigningInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/MemberSigningInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenInfoAndKeyId.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenInfoAndKeyId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenStatusInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/dto/TokenStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ActivateCert.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ActivateCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ActivateToken.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ActivateToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/CertificateRequestFormat.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/CertificateRequestFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ConnectionPing.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ConnectionPing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ConnectionPong.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ConnectionPong.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteCert.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteCertRequest.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteCertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteKey.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/DeleteKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateCertRequest.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateCertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateCertRequestResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateCertRequestResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateKey.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateSelfSignedCert.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateSelfSignedCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateSelfSignedCertResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GenerateSelfSignedCertResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetAuthKey.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetAuthKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetCertificateInfoForHash.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetCertificateInfoForHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetCertificateInfoResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetCertificateInfoResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetHSMOperationalInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetHSMOperationalInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetHSMOperationalInfoResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetHSMOperationalInfoResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetKeyIdForCertHash.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetKeyIdForCertHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetKeyIdForCertHashResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetKeyIdForCertHashResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberCerts.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberCerts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberCertsResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberCertsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberSigningInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetMemberSigningInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetOcspResponses.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetOcspResponses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetOcspResponsesResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetOcspResponsesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetSignMechanism.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetSignMechanism.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetSignMechanismResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetSignMechanismResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenBatchSigningEnabled.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenBatchSigningEnabled.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfo.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoAndKeyIdForCertHash.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoAndKeyIdForCertHash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoAndKeyIdForCertRequestId.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoAndKeyIdForCertRequestId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoForKeyId.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/GetTokenInfoForKeyId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ImportCert.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ImportCert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ImportCertResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ImportCertResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/InitSoftwareToken.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/InitSoftwareToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ListTokens.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/ListTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/RegenerateCertRequest.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/RegenerateCertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/RegenerateCertRequestResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/RegenerateCertRequestResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetCertStatus.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetCertStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetKeyFriendlyName.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetKeyFriendlyName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetOcspResponses.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetOcspResponses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetTokenFriendlyName.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SetTokenFriendlyName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/Sign.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/Sign.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SignResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SignResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SuccessResponse.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/SuccessResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/UpdateSoftwareTokenPin.java
+++ b/src/signer-protocol/src/main/java/ee/ria/xroad/signer/protocol/message/UpdateSoftwareTokenPin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientReload.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/OcspClientReload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/OcspRetrievalJob.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/OcspRetrievalJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/Signer.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/Signer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/SignerMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCache.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/GlobalConfChangeChecker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/GlobalConfChangeChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClient.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspResponseManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspResponseManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/CertRequest.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/CertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/Key.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/Key.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/Token.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/AbstractRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/AbstractRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/SignerRequestProcessor.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/SignerRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/AbstractDeleteFromKeyInfo.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/AbstractDeleteFromKeyInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/AbstractGenerateCertRequest.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/AbstractGenerateCertRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ActivateCertRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ActivateCertRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ActivateTokenRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ActivateTokenRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteCertRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteCertRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteCertRequestRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteCertRequestRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteKeyRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/DeleteKeyRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateCertRequestRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateCertRequestRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateKeyRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateKeyRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateSelfSignedCertRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GenerateSelfSignedCertRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetAuthKeyRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetAuthKeyRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetCertificateInfoForHashRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetCertificateInfoForHashRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetHSMOperationalInfoRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetHSMOperationalInfoRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetKeyIdForCertHashRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetKeyIdForCertHashRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetMemberCertsRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetMemberCertsRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetMemberSigningInfoRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetMemberSigningInfoRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetOcspResponsesRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetOcspResponsesRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetSignMechanismRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetSignMechanismRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenBatchSigningEnabledRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenBatchSigningEnabledRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoAndKeyIdForCertHashRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoAndKeyIdForCertHashRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoAndKeyIdForCertRequestIdRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoAndKeyIdForCertRequestIdRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoForKeyIdRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoForKeyIdRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/GetTokenInfoRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ImportCertRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ImportCertRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/InitSoftwareTokenRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/InitSoftwareTokenRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ListTokensRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ListTokensRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/RegenerateCertRequestRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/RegenerateCertRequestRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetCertStatusRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetCertStatusRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetKeyFriendlyNameRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetKeyFriendlyNameRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetOcspResponsesRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetOcspResponsesRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetTokenFriendlyNameRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SetTokenFriendlyNameRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SignRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/SignRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/UpdateSoftwareTokenPinRequestHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/UpdateSoftwareTokenPinRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/ServiceLocator.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/ServiceLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenConf.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/MergeOntoFileTokensStrategy.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/MergeOntoFileTokensStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/TokenMergeAddedCertificatesListener.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/TokenMergeAddedCertificatesListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/TokenMergeStrategy.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/merge/TokenMergeStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/DefaultModuleManagerImpl.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/DefaultModuleManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/HardwareModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleConf.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleConf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleInstanceProvider.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleInstanceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/ModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/PrivKeyAttributes.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/PrivKeyAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/PubKeyAttributes.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/PubKeyAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/SoftwareModuleType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/SoftwareModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/SoftwareModuleWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/SoftwareModuleWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/AbstractToken.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/AbstractToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/AbstractTokenWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/AbstractTokenWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareToken.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenUtil.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/SoftwareTokenWorker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/TokenSigner.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/TokenSigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/TokenType.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/token/TokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/AbstractSignerActor.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/AbstractSignerActor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/AbstractUpdateableActor.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/AbstractUpdateableActor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/CalculateSignature.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/CalculateSignature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/CalculatedSignature.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/CalculatedSignature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/DigestPrefixCache.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/DigestPrefixCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/ExceptionHelper.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/ExceptionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/TokenAndKey.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/TokenAndKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/TokenAndKeyId.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/TokenAndKeyId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/Update.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/Update.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/VariableIntervalPeriodicJob.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/VariableIntervalPeriodicJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/SignerTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/SignerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCacheTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/GlobalConfChangeCheckerTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/GlobalConfChangeCheckerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/OcspClientTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/OcspClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/TokenManagerMergeTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/TokenManagerMergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),

--- a/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/merge/MergeOntoFileTokenStrategyTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/merge/MergeOntoFileTokenStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),


### PR DESCRIPTION
Replace /** to /* in license header in all java classes.