### PR TITLE
fix: allow recovering from timestamping service failure

### DIFF
--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/TaskQueue.java
@@ -162,7 +162,7 @@ public class TaskQueue extends UntypedAbstractActor {
 
         if (timestampTasks.isEmpty()) {
             log.trace("Nothing to time-stamp, task queue is empty");
-
+            indicateSuccess();
             return;
         }
 


### PR DESCRIPTION
Security server never recovered from timestamping service outage in case there were no messages timestamp in database.

Refs: XRDDEV-2398