### PR TITLE
fix: nginx forward management requests without trailing slash in URL

### DIFF
--- a/src/packages/src/xroad/common/center-management-service/etc/xroad/nginx/management-service.conf
+++ b/src/packages/src/xroad/common/center-management-service/etc/xroad/nginx/management-service.conf
@@ -22,7 +22,7 @@ server {
          limit_except POST {
              deny all;
          }
-         proxy_pass http://127.0.0.1:8085;
+         proxy_pass http://127.0.0.1:8085/managementservice/manage;
          proxy_set_header Host $http_host;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_redirect http:// https://;

--- a/src/packages/src/xroad/common/center-registration-service/etc/xroad/nginx/registration-service.conf
+++ b/src/packages/src/xroad/common/center-registration-service/etc/xroad/nginx/registration-service.conf
@@ -22,7 +22,7 @@ server {
          limit_except POST {
              deny all;
          }
-         proxy_pass http://127.0.0.1:8084;
+         proxy_pass http://127.0.0.1:8084/managementservice;
          proxy_set_header Host $http_host;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_redirect http:// https://;
@@ -32,7 +32,7 @@ server {
          limit_except POST {
              deny all;
          }
-         proxy_pass http://127.0.0.1:8084;
+         proxy_pass http://127.0.0.1:8084/managementservice;
          proxy_set_header Host $http_host;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_redirect http:// https://;


### PR DESCRIPTION
Spring Boot 3 (Spring 6) changed the way trailing slashes are treated in in URL-s. Before, URL with trailing slash was treated as equal to one without it.

Refs: XRDDEV-2491