### PR TITLE
feat: truncating all timestamps to microseconds

### DIFF
--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogManager.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/LogManager.java
@@ -41,6 +41,7 @@ import ee.ria.xroad.common.messagelog.RestLogMessage;
 import ee.ria.xroad.common.messagelog.SoapLogMessage;
 import ee.ria.xroad.common.messagelog.TimestampRecord;
 import ee.ria.xroad.common.util.JobManager;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
@@ -55,7 +56,6 @@ import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -301,7 +301,7 @@ public class LogManager extends AbstractLogManager {
      * @param url url of timestamper which stamped successfully
      */
     static void putStatusMapSuccess(String url) {
-        statusMap.put(url, new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, OffsetDateTime.now()));
+        statusMap.put(url, new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, TimeUtils.offsetDateTimeNow()));
     }
 
     /**
@@ -314,7 +314,7 @@ public class LogManager extends AbstractLogManager {
         int errorCode = DiagnosticsUtils.getErrorCode(e);
         for (String tspUrl : ServerConf.getTspUrl()) {
             statusMap.put(tspUrl,
-                    new DiagnosticsStatus(errorCode, OffsetDateTime.now(), tspUrl));
+                    new DiagnosticsStatus(errorCode, TimeUtils.offsetDateTimeNow(), tspUrl));
         }
     }
 
@@ -371,7 +371,7 @@ public class LogManager extends AbstractLogManager {
             }
 
             if (isTimestampFailed()) {
-                if (Instant.now().minusSeconds(period).isAfter(timestampFailed)) {
+                if (TimeUtils.now().minusSeconds(period).isAfter(timestampFailed)) {
                     throw new CodedException(X_MLOG_TIMESTAMPER_FAILED, "Cannot time-stamp messages");
                 }
             }

--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SetTimestampingStatusMessage.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/messagelog/SetTimestampingStatusMessage.java
@@ -25,6 +25,8 @@
  */
 package ee.ria.xroad.proxy.messagelog;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import akka.dispatch.ControlMessage;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +55,7 @@ class SetTimestampingStatusMessage implements ControlMessage {
      */
     SetTimestampingStatusMessage(Status status) {
         this.status = status;
-        this.atTime = Instant.now();
+        this.atTime = TimeUtils.now();
     }
 }
 

--- a/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogTest.java
+++ b/src/addons/messagelog/messagelog-addon/src/test/java/ee/ria/xroad/proxy/messagelog/MessageLogTest.java
@@ -45,6 +45,7 @@ import ee.ria.xroad.common.messagelog.archive.GroupingStrategy;
 import ee.ria.xroad.common.signature.SignatureData;
 import ee.ria.xroad.common.util.CacheInputStream;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.messagelog.database.MessageRecordEncryption;
 import ee.ria.xroad.proxy.messagelog.Timestamper.TimestampFailed;
 import ee.ria.xroad.proxy.messagelog.Timestamper.TimestampSucceeded;
