### PR TITLE
fix: Avoid throwing exception when target shared parameters non existent during global group check

### DIFF
--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
@@ -548,7 +548,11 @@ public class GlobalConfImpl implements GlobalConfProvider {
     }
 
     SharedParameters.GlobalGroup findGlobalGroup(GlobalGroupId groupId) {
-        return getSharedParameters(groupId.getXRoadInstance()).getGlobalGroups().stream()
+        SharedParameters sharedParameters = confDir.getShared(groupId.getXRoadInstance());
+        if (sharedParameters == null) {
+            return null;
+        }
+        return sharedParameters.getGlobalGroups().stream()
                 .filter(g -> g.getGroupCode().equals(groupId.getGroupCode()))
                 .findFirst().orElse(null);
     }

--- a/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
+++ b/src/common/common-verifier/src/main/java/ee/ria/xroad/common/conf/globalconf/GlobalConfImpl.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -538,23 +539,16 @@ public class GlobalConfImpl implements GlobalConfProvider {
 
     @Override
     public boolean isSubjectInGlobalGroup(ClientId subjectId, GlobalGroupId groupId) {
-
-        SharedParameters.GlobalGroup group = findGlobalGroup(groupId);
-        if (group == null) {
-            return false;
-        }
-
-        return group.getGroupMembers().stream().anyMatch(m -> m.equals(subjectId));
+        return findGlobalGroup(groupId)
+                .filter(group -> group.getGroupMembers().stream().anyMatch(m -> m.equals(subjectId)))
+                .isPresent();
     }
 
-    SharedParameters.GlobalGroup findGlobalGroup(GlobalGroupId groupId) {
-        SharedParameters sharedParameters = confDir.getShared(groupId.getXRoadInstance());
-        if (sharedParameters == null) {
-            return null;
-        }
-        return sharedParameters.getGlobalGroups().stream()
-                .filter(g -> g.getGroupCode().equals(groupId.getGroupCode()))
-                .findFirst().orElse(null);
+    Optional<SharedParameters.GlobalGroup> findGlobalGroup(GlobalGroupId groupId) {
+        Optional<SharedParameters> sharedParameters = Optional.ofNullable(confDir.getShared(groupId.getXRoadInstance()));
+        return sharedParameters.flatMap(params -> params.getGlobalGroups().stream()
+                        .filter(g -> g.getGroupCode().equals(groupId.getGroupCode()))
+                        .findFirst());
     }
 
     @Override

--- a/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconf/GlobalConfTest.java
+++ b/src/common/common-verifier/src/test/java/ee/ria/xroad/common/conf/globalconf/GlobalConfTest.java
@@ -133,6 +133,21 @@ public class GlobalConfTest {
     }
 
     /**
+     * Tests checking if subject is in global group.
+     */
+    @Test
+    public void isSubjectInGlobalGroup() {
+        assertTrue(GlobalConf.isSubjectInGlobalGroup(
+                ClientId.Conf.create("EE", "BUSINESS", "member2"),
+                GlobalGroupId.Conf.create("EE", "Test group"))
+        );
+        assertFalse(GlobalConf.isSubjectInGlobalGroup(
+                ClientId.Conf.create("EE", "BUSINESS", "member2"),
+                GlobalGroupId.Conf.create("non-existent-instance", "non-existent-group"))
+        );
+    }
+
+    /**
      * Tests getting the global group description.
      */
     @Test


### PR DESCRIPTION
Refs: XRDDEV-1689