@@ -205,7 +206,7 @@ public class MessageLogTest extends AbstractMessageLogTest {
         final String requestId = UUID.randomUUID().toString();
         final RestRequest message = createRestRequest("q-" + requestId, requestId);
 
-        final Instant atDate = Instant.now();
+        final Instant atDate = TimeUtils.now();
         final byte[] body = "\"test message body\"".getBytes(StandardCharsets.UTF_8);
         log(atDate, message, createSignature(), body);
         final MessageRecord logRecord = (MessageRecord) findByQueryId(message.getQueryId(), atDate.minusMillis(1),
@@ -363,7 +364,7 @@ public class MessageLogTest extends AbstractMessageLogTest {
         log(createMessage(), createSignature());
         assertTaskQueueSize(3);
 
-        logManager.setTimestampFailed(Instant.now().minusSeconds(60));
+        logManager.setTimestampFailed(TimeUtils.now().minusSeconds(60));
 
         startTimestamping();
         waitForMessageInTaskQueue();

--- a/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogCleaner.java
+++ b/src/addons/messagelog/messagelog-archiver/src/main/java/ee/ria/xroad/messagelog/archiver/LogCleaner.java
@@ -26,13 +26,13 @@
 package ee.ria.xroad.messagelog.archiver;
 
 import ee.ria.xroad.common.messagelog.MessageLogProperties;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.messagelog.database.MessageLogDatabaseCtx;
 
 import akka.actor.UntypedAbstractActor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.query.Query;
 
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -68,7 +68,7 @@ public class LogCleaner extends UntypedAbstractActor {
     protected long handleClean() throws Exception {
 
         final Long time =
-                Instant.now().minus(MessageLogProperties.getKeepRecordsForDays(), ChronoUnit.DAYS).toEpochMilli();
+                TimeUtils.now().minus(MessageLogProperties.getKeepRecordsForDays(), ChronoUnit.DAYS).toEpochMilli();
         long count = 0;
         int removed;
         do {

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Auditable.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/Auditable.java
@@ -26,12 +26,14 @@
  */
 package org.niis.xroad.cs.admin.api.domain;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import lombok.Data;
 
 import java.time.Instant;
 
 @Data
 public abstract class Auditable {
-    private Instant createdAt = Instant.now();
+    private Instant createdAt = TimeUtils.now();
     private Instant updatedAt = createdAt;
 }

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuditableEntity.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/AuditableEntity.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 package org.niis.xroad.cs.admin.core.entity;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.Getter;
 
@@ -42,7 +44,7 @@ public abstract class AuditableEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     @Access(AccessType.FIELD)
     @Getter
-    private Instant createdAt = Instant.now();
+    private Instant createdAt = TimeUtils.now();
 
     @Column(name = "updated_at", nullable = false)
     @Access(AccessType.FIELD)
@@ -51,6 +53,6 @@ public abstract class AuditableEntity {
 
     @PreUpdate
     void preUpdate() {
-        this.updatedAt = Instant.now();
+        this.updatedAt = TimeUtils.now();
     }
 }

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapper.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapper.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 package org.niis.xroad.cs.admin.core.entity.mapper;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -38,7 +40,6 @@ import org.niis.xroad.cs.admin.core.config.AdminServiceProperties;
 import org.niis.xroad.cs.admin.core.entity.HAClusterStatusViewEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
@@ -60,7 +61,7 @@ public abstract class HAClusterNodeMapper implements GenericUniDirectionalMapper
         if (entity.getConfigurationGenerated() == null) {
             return HAClusterNodeStatus.UNKNOWN;
         }
-        long secondsPassedSinceConfGeneration = ChronoUnit.SECONDS.between(entity.getConfigurationGenerated(), Instant.now());
+        long secondsPassedSinceConfGeneration = ChronoUnit.SECONDS.between(entity.getConfigurationGenerated(), TimeUtils.now());
         if (secondsPassedSinceConfGeneration > systemParameterService.getConfExpireIntervalSeconds()) {
             return HAClusterNodeStatus.ERROR;
         } else if (secondsPassedSinceConfGeneration

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationBackupGenerator.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/CentralServerConfigurationBackupGenerator.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.common.util.process.ExternalProcessRunner;
 
 import org.niis.xroad.cs.admin.api.dto.HAConfigStatus;
@@ -39,7 +40,6 @@ import org.niis.xroad.restapi.config.audit.AuditDataHelper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
@@ -88,6 +88,6 @@ public class CentralServerConfigurationBackupGenerator extends BaseConfiguration
 
     @Override
     protected String generateBackupFileName() {
-        return String.format(FILE_NAME_FORMAT, LocalDateTime.now().format(DATE_TIME_FORMATTER));
+        return String.format(FILE_NAME_FORMAT, TimeUtils.localDateTimeNow().format(DATE_TIME_FORMATTER));
     }
 }

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImpl.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.conf.globalconf.privateparameters.v2.ConfigurationAnchorType;
 import ee.ria.xroad.common.conf.globalconf.privateparameters.v2.ObjectFactory;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -137,7 +138,7 @@ public class ConfigurationAnchorServiceImpl implements ConfigurationAnchorServic
         }
 
         final var sources = configurationSourceRepository.findAllBySourceType(configurationType.name().toLowerCase());
-        final var now = ZonedDateTime.now(ZoneId.of("UTC"));
+        final var now = TimeUtils.zonedDateTimeNow(ZoneId.of("UTC"));
         final var anchorXml = buildAnchorXml(configurationType, instanceIdentifier, now, sources);
         final var anchorXmlBytes = anchorXml.getBytes(StandardCharsets.UTF_8);
         final var anchorXmlHash = CryptoUtils.calculateAnchorHashDelimited(anchorXmlBytes);

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImpl.java
@@ -5,17 +5,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,7 @@ package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.commonui.OptionalConfPart;
 import ee.ria.xroad.commonui.OptionalPartsConf;
 
@@ -56,7 +57,6 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -205,7 +205,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         var distributedFileEntity = findOrCreate(contentIdentifier, version);
         distributedFileEntity.setFileName(fileName);
         distributedFileEntity.setFileData(data);
-        distributedFileEntity.setFileUpdatedAt(Instant.now());
+        distributedFileEntity.setFileUpdatedAt(TimeUtils.now());
         distributedFileEntity.setHaNodeName(haConfigStatus.getCurrentHaNodeName());
         distributedFileRepository.save(distributedFileEntity);
     }

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationSigningKeysServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationSigningKeysServiceImpl.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.KeyUsageInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
@@ -244,7 +245,7 @@ public class ConfigurationSigningKeysServiceImpl extends AbstractTokenConsumer i
             throw new SignerProxyException(KEY_GENERATION_FAILED, e);
         }
 
-        final Instant generatedAt = Instant.now();
+        final Instant generatedAt = TimeUtils.now();
 
         final ClientId.Conf clientId = ClientId.Conf.create(systemParameterService.getInstanceIdentifier(),
                 "selfsigned", UUID.randomUUID().toString());

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/NotificationServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/NotificationServiceImpl.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,7 @@
 
 package org.niis.xroad.cs.admin.core.service;
 
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
 
@@ -50,7 +51,6 @@ import java.util.Set;
 import static ee.ria.xroad.common.SystemProperties.getCenterTrustedAnchorsAllowed;
 import static ee.ria.xroad.signer.protocol.dto.TokenStatusInfo.NOT_INITIALIZED;
 import static java.lang.String.format;
-import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.niis.xroad.cs.admin.api.dto.GlobalConfGenerationStatus.GlobalConfGenerationStatusEnum.FAILURE;
@@ -117,7 +117,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private boolean isGlobalConfExpired(GlobalConfGenerationStatus status) {
-        return SECONDS.between(status.getTime(), now()) > systemParameterService.getConfExpireIntervalSeconds();
+        return SECONDS.between(status.getTime(), TimeUtils.now()) > systemParameterService.getConfExpireIntervalSeconds();
     }
 
     private Set<AlertInfo> checkConfigurationSigningKey(String sourceType, List<TokenInfo> tokens) {

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedCaMapperTest.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.cs.admin.core.entity.mapper;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.niis.xroad.cs.admin.core.entity.ApprovedCaEntity;
 import org.niis.xroad.cs.admin.core.entity.CaInfoEntity;
@@ -41,8 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = {ApprovedCaMapperImpl.class})
 class ApprovedCaMapperTest {
     private static final String URL = "https://github.com";
-    private static final Instant DATE_FROM = Instant.now().minusSeconds(60);
-    private static final Instant DATE_TO = Instant.now();
+    private static final Instant DATE_FROM = TimeUtils.now().minusSeconds(60);
+    private static final Instant DATE_TO = TimeUtils.now();
 
     @Autowired
     private ApprovedCaMapper approvedCaMapper;

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedTsaMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ApprovedTsaMapperTest.java
@@ -5,17 +5,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,7 @@
 package org.niis.xroad.cs.admin.core.entity.mapper;
 
 import ee.ria.xroad.common.TestCertUtil;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.jupiter.api.Test;
 import org.niis.xroad.cs.admin.api.domain.ApprovedTsa;
@@ -54,8 +55,8 @@ class ApprovedTsaMapperTest {
     private static final int ID = 123;
     private static final String URL = "http://test.url";
     private static final String NAME = "name";
-    private static final Instant VALID_FROM = Instant.now().minus(1, DAYS);
-    private static final Instant VALID_TO = Instant.now().plus(2, DAYS);
+    private static final Instant VALID_FROM = TimeUtils.now().minus(1, DAYS);
+    private static final Instant VALID_TO = TimeUtils.now().plus(2, DAYS);
     private static final X509Certificate CERTIFICATE = TestCertUtil.getTspCert();
 
     private static final Instant TEST_TSA_CERT_VALID_FROM = Instant.ofEpochMilli(1354189986000L); //2012-11-29 11:53:06Z

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/ConfigurationSigningKeyMapperTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,13 +27,13 @@
 
 package org.niis.xroad.cs.admin.core.entity.mapper;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.niis.xroad.cs.admin.api.domain.ConfigurationSigningKey;
 import org.niis.xroad.cs.admin.api.domain.ConfigurationSourceType;
 import org.niis.xroad.cs.admin.core.entity.ConfigurationSigningKeyEntity;
 import org.niis.xroad.cs.admin.core.entity.ConfigurationSourceEntity;
-
-import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +72,7 @@ class ConfigurationSigningKeyMapperTest {
         ConfigurationSigningKeyEntity configurationSigningKey = new ConfigurationSigningKeyEntity();
         configurationSigningKey.setKeyIdentifier("keyIdentifier");
         configurationSigningKey.setCert("keyCert".getBytes());
-        configurationSigningKey.setKeyGeneratedAt(Instant.now());
+        configurationSigningKey.setKeyGeneratedAt(TimeUtils.now());
         configurationSigningKey.setTokenIdentifier("tokenIdentifier");
 
         ConfigurationSourceEntity configurationSource = new ConfigurationSourceEntity();

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/HAClusterNodeMapperTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 package org.niis.xroad.cs.admin.core.entity.mapper;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,9 +81,9 @@ class HAClusterNodeMapperTest {
 
     private static Stream<Arguments> configurationsGeneratedWithExpectedStatus() {
         return Stream.of(
-                Arguments.of(Instant.now(), HAClusterNodeStatus.OK),
-                Arguments.of(Instant.now().minus(80, ChronoUnit.SECONDS), HAClusterNodeStatus.WARN),
-                Arguments.of(Instant.now().minus(610, ChronoUnit.SECONDS), HAClusterNodeStatus.ERROR),
+                Arguments.of(TimeUtils.now(), HAClusterNodeStatus.OK),
+                Arguments.of(TimeUtils.now().minus(80, ChronoUnit.SECONDS), HAClusterNodeStatus.WARN),
+                Arguments.of(TimeUtils.now().minus(610, ChronoUnit.SECONDS), HAClusterNodeStatus.ERROR),
                 Arguments.of(null, HAClusterNodeStatus.UNKNOWN)
         );
     }

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/TrustedAnchorMapperTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/entity/mapper/TrustedAnchorMapperTest.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.cs.admin.core.entity.mapper;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.niis.xroad.cs.admin.core.entity.AnchorUrlCertEntity;
 import org.niis.xroad.cs.admin.core.entity.AnchorUrlEntity;
@@ -33,7 +35,6 @@ import org.niis.xroad.cs.admin.core.entity.TrustedAnchorEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 
@@ -66,7 +67,7 @@ class TrustedAnchorMapperTest {
         source.setInstanceIdentifier("INSTANCE");
         source.setTrustedAnchorHash("trusted anchor hash");
         source.setTrustedAnchorFile("trusted anchor file".getBytes(UTF_8));
-        source.setGeneratedAt(Instant.now());
+        source.setGeneratedAt(TimeUtils.now());
         return source;
     }
 

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/CertificationServicesServiceImplTest.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.TestCertUtil;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.SneakyThrows;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
@@ -87,8 +88,8 @@ import static org.niis.xroad.restapi.config.audit.RestApiAuditProperty.OCSP_URL;
 @ExtendWith(MockitoExtension.class)
 class CertificationServicesServiceImplTest {
     private static final Integer ID = 123;
-    private static final Instant VALID_FROM = Instant.now().minus(1, DAYS);
-    private static final Instant VALID_TO = Instant.now().plus(1, DAYS);
+    private static final Instant VALID_FROM = TimeUtils.now().minus(1, DAYS);
+    private static final Instant VALID_TO = TimeUtils.now().plus(1, DAYS);
     private static final String CA_NAME = "X-Road Test CA";
     private static final String CERT_PROFILE = "ee.ria.xroad.common.certificateprofile.impl.FiVRKCertificateProfileInfoProvider";
 

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationAnchorServiceImplTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,8 @@
  */
 
 package org.niis.xroad.cs.admin.core.service;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -76,7 +78,7 @@ public class ConfigurationAnchorServiceImplTest {
     private static final String EXTERNAL_CONFIGURATION = "external";
     private static final String CENTRAL_SERVICE = "cs";
     private static final String HA_NODE_NAME = "haNodeName";
-    private static final Instant FILE_UPDATED_AT = Instant.now();
+    private static final Instant FILE_UPDATED_AT = TimeUtils.now();
     private static final String HASH = "F5:1B:1F:9C:07:23:4C:DA:E6:4C:99:CB:FC:D8:EE:0E:C5:5F:A4:AF";
     private static final byte[] FILE_DATA = "file-data".getBytes(UTF_8);
 
@@ -222,7 +224,7 @@ public class ConfigurationAnchorServiceImplTest {
             verify(auditDataHelper).putAnchorHash(any());
 
             assertThat(result.getAnchorGeneratedAt().truncatedTo(MINUTES))
-                    .isEqualTo(Instant.now().truncatedTo(MINUTES));
+                    .isEqualTo(TimeUtils.now().truncatedTo(MINUTES));
 
             final var xml = new String(xmlCaptor.getValue());
             XmlAssert.assertThat(xml).withNamespaceContext(namespace)
@@ -296,7 +298,7 @@ public class ConfigurationAnchorServiceImplTest {
             verify(auditDataHelper).putAnchorHash(any());
 
             assertThat(result.getAnchorGeneratedAt().truncatedTo(MINUTES))
-                    .isEqualTo(Instant.now().truncatedTo(MINUTES));
+                    .isEqualTo(TimeUtils.now().truncatedTo(MINUTES));
 
             final var xml = new String(xmlCaptor.getValue());
             XmlAssert.assertThat(xml).withNamespaceContext(namespace)

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImplTest.java
@@ -5,17 +5,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.CodedException;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.commonui.OptionalPartsConf;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -91,7 +92,7 @@ class ConfigurationServiceImplTest {
     private static final String FILE_NAME = "fileName";
     private static final String FILE_NAME_PRIVATE_PARAMS = "private-params.xml";
     private static final String CONTENT_IDENTIFIER = "Content";
-    private static final Instant FILE_UPDATED_AT = Instant.now();
+    private static final Instant FILE_UPDATED_AT = TimeUtils.now();
     private static final byte[] FILE_DATA = "file-data".getBytes(UTF_8);
     private static final String NODE_LOCAL_CONTENT_ID = CONTENT_ID_PRIVATE_PARAMETERS;
     private static final String TEST_CONFIGURATION_PART = "TEST-CONFIGURATION-PART";
@@ -312,7 +313,7 @@ class ConfigurationServiceImplTest {
 
         @Test
         void getConfigurationPartFile() {
-            var fileEntity = new DistributedFileEntity(VERSION, FILE_NAME, CONTENT_IDENTIFIER, Instant.now());
+            var fileEntity = new DistributedFileEntity(VERSION, FILE_NAME, CONTENT_IDENTIFIER, TimeUtils.now());
             fileEntity.setFileData(new byte[]{1, 2, 3});
 
             when(distributedFileRepository.findByContentIdAndVersion(CONTENT_IDENTIFIER, VERSION, null))

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationSigningKeysServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationSigningKeysServiceImplTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.KeyUsageInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
@@ -320,8 +321,8 @@ class ConfigurationSigningKeysServiceImplTest {
 
         when(configurationSigningKeyRepository.findByKeyIdentifierIn(Set.of("keyId-1", "keyId-3")))
                 .thenReturn(List.of(
-                        new ConfigurationSigningKeyEntity("keyId-1", new byte[0], Instant.now(), TOKEN_ID),
-                        new ConfigurationSigningKeyEntity("keyId-3", new byte[0], Instant.now(), TOKEN_ID)
+                        new ConfigurationSigningKeyEntity("keyId-1", new byte[0], TimeUtils.now(), TOKEN_ID),
+                        new ConfigurationSigningKeyEntity("keyId-3", new byte[0], TimeUtils.now(), TOKEN_ID)
                 ));
 
         final List<ConfigurationSigningKeyWithDetails> keysWithDetails = configurationSigningKeysServiceImpl.findDetailedByToken(token);
@@ -347,7 +348,7 @@ class ConfigurationSigningKeysServiceImplTest {
         ConfigurationSigningKeyEntity configurationSigningKey = new ConfigurationSigningKeyEntity();
         configurationSigningKey.setKeyIdentifier("keyIdentifier");
         configurationSigningKey.setCert("keyCert".getBytes());
-        configurationSigningKey.setKeyGeneratedAt(Instant.now());
+        configurationSigningKey.setKeyGeneratedAt(TimeUtils.now());
         configurationSigningKey.setTokenIdentifier(TOKEN_ID);
 
         ConfigurationSourceEntity configurationSource = new ConfigurationSourceEntity();

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/NotificationServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/NotificationServiceImplTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,7 @@
 package org.niis.xroad.cs.admin.core.service;
 
 import ee.ria.xroad.common.SystemProperties;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
 
@@ -54,7 +55,6 @@ import java.util.Set;
 
 import static ee.ria.xroad.signer.protocol.dto.KeyUsageInfo.SIGNING;
 import static ee.ria.xroad.signer.protocol.dto.TokenStatusInfo.OK;
-import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -94,7 +94,7 @@ class NotificationServiceImplTest {
         ConfigurationSigningKey confSigningKey = new ConfigurationSigningKey();
         confSigningKey.setKeyIdentifier("id");
         mockInitialized(true, true);
-        when(globalConfGenerationStatus.get()).thenReturn(new GlobalConfGenerationStatus(SUCCESS, now()));
+        when(globalConfGenerationStatus.get()).thenReturn(new GlobalConfGenerationStatus(SUCCESS, TimeUtils.now()));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_INTERNAL))
                 .thenReturn(Optional.of(confSigningKey));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_EXTERNAL))
@@ -115,7 +115,7 @@ class NotificationServiceImplTest {
         confSigningKey.setKeyIdentifier("id-other");
         mockInitialized(true, true);
 
-        Instant time = Instant.now();
+        Instant time = TimeUtils.now();
         when(globalConfGenerationStatus.get()).thenReturn(new GlobalConfGenerationStatus(FAILURE, time));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_INTERNAL))
                 .thenReturn(Optional.of(confSigningKey));
@@ -140,7 +140,7 @@ class NotificationServiceImplTest {
         confSigningKey.setKeyIdentifier("id");
         mockInitialized(false, true);
         when(systemParameterService.getConfExpireIntervalSeconds()).thenReturn(600);
-        when(globalConfGenerationStatus.get()).thenReturn(new GlobalConfGenerationStatus(SUCCESS, now()));
+        when(globalConfGenerationStatus.get()).thenReturn(new GlobalConfGenerationStatus(SUCCESS, TimeUtils.now()));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_INTERNAL))
                 .thenReturn(Optional.of(confSigningKey));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_EXTERNAL))
@@ -187,7 +187,7 @@ class NotificationServiceImplTest {
         confSigningKey.setKeyIdentifier("id");
         mockInitialized(true, true);
         when(globalConfGenerationStatus.get())
-                .thenReturn(new GlobalConfGenerationStatus(SUCCESS, now().minus(1, HOURS)));
+                .thenReturn(new GlobalConfGenerationStatus(SUCCESS, TimeUtils.now().minus(1, HOURS)));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_INTERNAL))
                 .thenReturn(Optional.of(confSigningKey));
         when(configurationSigningKeysService.findActiveForSource(SOURCE_TYPE_EXTERNAL))

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/OcspRespondersServiceImplTest.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -51,11 +51,9 @@ import org.niis.xroad.cs.admin.core.repository.OcspInfoRepository;
 import org.niis.xroad.cs.admin.core.validation.UrlValidator;
 import org.niis.xroad.restapi.config.audit.AuditDataHelper;
 
-import java.time.Instant;
 import java.util.Optional;
 
 import static ee.ria.xroad.common.util.CryptoUtils.DEFAULT_CERT_HASH_ALGORITHM_ID;
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -75,10 +73,6 @@ import static org.niis.xroad.restapi.config.audit.RestApiAuditProperty.OCSP_URL;
 @ExtendWith(MockitoExtension.class)
 class OcspRespondersServiceImplTest {
     private static final Integer ID = 123;
-    private static final Instant VALID_FROM = Instant.now().minus(1, DAYS);
-    private static final Instant VALID_TO = Instant.now().plus(1, DAYS);
-    private static final String CA_NAME = "X-Road Test CA";
-    private static final String CERT_PROFILE = "ee.ria.xroad.common.certificateprofile.impl.FiVRKCertificateProfileInfoProvider";
 
     @Mock
     private OcspInfoRepository ocspInfoRepository;

--- a/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/GlobalConfGenerationServiceImpl.java
+++ b/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/GlobalConfGenerationServiceImpl.java
@@ -29,6 +29,7 @@ package org.niis.xroad.cs.admin.globalconf.generator;
 import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.conf.globalconf.ConfigurationConstants;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.commonui.OptionalConfPart;
 
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -99,7 +99,7 @@ public class GlobalConfGenerationServiceImpl implements GlobalConfGenerationServ
             log.debug("Starting global conf generation");
 
             generateAndSaveConfiguration();
-            var configGenerationTime = Instant.now();
+            var configGenerationTime = TimeUtils.now();
 
             var allConfigurationParts = toConfigurationParts(configurationService.getAllConfigurationFiles(CONFIGURATION_VERSION));
             var internalConfigurationParts = internalConfigurationParts(allConfigurationParts);
@@ -137,7 +137,7 @@ public class GlobalConfGenerationServiceImpl implements GlobalConfGenerationServ
         return Files.isDirectory(dirPath)
                 && dirPath.getFileName().toString().matches("\\A\\d+\\z")
                 && Files.getLastModifiedTime(dirPath).toInstant().isBefore(
-                Instant.now().minusSeconds(OLD_CONF_PRESERVING_SECONDS));
+                TimeUtils.now().minusSeconds(OLD_CONF_PRESERVING_SECONDS));
     }
 
     @SneakyThrows
@@ -189,7 +189,7 @@ public class GlobalConfGenerationServiceImpl implements GlobalConfGenerationServ
     private String createSignedDirectory(Set<ConfigurationPart> configurationParts, String pathPrefix, ConfigurationSigningKey signingKey) {
         var directoryContentBuilder = new DirectoryContentBuilder(
                 getConfHashAlgoId(),
-                Instant.now().plusSeconds(systemParameterService.getConfExpireIntervalSeconds()),
+                TimeUtils.now().plusSeconds(systemParameterService.getConfExpireIntervalSeconds()),
                 pathPrefix,
                 systemParameterService.getInstanceIdentifier())
                 .contentParts(configurationParts);
@@ -236,7 +236,7 @@ public class GlobalConfGenerationServiceImpl implements GlobalConfGenerationServ
     private void writeLocalCopy(Set<ConfigurationPart> allConfigurationParts) {
         new LocalCopyWriter(systemParameterService.getInstanceIdentifier(),
                 Path.of(SystemProperties.getConfigurationPath()),
-                Instant.now().plusSeconds(systemParameterService.getConfExpireIntervalSeconds()))
+                TimeUtils.now().plusSeconds(systemParameterService.getConfExpireIntervalSeconds()))
                 .write(allConfigurationParts);
     }
 

--- a/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/GlobalConfGenerationStatusServiceImpl.java
+++ b/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/GlobalConfGenerationStatusServiceImpl.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -44,7 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 
-import static java.time.Instant.now;
+import static ee.ria.xroad.common.util.TimeUtils.now;
 import static org.niis.xroad.cs.admin.api.dto.GlobalConfGenerationStatus.GlobalConfGenerationStatusEnum.FAILURE;
 import static org.niis.xroad.cs.admin.api.dto.GlobalConfGenerationStatus.GlobalConfGenerationStatusEnum.SUCCESS;
 import static org.niis.xroad.cs.admin.api.dto.GlobalConfGenerationStatus.GlobalConfGenerationStatusEnum.UNKNOWN;

--- a/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/ConfigurationDistributorTest.java
+++ b/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/ConfigurationDistributorTest.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.cs.admin.globalconf.generator;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -74,7 +76,7 @@ class ConfigurationDistributorTest {
 
     @Test
     void writeFiles() {
-        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, Instant.now());
+        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, TimeUtils.now());
         var confDir = configurationDistributor.initConfLocation();
 
         configurationDistributor.writeConfigurationFiles(List.of(CONFIGURATION_PART1, CONFIGURATION_PART2));
@@ -89,7 +91,7 @@ class ConfigurationDistributorTest {
 
     @Test
     void writeFilesBeforeInitShouldThrow() {
-        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, Instant.now());
+        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, TimeUtils.now());
         // initConfLocation omitted
 
         var configurationParts = List.of(CONFIGURATION_PART1);
@@ -100,7 +102,7 @@ class ConfigurationDistributorTest {
 
     @Test
     void writeDirectoryContent() {
-        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, Instant.now());
+        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, TimeUtils.now());
         configurationDistributor.initConfLocation();
 
         configurationDistributor.writeDirectoryContentFile(CONF_DIRECTORY, "data".getBytes(UTF_8));
@@ -112,7 +114,7 @@ class ConfigurationDistributorTest {
 
     @Test
     void moveDirectoryContentFile() {
-        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, Instant.now());
+        ConfigurationDistributor configurationDistributor = new ConfigurationDistributor(generatedConfDir, VERSION, TimeUtils.now());
         configurationDistributor.initConfLocation();
         configurationDistributor.writeDirectoryContentFile(CONF_DIRECTORY + ".tmp", "data".getBytes(UTF_8));
 

--- a/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/LocalCopyWriterTest.java
+++ b/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/LocalCopyWriterTest.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.cs.admin.globalconf.generator;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -63,7 +65,7 @@ class LocalCopyWriterTest {
 
     @Test
     void shouldCreateDir() {
-        var localCopyWriter = new LocalCopyWriter(INSTANCE, localConfDir, Instant.now());
+        var localCopyWriter = new LocalCopyWriter(INSTANCE, localConfDir, TimeUtils.now());
         localCopyWriter.write(CONFIGURATION_PARTS);
 
         assertThat(localConfDir.resolve(INSTANCE))
@@ -73,7 +75,7 @@ class LocalCopyWriterTest {
 
     @Test
     void shouldWriteFiles() {
-        var localCopyWriter = new LocalCopyWriter(INSTANCE, localConfDir, Instant.now());
+        var localCopyWriter = new LocalCopyWriter(INSTANCE, localConfDir, TimeUtils.now());
         localCopyWriter.write(CONFIGURATION_PARTS);
 
         CONFIGURATION_PARTS.forEach(part ->

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverterTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/converter/BackupDtoConverterTest.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,10 +25,10 @@
  */
 package org.niis.xroad.cs.admin.rest.api.converter;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.jupiter.api.Test;
 import org.niis.xroad.restapi.common.backup.dto.BackupFile;
-
-import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +37,7 @@ class BackupDtoConverterTest {
 
     @Test
     void shouldSuccessfullyMapToDto() {
-        var backupFile = new BackupFile("test.tar", OffsetDateTime.now());
+        var backupFile = new BackupFile("test.tar", TimeUtils.offsetDateTimeNow());
 
         var result = backupDtoConverter.toTarget(backupFile);
 

--- a/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/mapper/TokenDtoMapperTest.java
+++ b/src/central-server/admin-service/infra-api-rest/src/test/java/org/niis/xroad/cs/admin/rest/api/mapper/TokenDtoMapperTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,8 @@
  */
 
 package org.niis.xroad.cs.admin.rest.api.mapper;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +43,6 @@ import org.niis.xroad.cs.openapi.model.PossibleTokenActionDto;
 import org.niis.xroad.cs.openapi.model.TokenDto;
 import org.niis.xroad.cs.openapi.model.TokenStatusDto;
 
-import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -105,7 +106,7 @@ class TokenDtoMapperTest {
         final ConfigurationSigningKeyWithDetails signingKey = new ConfigurationSigningKeyWithDetails();
         signingKey.setKeyIdentifier("keyIdentifier");
         signingKey.setTokenIdentifier("id");
-        signingKey.setKeyGeneratedAt(Instant.now());
+        signingKey.setKeyGeneratedAt(TimeUtils.now());
         signingKey.setActiveSourceSigningKey(true);
         signingKey.setPossibleActions(List.of(PossibleKeyAction.ACTIVATE));
         signingKey.setLabel(new KeyLabel("LABEL"));

--- a/src/central-server/admin-service/int-test/build.gradle
+++ b/src/central-server/admin-service/int-test/build.gradle
@@ -11,6 +11,7 @@ configurations {
 dependencies {
     intTestImplementation project(path:":central-server:admin-service:infra-jpa", configuration:"changelogJar")
     intTestImplementation project(":central-server:openapi-model")
+    intTestImplementation project(":common:common-util")
 
     intTestImplementation("com.nortal.test:test-automation-core:$testAutomationFrameworkVersion")
     intTestImplementation("com.nortal.test:test-automation-assert:$testAutomationFrameworkVersion")

--- a/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/CertificateUtils.java
+++ b/src/central-server/admin-service/int-test/src/intTest/java/org/niis/xroad/cs/test/utils/CertificateUtils.java
@@ -5,17 +5,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,8 @@
  */
 
 package org.niis.xroad.cs.test.utils;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
@@ -44,7 +46,6 @@ import java.security.PrivateKey;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -90,8 +91,8 @@ public final class CertificateUtils {
         return new JcaX509v3CertificateBuilder(
                 issuerCertificate.getSubjectX500Principal(),
                 BigInteger.ONE,
-                Date.from(Instant.now().minus(1, ChronoUnit.MINUTES)),
-                Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+                Date.from(TimeUtils.now().minus(1, ChronoUnit.MINUTES)),
+                Date.from(TimeUtils.now().plus(365, ChronoUnit.DAYS)),
                 subject,
                 issuerCertificate.getPublicKey())
                 .addExtension(Extension.create(

--- a/src/central-server/admin-service/ui-system-test/build.gradle
+++ b/src/central-server/admin-service/ui-system-test/build.gradle
@@ -2,13 +2,14 @@
 
 dependencies {
     intTestImplementation project(":central-server:openapi-model")
+    intTestImplementation project(":common:common-util")
     intTestImplementation("com.nortal.test:test-automation-core:${testAutomationFrameworkVersion}")
     intTestImplementation("com.nortal.test:test-automation-selenide:${testAutomationFrameworkVersion}")
     intTestImplementation("com.nortal.test:test-automation-allure:${testAutomationFrameworkVersion}")
     intTestImplementation("com.nortal.test:test-automation-containers:${testAutomationFrameworkVersion}")
     intTestImplementation("com.nortal.test:test-automation-feign:$testAutomationFrameworkVersion")
     intTestImplementation("org.bouncycastle:bcpkix-jdk15on:${bouncyCastleVersion}")
-    intTestImplementation( "org.awaitility:awaitility:${awaitilityVersion}")
+    intTestImplementation("org.awaitility:awaitility:${awaitilityVersion}")
 }
 
 task systemTest(type: Test) {

--- a/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/CertificateUtils.java
+++ b/src/central-server/admin-service/ui-system-test/src/intTest/java/org/niis/xroad/cs/test/ui/utils/CertificateUtils.java
@@ -5,17 +5,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,8 @@
  */
 
 package org.niis.xroad.cs.test.ui.utils;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
@@ -50,7 +52,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collection;
@@ -124,8 +125,8 @@ public final class CertificateUtils {
         return new JcaX509v3CertificateBuilder(
                 new X500Principal(principalName),
                 serial,
-                Date.from(Instant.now().minus(1, ChronoUnit.MINUTES)),
-                Date.from(Instant.now().plus(365 + serial.abs().intValue(), ChronoUnit.DAYS)),
+                Date.from(TimeUtils.now().minus(1, ChronoUnit.MINUTES)),
+                Date.from(TimeUtils.now().plus(365 + serial.abs().intValue(), ChronoUnit.DAYS)),
                 subject,
                 issuerCertificate.getPublicKey())
                 .addExtension(Extension.create(

--- a/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ManagementRequestStepDefs.java
+++ b/src/central-server/management-service/int-test/src/intTest/java/org/niis/xroad/cs/test/glue/ManagementRequestStepDefs.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,8 @@
  */
 
 package org.niis.xroad.cs.test.glue;
+
+import ee.ria.xroad.common.util.TimeUtils;
 
 import com.nortal.test.asserts.Assertion;
 import io.cucumber.java.en.Step;
@@ -43,7 +45,6 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Objects;
 
@@ -196,7 +197,7 @@ public class ManagementRequestStepDefs extends BaseStepDefs {
                 .withReceiverClientId(DEFAULT_RECEIVER)
                 .withServerId(DEFAULT_SERVER_ID)
                 .withClientId(clientId)
-                .withClientOcsp(new RevokedStatus(Date.from(Instant.now().minusSeconds(3600)), CRLReason.unspecified))
+                .withClientOcsp(new RevokedStatus(Date.from(TimeUtils.now().minusSeconds(3600)), CRLReason.unspecified))
                 .build();
         executeRequest(request.createPayload());
     }

--- a/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestControllerTest.java
+++ b/src/central-server/registration-service/src/test/java/org/niis/xroad/cs/registrationservice/controller/RegistrationRequestControllerTest.java
@@ -1,21 +1,21 @@
 /*
  * The MIT License
- * <p>
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.TestCertUtil;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.identifier.SecurityServerId;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
@@ -55,7 +56,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Random;
 
@@ -161,7 +161,7 @@ class RegistrationRequestControllerTest {
                 TestCertUtil.getCaCert(),
                 TestCertUtil.getOcspSigner().certChain[0],
                 TestCertUtil.getOcspSigner().key,
-                new RevokedStatus(Date.from(Instant.now().minusSeconds(3600)), CRLReason.unspecified));
+                new RevokedStatus(Date.from(TimeUtils.now().minusSeconds(3600)), CRLReason.unspecified));
 
         var builder = new TestManagementRequestBuilder(serverId.getOwner(), serverId.getOwner());
         var req = builder.buildAuthCertRegRequest(serverId, "ss1.example.org", authCert);

--- a/src/common/common-test/src/main/java/ee/ria/xroad/common/TestCertUtil.java
+++ b/src/common/common-test/src/main/java/ee/ria/xroad/common/TestCertUtil.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,7 @@ package ee.ria.xroad.common;
 
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.SneakyThrows;
 import org.bouncycastle.asn1.x509.Extension;
@@ -50,7 +51,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -387,8 +387,8 @@ public final class TestCertUtil {
         return new JcaX509v3CertificateBuilder(
                 issuer,
                 BigInteger.ONE,
-                Date.from(Instant.now()),
-                Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+                Date.from(TimeUtils.now()),
+                Date.from(TimeUtils.now().plus(365, ChronoUnit.DAYS)),
                 subject,
                 subjectKey)
                 .addExtension(Extension.create(
@@ -416,8 +416,8 @@ public final class TestCertUtil {
         var cert = new JcaX509v3CertificateBuilder(
                 issuer,
                 BigInteger.TWO,
-                Date.from(Instant.now().minus(1, ChronoUnit.MINUTES)),
-                Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+                Date.from(TimeUtils.now().minus(1, ChronoUnit.MINUTES)),
+                Date.from(TimeUtils.now().plus(365, ChronoUnit.DAYS)),
                 subject,
                 subjectKey)
                 .addExtension(Extension.create(

--- a/src/common/common-util/build.gradle
+++ b/src/common/common-util/build.gradle
@@ -57,9 +57,11 @@ dependencies {
 
     implementation "ch.qos.logback:logback-classic:$logbackVersion"
 
+    testImplementation project(':common:common-test')
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation project(':common:common-test')
+    testImplementation "org.mockito:mockito-inline:$mockitoVersion"
+
 
     xjc "org.glassfish.jaxb:jaxb-xjc:$jaxbVersion"
     xjc "org.glassfish.jaxb:jaxb-runtime:$jaxbVersion"

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/DiagnosticsStatus.java
@@ -25,6 +25,8 @@
  */
 package ee.ria.xroad.common;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -90,6 +92,6 @@ public class DiagnosticsStatus implements Serializable {
      */
     public void setReturnCodeNow(int newReturnCode) {
         this.returnCode = newReturnCode;
-        this.prevUpdate = OffsetDateTime.now();
+        this.prevUpdate = TimeUtils.offsetDateTimeNow();
     }
 }

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/Configuration.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/Configuration.java
@@ -25,12 +25,13 @@
  */
 package ee.ria.xroad.common.conf.globalconf;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,7 @@ public class Configuration {
      * @return true, if the configuration is expired at the current date
      */
     public boolean isExpired() {
-        return expirationDate != null && Instant.now().isAfter(expirationDate.toInstant());
+        return expirationDate != null && TimeUtils.now().isAfter(expirationDate.toInstant());
     }
 
 

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationDirectoryV2.java
@@ -26,6 +26,7 @@
 package ee.ria.xroad.common.conf.globalconf;
 
 import ee.ria.xroad.common.CodedException;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -152,7 +153,7 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
         // ignore federated parameters that are expired
         if (parameters != null
                 && (parameters.getInstanceIdentifier().equals(instanceIdentifier)
-                    || parameters.getExpiresOn().isAfter(OffsetDateTime.now()))) {
+                    || parameters.getExpiresOn().isAfter(TimeUtils.offsetDateTimeNow()))) {
             return parameters;
         }
         return null;
@@ -162,7 +163,7 @@ public class ConfigurationDirectoryV2 implements ConfigurationDirectory {
      * @return all known shared parameters
      */
     public List<SharedParametersV2> getShared() {
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = TimeUtils.offsetDateTimeNow();
         return sharedParameters.values()
                 .stream()
                 .filter(p -> p.getInstanceIdentifier().equals(instanceIdentifier) || p.getExpiresOn().isAfter(now))

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
@@ -88,18 +88,38 @@ public final class TimeUtils {
         return Instant.now().truncatedTo(MICROS);
     }
 
+    /**
+     * Current time truncated to microseconds. Some OS/JDK might use nanoseconds precision.
+     *
+     * @return OffsetDateTime wil microseconds precision.
+     */
     public static OffsetDateTime offsetDateTimeNow() {
         return OffsetDateTime.now().truncatedTo(MICROS);
     }
 
+    /**
+     * Current time truncated to microseconds. Some OS/JDK might use nanoseconds precision.
+     *
+     * @return OffsetDateTime wil microseconds precision.
+     */
     public static OffsetDateTime offsetDateTimeNow(ZoneId zoneId) {
         return OffsetDateTime.now(zoneId).truncatedTo(MICROS);
     }
 
+    /**
+     * Current time truncated to microseconds. Some OS/JDK might use nanoseconds precision.
+     *
+     * @return LocalDateTime wil microseconds precision.
+     */
     public static LocalDateTime localDateTimeNow() {
         return LocalDateTime.now().truncatedTo(MICROS);
     }
 
+    /**
+     * Current time truncated to microseconds. Some OS/JDK might use nanoseconds precision.
+     *
+     * @return ZonedDateTime wil microseconds precision.
+     */
     public static ZonedDateTime zonedDateTimeNow(ZoneId zoneId) {
         return ZonedDateTime.now(zoneId).truncatedTo(MICROS);
     }

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/TimeUtils.java
@@ -26,10 +26,14 @@
 package ee.ria.xroad.common.util;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
+import static java.time.temporal.ChronoUnit.MICROS;
 
 /**
  * This class contains various time related utility methods.
@@ -41,6 +45,7 @@ public final class TimeUtils {
 
     /**
      * Gets the number of seconds from the Java epoch of 1970-01-01T00:00:00Z.
+     *
      * @return the seconds from the epoch of 1970-01-01T00:00:00Z
      */
     public static long getEpochSecond() {
@@ -50,6 +55,7 @@ public final class TimeUtils {
     /**
      * Gets the number of milliseconds from the Java epoch of
      * 1970-01-01T00:00:00Z.
+     *
      * @return the milliseconds from the epoch of 1970-01-01T00:00:00Z
      */
     public static long getEpochMillisecond() {
@@ -58,6 +64,7 @@ public final class TimeUtils {
 
     /**
      * Converts given seconds to milliseconds.
+     *
      * @param seconds given seconds
      * @return the converted milliseconds
      */
@@ -71,4 +78,30 @@ public final class TimeUtils {
     public static OffsetDateTime toOffsetDateTime(Date date) {
         return date == null ? null : date.toInstant().atZone(ZoneId.systemDefault()).toOffsetDateTime();
     }
+
+    /**
+     * Current time truncated to microseconds. Some OS/JDK might use nanoseconds precision.
+     *
+     * @return Instant wil microseconds precision.
+     */
+    public static Instant now() {
+        return Instant.now().truncatedTo(MICROS);
+    }
+
+    public static OffsetDateTime offsetDateTimeNow() {
+        return OffsetDateTime.now().truncatedTo(MICROS);
+    }
+
+    public static OffsetDateTime offsetDateTimeNow(ZoneId zoneId) {
+        return OffsetDateTime.now(zoneId).truncatedTo(MICROS);
+    }
+
+    public static LocalDateTime localDateTimeNow() {
+        return LocalDateTime.now().truncatedTo(MICROS);
+    }
+
+    public static ZonedDateTime zonedDateTimeNow(ZoneId zoneId) {
+        return ZonedDateTime.now(zoneId).truncatedTo(MICROS);
+    }
+
 }

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadataTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/conf/globalconf/ConfigurationPartMetadataTest.java
@@ -25,10 +25,11 @@
  */
 package ee.ria.xroad.common.conf.globalconf;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.time.OffsetDateTime;
 
 import static org.junit.Assert.assertEquals;
 
@@ -39,6 +40,7 @@ public class ConfigurationPartMetadataTest {
 
     /**
      * Test that ensures metadata is written and read correctly.
+     *
      * @throws Exception in case of any unexpected errors
      */
     @Test
@@ -46,7 +48,7 @@ public class ConfigurationPartMetadataTest {
         ConfigurationPartMetadata write = new ConfigurationPartMetadata();
         write.setContentIdentifier("SHARED-PARAMETERS");
         write.setInstanceIdentifier("FOO");
-        write.setExpirationDate(OffsetDateTime.now());
+        write.setExpirationDate(TimeUtils.offsetDateTimeNow());
 
         final byte[] bytes = write.toByteArray();
         ConfigurationPartMetadata read = ConfigurationPartMetadata.read(

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/JsonUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/JsonUtilsTest.java
@@ -64,7 +64,7 @@ public class JsonUtilsTest {
      */
     @Test
     public void testIgnoresTabsInContentType() throws Exception {
-        final Foo foo = new Foo(100, 200, OffsetDateTime.now(), null);
+        final Foo foo = new Foo(100, 200, TimeUtils.offsetDateTimeNow(), null);
         final String json = OBJECT_WRITER.writeValueAsString(foo);
         final Foo foo2 = OBJECT_READER.readValue(json, Foo.class);
 

--- a/src/common/common-util/src/test/java/ee/ria/xroad/common/util/TimeUtilsTest.java
+++ b/src/common/common-util/src/test/java/ee/ria/xroad/common/util/TimeUtilsTest.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package ee.ria.xroad.common.util;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TimeUtilsTest {
+
+    private static final int EPOCH_SECONDS = 1696572342; // 2023-10-06T06:05:42 UTC
+
+    private final Clock spyClock = spy(Clock.class);
+
+    @Test
+    public void now() {
+        try (MockedStatic<Clock> clockMock = mockStatic(Clock.class)) {
+            clockMock.when(Clock::systemUTC).thenReturn(spyClock);
+            when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(EPOCH_SECONDS, 123456789));
+
+            final Instant now = TimeUtils.now();
+
+            assertEquals(123456000, now.getNano());
+        }
+    }
+
+    @Test
+    public void offsetDateTimeNow() {
+        try (MockedStatic<Clock> clockMock = mockStatic(Clock.class)) {
+            clockMock.when(Clock::systemDefaultZone).thenReturn(spyClock);
+            when(spyClock.getZone()).thenReturn(ZoneId.of("UTC"));
+            when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(EPOCH_SECONDS, 123456789));
+
+            final OffsetDateTime now = TimeUtils.offsetDateTimeNow();
+
+            assertEquals(123456000, now.getNano());
+        }
+    }
+
+    @Test
+    public void offsetDateTimeNowAtZone() {
+        final ZoneId zone = ZoneOffset.UTC;
+        try (MockedStatic<Clock> clockMock = mockStatic(Clock.class)) {
+            clockMock.when(() -> Clock.system(zone)).thenReturn(spyClock);
+            when(spyClock.getZone()).thenReturn(zone);
+            when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(EPOCH_SECONDS, 123456789));
+
+            final OffsetDateTime now = TimeUtils.offsetDateTimeNow(zone);
+
+            assertEquals(123456000, now.getNano());
+        }
+    }
+
+    @Test
+    public void localDateTimeNow() {
+        try (MockedStatic<Clock> clockMock = mockStatic(Clock.class)) {
+            clockMock.when(Clock::systemDefaultZone).thenReturn(spyClock);
+            when(spyClock.getZone()).thenReturn(ZoneId.of("UTC"));
+            when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(EPOCH_SECONDS, 123456789));
+
+            final LocalDateTime now = TimeUtils.localDateTimeNow();
+
+            assertEquals(123456000, now.getNano());
+        }
+    }
+
+    @Test
+    public void zonedDateTimeNow() {
+        final ZoneId zone = ZoneOffset.UTC;
+        try (MockedStatic<Clock> clockMock = mockStatic(Clock.class)) {
+            clockMock.when(() -> Clock.system(zone)).thenReturn(spyClock);
+            when(spyClock.getZone()).thenReturn(zone);
+            when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(EPOCH_SECONDS, 123456789));
+
+            final ZonedDateTime now = TimeUtils.zonedDateTimeNow(zone);
+
+            assertEquals(123456000, now.getNano());
+        }
+    }
+
+}

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
@@ -44,6 +44,7 @@ import ee.ria.xroad.common.identifier.GlobalGroupId;
 import ee.ria.xroad.common.identifier.SecurityServerId;
 import ee.ria.xroad.common.util.CertUtils;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
@@ -102,7 +103,7 @@ public class GlobalConfImpl implements GlobalConfProvider {
         // it is important to get handle of confDir as this variable is volatile
         ConfigurationDirectoryV2 checkDir = confDir;
         String mainInstance = checkDir.getInstanceIdentifier();
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = TimeUtils.offsetDateTimeNow();
         try {
             if (now.isAfter(checkDir.getPrivate(mainInstance).getExpiresOn())) {
                 log.warn("Main privateParameters expired at {}", checkDir.getPrivate(mainInstance).getExpiresOn());

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspCacheTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspCacheTest.java
@@ -29,6 +29,7 @@ import ee.ria.xroad.common.OcspTestUtils;
 import ee.ria.xroad.common.TestCertUtil;
 import ee.ria.xroad.common.conf.globalconf.EmptyGlobalConf;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.bouncycastle.cert.ocsp.CertificateStatus;
 import org.bouncycastle.cert.ocsp.OCSPResp;
@@ -37,7 +38,6 @@ import org.junit.Test;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
@@ -80,7 +80,7 @@ public class OcspCacheTest {
      */
     @Test
     public void putGet() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 
@@ -95,7 +95,7 @@ public class OcspCacheTest {
      */
     @Test
     public void expiredResponse() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().minus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/ocsp/OcspVerifierTest.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.TestCertUtil;
 import ee.ria.xroad.common.TestSecurityUtil;
 import ee.ria.xroad.common.conf.globalconf.EmptyGlobalConf;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import com.google.common.cache.Cache;
 import org.bouncycastle.asn1.x509.CRLReason;
@@ -46,7 +47,6 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
@@ -80,7 +80,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void errorCertMismatch() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 
@@ -149,7 +149,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void errorThisUpdateAfterNow() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plusMillis(12345L));
+        Date thisUpdate = Date.from(TimeUtils.now().plusMillis(12345L));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD,
                 thisUpdate, new Date());
@@ -166,7 +166,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void errorNextUpdateBeforeNow() throws Exception {
-        Date nextUpdate = Date.from(Instant.now().minusMillis(12345L));
+        Date nextUpdate = Date.from(TimeUtils.now().minusMillis(12345L));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD,
                 new Date(), nextUpdate);
@@ -184,7 +184,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void nextUpdateBeforeNow() throws Exception {
-        Date nextUpdate = Date.from(Instant.now().minusMillis(12345L));
+        Date nextUpdate = Date.from(TimeUtils.now().minusMillis(12345L));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD,
                 new Date(), nextUpdate);
@@ -199,7 +199,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void certStatusGood() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD,
                 thisUpdate, null);
@@ -215,7 +215,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void certStatusRevoked() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey,
                 new RevokedStatus(new Date(), CRLReason.unspecified),
@@ -233,7 +233,7 @@ public class OcspVerifierTest {
      */
     @Test
     public void certStatusUnknown() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, new UnknownStatus(),
                 thisUpdate, null);
@@ -246,7 +246,7 @@ public class OcspVerifierTest {
 
     @Test
     public void responseValidityCache() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD,
                 thisUpdate, null);

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientJob.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientJob.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,6 +29,7 @@ import ee.ria.xroad.common.DiagnosticsErrorCodes;
 import ee.ria.xroad.common.DiagnosticsStatus;
 import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.util.JobManager;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.niis.xroad.schedule.RetryingQuartzJob;
@@ -38,8 +39,6 @@ import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.SchedulerException;
-
-import java.time.OffsetDateTime;
 
 /**
  * Quartz job implementation for the configuration client.
@@ -63,14 +62,14 @@ public class ConfigurationClientJob extends RetryingQuartzJob {
                 ((ConfigurationClient) client).execute();
 
                 DiagnosticsStatus status =
-                        new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, OffsetDateTime.now(),
-                                OffsetDateTime.now()
+                        new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, TimeUtils.offsetDateTimeNow(),
+                                TimeUtils.offsetDateTimeNow()
                                         .plusSeconds(SystemProperties.getConfigurationClientUpdateIntervalSeconds()));
                 context.setResult(status);
             } catch (Exception e) {
                 DiagnosticsStatus status = new DiagnosticsStatus(ConfigurationClientUtils.getErrorCode(e),
-                        OffsetDateTime.now(),
-                        OffsetDateTime.now()
+                        TimeUtils.offsetDateTimeNow(),
+                        TimeUtils.offsetDateTimeNow()
                                 .plusSeconds(SystemProperties.getConfigurationClientUpdateIntervalSeconds()));
                 context.setResult(status);
 

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,6 +33,7 @@ import ee.ria.xroad.common.Version;
 import ee.ria.xroad.common.util.AdminPort;
 import ee.ria.xroad.common.util.JobManager;
 import ee.ria.xroad.common.util.JsonUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.BasicParser;
@@ -50,7 +51,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.nio.file.Path;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -331,8 +331,8 @@ public final class ConfigurationClientMain {
         private static DiagnosticsStatus status;
 
         static {
-            status = new DiagnosticsStatus(DiagnosticsErrorCodes.ERROR_CODE_UNINITIALIZED, OffsetDateTime.now(),
-                    OffsetDateTime.now().plusSeconds(SystemProperties.getConfigurationClientUpdateIntervalSeconds()));
+            status = new DiagnosticsStatus(DiagnosticsErrorCodes.ERROR_CODE_UNINITIALIZED, TimeUtils.offsetDateTimeNow(),
+                    TimeUtils.offsetDateTimeNow().plusSeconds(SystemProperties.getConfigurationClientUpdateIntervalSeconds()));
         }
 
         private static synchronized void setStatus(DiagnosticsStatus newStatus) {

--- a/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/OutputBuilder.java
+++ b/src/configuration-proxy/src/main/java/ee/ria/xroad/confproxy/util/OutputBuilder.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.util.CryptoUtils;
 import ee.ria.xroad.common.util.HashCalculator;
 import ee.ria.xroad.common.util.MimeTypes;
 import ee.ria.xroad.common.util.MultipartEncoder;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.confproxy.ConfProxyProperties;
 import ee.ria.xroad.signer.SignerProxy;
 
@@ -193,7 +194,7 @@ public class OutputBuilder implements AutoCloseable {
      */
     private void build(final ByteArrayOutputStream mimeContent) throws Exception {
         try (MultipartEncoder encoder = new MultipartEncoder(mimeContent, dataBoundary)) {
-            OffsetDateTime expireDate = OffsetDateTime.now().plusSeconds(conf.getValidityIntervalSeconds());
+            OffsetDateTime expireDate = TimeUtils.offsetDateTimeNow().plusSeconds(conf.getValidityIntervalSeconds());
             encoder.startPart(null, new String[]{
                     HEADER_EXPIRE_DATE + ": " + DATETIME_FORMAT.format(expireDate.truncatedTo(ChronoUnit.MILLIS)),
                     HEADER_VERSION + ": " + String.format("%d", version)

--- a/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/HistogramDto.java
+++ b/src/monitor-common/src/main/java/ee/ria/xroad/monitor/common/dto/HistogramDto.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 
 import java.time.Instant;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
+
 /**
  * Created by hyoty on 24.9.2015.
  */
@@ -67,7 +69,7 @@ public class HistogramDto extends MetricDto {
                         double min,
                         double stdDev) {
         super(name);
-        updateDateTime = Instant.now();
+        updateDateTime = Instant.now().truncatedTo(MILLIS);
         this.distribution75thPercentile = distribution75thPercentile;
         this.distribution95thPercentile = distribution95thPercentile;
         this.distribution98thPercentile = distribution98thPercentile;

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordCleaner.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OperationalDataRecordCleaner.java
@@ -28,6 +28,7 @@ package ee.ria.xroad.opmonitordaemon;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringSystemProperties;
 import ee.ria.xroad.common.util.JobManager;
 import ee.ria.xroad.common.util.MessageSendingJob;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
@@ -87,7 +88,7 @@ final class OperationalDataRecordCleaner extends UntypedAbstractActor {
 
     private static void handleCleanup() throws Exception {
         cleanRecords(
-                Instant.now().minus(OpMonitoringSystemProperties.getOpMonitorKeepRecordsForDays(), ChronoUnit.DAYS));
+                TimeUtils.now().minus(OpMonitoringSystemProperties.getOpMonitorKeepRecordsForDays(), ChronoUnit.DAYS));
     }
 
     static int cleanRecords(Instant before) throws Exception {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyMain.java
@@ -50,6 +50,7 @@ import ee.ria.xroad.common.util.AdminPort;
 import ee.ria.xroad.common.util.JobManager;
 import ee.ria.xroad.common.util.JsonUtils;
 import ee.ria.xroad.common.util.StartStop;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.common.util.healthcheck.HealthCheckPort;
 import ee.ria.xroad.proxy.addon.AddOn;
 import ee.ria.xroad.proxy.clientproxy.ClientProxy;
@@ -77,7 +78,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -509,11 +509,11 @@ public final class ProxyMain {
                     log.warn("Timestamp check received HTTP error: {} - {}. Might still be ok", con.getResponseCode(),
                             con.getResponseMessage());
                     statuses.put(tspUrl,
-                            new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, OffsetDateTime.now(),
+                            new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, TimeUtils.offsetDateTimeNow(),
                                     tspUrl));
                 } else {
                     statuses.put(tspUrl,
-                            new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, OffsetDateTime.now(),
+                            new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, TimeUtils.offsetDateTimeNow(),
                                     tspUrl));
                 }
 
@@ -521,7 +521,7 @@ public final class ProxyMain {
                 log.warn("Timestamp status check failed {}", e);
 
                 statuses.put(tspUrl,
-                        new DiagnosticsStatus(DiagnosticsUtils.getErrorCode(e), OffsetDateTime.now(), tspUrl));
+                        new DiagnosticsStatus(DiagnosticsUtils.getErrorCode(e), TimeUtils.offsetDateTimeNow(), tspUrl));
             }
         }
         return statuses;

--- a/src/proxy/src/test/java/ee/ria/xroad/common/signature/BatchSignerIntegrationTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/signature/BatchSignerIntegrationTest.java
@@ -32,6 +32,7 @@ import ee.ria.xroad.common.hashchain.HashChainReferenceResolver;
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.util.CryptoUtils;
 import ee.ria.xroad.common.util.MessageFileNames;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.proxy.signedmessage.SignerSigningKey;
 import ee.ria.xroad.signer.protocol.SignerClient;
 
@@ -54,7 +55,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -125,7 +125,7 @@ public final class BatchSignerIntegrationTest {
         }
 
         latch = new CountDownLatch(messages.size());
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         final OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subjectCert, issuerCert, signerCert, signerKey,
                 CertificateStatus.GOOD, thisUpdate, null);
 

--- a/src/proxy/src/test/java/ee/ria/xroad/common/signature/SignatureBuilderTest.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/common/signature/SignatureBuilderTest.java
@@ -30,6 +30,7 @@ import ee.ria.xroad.common.TestCertUtil;
 import ee.ria.xroad.common.TestSecurityUtil;
 import ee.ria.xroad.common.util.CryptoUtils;
 import ee.ria.xroad.common.util.MessageFileNames;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
@@ -44,7 +45,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
@@ -112,7 +112,7 @@ public class SignatureBuilderTest {
         SignatureBuilder builder = new SignatureBuilder();
         builder.addPart(hash);
 
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
 
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subjectCert, issuerCert, signerCert, signerKey,
                 CertificateStatus.GOOD, thisUpdate, null);
@@ -141,7 +141,7 @@ public class SignatureBuilderTest {
     public void buildSuccessfullyWithExtraCerts() throws Exception {
         SignatureBuilder builder = new SignatureBuilder();
 
-        final Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        final Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
 
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subjectCert, issuerCert, signerCert, signerKey,
                 CertificateStatus.GOOD, thisUpdate, null);

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteKeyConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testsuite/TestSuiteKeyConf.java
@@ -35,6 +35,7 @@ import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.ocsp.OcspVerifier;
 import ee.ria.xroad.common.ocsp.OcspVerifierOptions;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.proxy.conf.SigningCtx;
 import ee.ria.xroad.proxy.util.TestUtil;
 
@@ -44,7 +45,6 @@ import org.bouncycastle.cert.ocsp.OCSPResp;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
@@ -99,7 +99,7 @@ public class TestSuiteKeyConf extends EmptyKeyConf {
 
         if (!ocspResponses.containsKey(certHash)) {
             try {
-                Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+                Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
                 OCSPResp resp = OcspTestUtils.createOCSPResponse(cert,
                         GlobalConf.getCaCert("EE", cert), getOcspSignerCert(),
                         getOcspRequestKey(), CertificateStatus.GOOD,

--- a/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestKeyConf.java
+++ b/src/proxy/src/test/java/ee/ria/xroad/proxy/testutil/TestKeyConf.java
@@ -35,6 +35,7 @@ import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.ocsp.OcspVerifier;
 import ee.ria.xroad.common.ocsp.OcspVerifierOptions;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.proxy.conf.SigningCtx;
 import ee.ria.xroad.proxy.testsuite.EmptyKeyConf;
 import ee.ria.xroad.proxy.util.TestUtil;
@@ -45,7 +46,6 @@ import org.bouncycastle.cert.ocsp.OCSPResp;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
@@ -93,7 +93,7 @@ public class TestKeyConf extends EmptyKeyConf {
 
         if (!ocspResponses.containsKey(certHash)) {
             try {
-                Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+                Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
                 OCSPResp resp = OcspTestUtils.createOCSPResponse(cert,
                         GlobalConf.getCaCert("EE", cert), getOcspSignerCert(),
                         getOcspRequestKey(), CertificateStatus.GOOD,

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CustomErrorAttributes.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/CustomErrorAttributes.java
@@ -25,12 +25,13 @@
  */
 package org.niis.xroad.securityserver.restapi.config;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.WebRequest;
 
-import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 
@@ -43,7 +44,7 @@ public class CustomErrorAttributes extends DefaultErrorAttributes {
     @Override
     public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
         Map<String, Object> errorAttributes = super.getErrorAttributes(webRequest, options);
-        errorAttributes.put("timestamp", OffsetDateTime.now(ZoneOffset.UTC));
+        errorAttributes.put("timestamp", TimeUtils.offsetDateTimeNow(ZoneOffset.UTC));
         // Remove path to avoid reflecting input in response
         errorAttributes.remove("path");
         // Remove message since it's not defined

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/converter/TokenCertificateConverter.java
@@ -25,6 +25,7 @@
  */
 package org.niis.xroad.securityserver.restapi.converter;
 
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.CertificateInfo;
 import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
@@ -102,7 +103,7 @@ public class TokenCertificateConverter {
         if (!info.isActive()) {
             return CertificateOcspStatus.DISABLED;
         }
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = TimeUtils.offsetDateTimeNow();
         if (now.isAfter(details.getNotAfter())) {
             return CertificateOcspStatus.EXPIRED;
         }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/CsrFilenameCreator.java
@@ -27,13 +27,13 @@ package org.niis.xroad.securityserver.restapi.openapi;
 
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.identifier.SecurityServerId;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.protocol.dto.KeyUsageInfo;
 import ee.ria.xroad.signer.protocol.message.CertificateRequestFormat;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -71,7 +71,7 @@ public class CsrFilenameCreator {
     }
 
     String createDateString() {
-        return LocalDateTime.now()
+        return TimeUtils.localDateTimeNow()
                 .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
     }
 

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/NotificationService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/NotificationService.java
@@ -26,6 +26,7 @@
 package org.niis.xroad.securityserver.restapi.service;
 
 import ee.ria.xroad.common.CodedException;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.SignerProxy;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
 
@@ -66,7 +67,7 @@ public class NotificationService {
         OffsetDateTime backupRestoreStartedAt = getBackupRestoreRunningSince();
         if (backupRestoreStartedAt != null) {
             alertStatus.setBackupRestoreRunningSince(backupRestoreStartedAt);
-            alertStatus.setCurrentTime(OffsetDateTime.now(ZoneOffset.UTC));
+            alertStatus.setCurrentTime(TimeUtils.offsetDateTimeNow(ZoneOffset.UTC));
             alertStatus.setSoftTokenPinEntered(false);
             alertStatus.setSoftTokenPinEnteredCheckSuccess(false);
         } else {
@@ -139,7 +140,7 @@ public class NotificationService {
      * Sets backupRestoreRunningSince to current date/time.
      */
     public synchronized void setBackupRestoreRunningSince() {
-        backupRestoreRunningSince = OffsetDateTime.now(ZoneOffset.UTC);
+        backupRestoreRunningSince = TimeUtils.offsetDateTimeNow(ZoneOffset.UTC);
     }
 
     @EventListener

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGenerator.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/SecurityServerConfigurationBackupGenerator.java
@@ -27,6 +27,7 @@
 package org.niis.xroad.securityserver.restapi.service;
 
 import ee.ria.xroad.common.identifier.SecurityServerId;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.common.util.process.ExternalProcessRunner;
 
 import org.niis.xroad.restapi.common.backup.repository.BackupRepository;
@@ -36,7 +37,6 @@ import org.niis.xroad.restapi.config.audit.AuditDataHelper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Component
@@ -69,6 +69,6 @@ public class SecurityServerConfigurationBackupGenerator extends BaseConfiguratio
     @Override
     protected String generateBackupFileName() {
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern(BACKUP_FILENAME_DATE_TIME_FORMAT);
-        return "conf_backup_" + LocalDateTime.now().format(dtf) + ".gpg";
+        return "conf_backup_" + TimeUtils.localDateTimeNow().format(dtf) + ".gpg";
     }
 }

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/controller/NotificationsAlertsApiControllerTest.java
@@ -25,6 +25,8 @@
  */
 package org.niis.xroad.securityserver.restapi.controller;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.Test;
 import org.niis.xroad.securityserver.restapi.domain.AlertData;
 import org.niis.xroad.securityserver.restapi.dto.AlertStatus;
@@ -72,7 +74,7 @@ public class NotificationsAlertsApiControllerTest extends AbstractApiControllerT
     @Test
     @WithMockUser
     public void checkAlertsBackupRestoreRunning() {
-        OffsetDateTime date = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime date = TimeUtils.offsetDateTimeNow(ZoneOffset.UTC);
         AlertStatus alertStatus = new AlertStatus();
         alertStatus.setBackupRestoreRunningSince(date);
         alertStatus.setCurrentTime(date);

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/AlertDataConverterTest.java
@@ -25,6 +25,8 @@
  */
 package org.niis.xroad.securityserver.restapi.converter;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.niis.xroad.securityserver.restapi.domain.AlertData;
@@ -48,7 +50,7 @@ public class AlertDataConverterTest {
 
     @Test
     public void convertAlertData() {
-        OffsetDateTime date = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime date = TimeUtils.offsetDateTimeNow(ZoneOffset.UTC);
         AlertStatus alertStatus = new AlertStatus();
         alertStatus.setBackupRestoreRunningSince(date);
         alertStatus.setCurrentTime(date);

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/BackupConverterTest.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,12 +25,13 @@
  */
 package org.niis.xroad.securityserver.restapi.converter;
 
+import ee.ria.xroad.common.util.TimeUtils;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.niis.xroad.restapi.common.backup.dto.BackupFile;
 import org.niis.xroad.securityserver.restapi.openapi.model.Backup;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ public class BackupConverterTest {
 
     private static final String BACKUP_FILE_3 = "ss-automatic-backup-2019_12_31_031502.tar";
 
-    private static final OffsetDateTime DEFAULT_CREATED_TIME = Instant.now().atOffset(ZoneOffset.UTC);
+    private static final OffsetDateTime DEFAULT_CREATED_TIME = TimeUtils.now().atOffset(ZoneOffset.UTC);
 
     @Before
 

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/TimestampingServiceDiagnosticConverterTest.java
@@ -27,6 +27,7 @@ package org.niis.xroad.securityserver.restapi.converter;
 
 import ee.ria.xroad.common.DiagnosticsErrorCodes;
 import ee.ria.xroad.common.DiagnosticsStatus;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class TimestampingServiceDiagnosticConverterTest {
 
     @Test
     public void convertSingleTimestampingServiceDiagnostics() {
-        final OffsetDateTime now = OffsetDateTime.now();
+        final OffsetDateTime now = TimeUtils.offsetDateTimeNow();
         DiagnosticsStatus diagnosticsStatus = new DiagnosticsStatus(DiagnosticsErrorCodes.RETURN_SUCCESS, now);
         diagnosticsStatus.setDescription(URL_1);
         TimestampingServiceDiagnostics timestampingServiceDiagnostics = timestampingServiceDiagnosticConverter.convert(
@@ -71,7 +72,7 @@ public class TimestampingServiceDiagnosticConverterTest {
 
     @Test
     public void convertMultipleTimestampingServiceDiagnostics() {
-        final OffsetDateTime prevUpdate = OffsetDateTime.now();
+        final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow();
         final OffsetDateTime prevUpdate2 = prevUpdate.plusSeconds(60);
         DiagnosticsStatus diagnosticsStatus1 =
                 new DiagnosticsStatus(DiagnosticsErrorCodes.ERROR_CODE_INTERNAL, prevUpdate);

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/BackupsApiControllerTest.java
@@ -4,17 +4,17 @@
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
  * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,6 +25,7 @@
  */
 package org.niis.xroad.securityserver.restapi.openapi;
 
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.common.util.process.ProcessFailedException;
 
 import org.junit.Assert;
@@ -51,7 +52,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -207,7 +207,7 @@ public class BackupsApiControllerTest extends AbstractApiControllerTestContext {
     @Test
     @WithMockUser(authorities = {"BACKUP_CONFIGURATION"})
     public void addBackup() throws Exception {
-        BackupFile backupFile = new BackupFile(BACKUP_FILE_1_NAME, Instant.now().atOffset(ZoneOffset.UTC));
+        BackupFile backupFile = new BackupFile(BACKUP_FILE_1_NAME, TimeUtils.now().atOffset(ZoneOffset.UTC));
         when(backupGenerator.generateBackup()).thenReturn(backupFile);
 
         ResponseEntity<Backup> response = backupsApiController.addBackup();
@@ -231,7 +231,7 @@ public class BackupsApiControllerTest extends AbstractApiControllerTestContext {
     @Test
     @WithMockUser(authorities = {"BACKUP_CONFIGURATION"})
     public void uploadBackup() throws Exception {
-        BackupFile backupFile = new BackupFile(BACKUP_FILE_1_NAME, Instant.now().atOffset(ZoneOffset.UTC));
+        BackupFile backupFile = new BackupFile(BACKUP_FILE_1_NAME, TimeUtils.now().atOffset(ZoneOffset.UTC));
 
         when(backupService.uploadBackup(any(Boolean.class), any(String.class), any())).thenReturn(backupFile);
 

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/DiagnosticsApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/DiagnosticsApiControllerTest.java
@@ -28,6 +28,7 @@ package org.niis.xroad.securityserver.restapi.openapi;
 import ee.ria.xroad.common.DiagnosticsErrorCodes;
 import ee.ria.xroad.common.PortNumbers;
 import ee.ria.xroad.common.SystemProperties;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -69,7 +70,7 @@ import static org.junit.Assert.assertTrue;
 @AutoConfigureWireMock(port = PortNumbers.ADMIN_PORT)
 public class DiagnosticsApiControllerTest extends AbstractApiControllerTestContext {
 
-    private static final OffsetDateTime PREVIOUS_UPDATE = OffsetDateTime.now().with(LocalTime.of(10, 42));
+    private static final OffsetDateTime PREVIOUS_UPDATE = TimeUtils.offsetDateTimeNow().with(LocalTime.of(10, 42));
     private static final OffsetDateTime NEXT_UPDATE = PREVIOUS_UPDATE.plusHours(1);
     private static final OffsetDateTime PREVIOUS_UPDATE_MIDNIGHT = PREVIOUS_UPDATE.with(LocalTime.of(0, 0));
     private static final OffsetDateTime NEXT_UPDATE_MIDNIGHT = PREVIOUS_UPDATE_MIDNIGHT.plusHours(1);
@@ -148,7 +149,7 @@ public class DiagnosticsApiControllerTest extends AbstractApiControllerTestConte
 
     @Test
     public void getGlobalConfDiagnosticsSuccess() {
-        final OffsetDateTime prevUpdate = OffsetDateTime.now();
+        final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow();
         final OffsetDateTime nextUpdate = prevUpdate.plusHours(1);
         stubForDiagnosticsRequest("/status",
                 "{\"returnCode\":" + DiagnosticsErrorCodes.RETURN_SUCCESS + ",\"prevUpdate\":\"" + prevUpdate
@@ -166,7 +167,7 @@ public class DiagnosticsApiControllerTest extends AbstractApiControllerTestConte
 
     @Test
     public void getGlobalConfDiagnosticsWaiting() {
-        final OffsetDateTime prevUpdate = OffsetDateTime.now();
+        final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow();
         final OffsetDateTime nextUpdate = prevUpdate.plusHours(1);
         stubForDiagnosticsRequest("/status", "{\"returnCode\":" + DiagnosticsErrorCodes.ERROR_CODE_UNINITIALIZED + ","
                 + "\"prevUpdate\":\"" + prevUpdate + "\",\"nextUpdate\":\"" + nextUpdate + "\"}");
@@ -183,7 +184,7 @@ public class DiagnosticsApiControllerTest extends AbstractApiControllerTestConte
 
     @Test
     public void getGlobalConfDiagnosticsFailNextUpdateTomorrow() {
-        final OffsetDateTime prevUpdate = OffsetDateTime.now();
+        final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow();
         final OffsetDateTime nextUpdate = prevUpdate.plusDays(1);
         stubForDiagnosticsRequest("/status",
                 "{\"returnCode\":" + DiagnosticsErrorCodes.ERROR_CODE_INTERNAL + ",\"prevUpdate\":\"" + prevUpdate
@@ -201,7 +202,7 @@ public class DiagnosticsApiControllerTest extends AbstractApiControllerTestConte
 
     @Test
     public void getGlobalConfDiagnosticsFailPreviousUpdateYesterday() {
-        final OffsetDateTime prevUpdate = OffsetDateTime.now().with(LocalTime.of(0, 0));
+        final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow().with(LocalTime.of(0, 0));
         final OffsetDateTime nextUpdate = prevUpdate.plusDays(1);
         stubForDiagnosticsRequest("/status",
                 "{\"returnCode\":" + ERROR_CODE_UNKNOWN + ",\"prevUpdate\":\"" + prevUpdate + "\",\"nextUpdate\":\""

--- a/src/signer-protocol/src/intTest/java/ee/ria/xroad/signer/glue/SignerStepDefs.java
+++ b/src/signer-protocol/src/intTest/java/ee/ria/xroad/signer/glue/SignerStepDefs.java
@@ -29,6 +29,7 @@ package ee.ria.xroad.signer.glue;
 
 import ee.ria.xroad.common.identifier.ClientId;
 import ee.ria.xroad.common.util.CryptoUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.SignerProxy;
 import ee.ria.xroad.signer.protocol.SignerClient;
 import ee.ria.xroad.signer.protocol.dto.CertificateInfo;
@@ -71,7 +72,6 @@ import static ee.ria.xroad.common.util.CryptoUtils.SHA256WITHRSA_ID;
 import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
 import static ee.ria.xroad.common.util.CryptoUtils.calculateDigest;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,7 +211,7 @@ public class SignerStepDefs {
         final KeyInfo keyInToken = findKeyInToken(tokenId, keyName);
 
         final byte[] certBytes = SignerProxy.generateSelfSignedCert(keyInToken.getId(), getClientId(client), KeyUsageInfo.SIGNING,
-                "CN=" + client, Date.from(now().minus(5, DAYS)), Date.from(now().plus(5, DAYS)));
+                "CN=" + client, Date.from(TimeUtils.now().minus(5, DAYS)), Date.from(TimeUtils.now().plus(5, DAYS)));
         this.certHash = CryptoUtils.calculateCertHexHash(certBytes);
     }
 

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
@@ -37,6 +37,7 @@ import ee.ria.xroad.common.conf.globalconfextension.OcspFetchInterval;
 import ee.ria.xroad.common.ocsp.OcspVerifier;
 import ee.ria.xroad.common.ocsp.OcspVerifierOptions;
 import ee.ria.xroad.common.util.CertUtils;
+import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.signer.OcspClientJob;
 import ee.ria.xroad.signer.certmanager.OcspResponseManager.IsCachedOcspResponse;
 import ee.ria.xroad.signer.protocol.dto.CertificateInfo;
@@ -306,7 +307,7 @@ public class OcspClientWorker extends AbstractSignerActor {
         final OcspVerifier verifier = new OcspVerifier(GlobalConf.getOcspFreshnessSeconds(), verifierOptions);
 
         for (String responderURI : responderURIs) {
-            final OffsetDateTime prevUpdate = OffsetDateTime.now();
+            final OffsetDateTime prevUpdate = TimeUtils.offsetDateTimeNow();
             final OffsetDateTime nextUpdate = prevUpdate
                     .plusSeconds(GlobalConfExtensions.getInstance().getOcspFetchInterval());
             int errorCode = DiagnosticsErrorCodes.ERROR_CODE_OCSP_RESPONSE_INVALID;
@@ -481,7 +482,7 @@ public class OcspClientWorker extends AbstractSignerActor {
 
                 addresses.forEach(responderURI -> responderStatusMap.computeIfAbsent(responderURI,
                         uri -> new OcspResponderStatus(DiagnosticsErrorCodes.ERROR_CODE_OCSP_UNINITIALIZED, uri, null,
-                                OffsetDateTime.now().plusSeconds(fetchInterval))));
+                                TimeUtils.offsetDateTimeNow().plusSeconds(fetchInterval))));
             } catch (Exception e) {
                 log.error("Error while initializing diagnostics", e);
             }

--- a/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCacheTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/FileBasedOcspCacheTest.java
@@ -29,6 +29,7 @@ import ee.ria.xroad.common.OcspTestUtils;
 import ee.ria.xroad.common.TestCertUtil;
 import ee.ria.xroad.common.conf.globalconf.EmptyGlobalConf;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import org.bouncycastle.cert.ocsp.CertificateStatus;
 import org.bouncycastle.cert.ocsp.OCSPResp;
@@ -39,7 +40,6 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
@@ -64,7 +64,7 @@ public class FileBasedOcspCacheTest {
      */
     @Test
     public void putGet() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 
@@ -88,7 +88,7 @@ public class FileBasedOcspCacheTest {
      */
     @Test
     public void expiredResponse() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().minus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 
@@ -111,7 +111,7 @@ public class FileBasedOcspCacheTest {
      */
     @Test
     public void saveLoadOcspResponseToFile() throws Exception {
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
         OCSPResp ocsp = OcspTestUtils.createOCSPResponse(subject, issuer,
                 signer, signerKey, CertificateStatus.GOOD, thisUpdate, null);
 

--- a/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/OcspClientTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/certmanager/OcspClientTest.java
@@ -31,6 +31,7 @@ import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.conf.globalconf.GlobalConfProvider;
 import ee.ria.xroad.common.ocsp.OcspVerifier;
 import ee.ria.xroad.common.ocsp.OcspVerifierOptions;
+import ee.ria.xroad.common.util.TimeUtils;
 
 import akka.actor.ActorSystem;
 import akka.actor.Props;
@@ -61,7 +62,6 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,7 +109,7 @@ public class OcspClientTest {
 
         GlobalConf.reload(getTestGlobalConf());
 
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
 
         responseData = OcspTestUtils.createOCSPResponse(subject, GlobalConf.getCaCert("EE", subject), ocspResponderCert,
                 getOcspSignerKey(), CertificateStatus.GOOD, thisUpdate, null).getEncoded();
@@ -137,7 +137,7 @@ public class OcspClientTest {
                 Arrays.asList("http://127.0.0.1:1234", RESPONDER_URI));
         GlobalConf.reload(conf);
 
-        Date thisUpdate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        Date thisUpdate = Date.from(TimeUtils.now().plus(1, ChronoUnit.DAYS));
 
         responseData = OcspTestUtils.createOCSPResponse(subject, GlobalConf.getCaCert("EE", subject), ocspResponderCert,
                 getOcspSignerKey(), CertificateStatus.GOOD, thisUpdate, null).getEncoded();


### PR DESCRIPTION
Preparing for update to Java 17. 
Truncating all timestamps to microseconds, because some OS/JDKs might use nanoseconds precision.

Refs: XRDDEV-2490