### PR TITLE
fix: restore OCSP responses to work with sha1 cert hashes for backwards compatibility

### DIFF
--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/VersionedConfigurationDirectory.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/conf/globalconf/VersionedConfigurationDirectory.java
@@ -332,8 +332,8 @@ public class VersionedConfigurationDirectory implements ConfigurationDirectory {
     }
 
     public static boolean isCurrentVersion(Path filePath) {
-            Integer confVersion = getVersion(filePath);
-            return confVersion != null && confVersion == CURRENT_GLOBAL_CONFIGURATION_VERSION;
+        Integer confVersion = getVersion(filePath);
+        return confVersion != null && confVersion == CURRENT_GLOBAL_CONFIGURATION_VERSION;
     }
 
     public static Integer getVersion(Path filePath) {

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertHashBasedOcspResponderClient.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertHashBasedOcspResponderClient.java
@@ -29,7 +29,7 @@ import ee.ria.xroad.common.SystemProperties;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.parser.AbstractContentHandler;
 import org.apache.james.mime4j.parser.MimeStreamParser;
@@ -37,12 +37,15 @@ import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +57,8 @@ import java.util.List;
 public final class CertHashBasedOcspResponderClient {
 
     private static final String METHOD = "GET";
-    private static final String CERT_PARAM = "cert";
+    private static final String SHA_1_CERT_PARAM = "cert";
+    private static final String SHA_256_CERT_PARAM = "cert_hash";
 
     private static final List<Integer> VALID_RESPONSE_CODES = Arrays.asList(
             200, 201, 202, 203, 204, 205, 206, 207, 208, 226);
@@ -66,17 +70,13 @@ public final class CertHashBasedOcspResponderClient {
      * Creates an GET request to the internal cert hash based OCSP responder and expects an OCSP responses.
      *
      * @param providerAddress URL of the OCSP response provider
-     * @param hashes          certificate hashes for which to get the responses
+     * @param certificates    certificates for which to get the responses
      * @return list of OCSP response objects
-     * @throws IOException   if I/O errors occurred
-     * @throws OCSPException if the response could not be parsed
+     * @throws Exception   if I/O errors occurred
      */
-    public static List<OCSPResp> getOcspResponsesFromServer(String providerAddress, String[] hashes)
-            throws IOException, OCSPException {
-        URL url = createUrl(providerAddress, hashes);
-
-        log.debug("Getting OCSP responses for hashes ({}) from: {}", Arrays.toString(hashes), url.getHost());
-
+    public static List<OCSPResp> getOcspResponsesFromServer(String providerAddress, List<X509Certificate> certificates)
+            throws CertificateEncodingException, URISyntaxException, IOException, OperatorCreationException, OCSPException {
+        URL url = createUrl(providerAddress, certificates);
         return getOcspResponsesFromServer(url);
     }
 
@@ -132,8 +132,19 @@ public final class CertHashBasedOcspResponderClient {
         return responses;
     }
 
-    private static URL createUrl(String providerAddress, String[] hashes) throws MalformedURLException {
-        return new URL("http", providerAddress, SystemProperties.getOcspResponderPort(), "/?" + CERT_PARAM + "="
-                + StringUtils.join(hashes, "&" + CERT_PARAM + "="));
+    private static URL createUrl(String providerAddress, List<X509Certificate> certificates)
+            throws URISyntaxException, IOException, CertificateEncodingException, OperatorCreationException {
+        String[] sha1Hashes = CertUtils.getSha1Hashes(certificates);
+        String[] sha256Hashes = CertUtils.getHashes(certificates);
+
+        var uriBuilder = new URIBuilder().setScheme("http").setHost(providerAddress).setPort(SystemProperties.getOcspResponderPort());
+        // TODO sha1 hashes should not be added to the request once 7.3.x is no longer supported
+        Arrays.stream(sha1Hashes).forEach(hash -> uriBuilder.addParameter(SHA_1_CERT_PARAM, hash));
+        Arrays.stream(sha256Hashes).forEach(hash -> uriBuilder.addParameter(SHA_256_CERT_PARAM, hash));
+        var uri = uriBuilder.build();
+
+        log.debug("Getting OCSP responses for hashes ({}) from: {}", Arrays.toString(sha1Hashes), uri.getHost());
+
+        return uri.toURL();
     }
 }

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CertUtils.java
@@ -74,6 +74,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateFactory;
@@ -90,6 +91,7 @@ import java.util.List;
 
 import static ee.ria.xroad.common.ErrorCodes.X_INTERNAL_ERROR;
 import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 import static ee.ria.xroad.common.util.CryptoUtils.toDERObject;
 
 /**
@@ -329,11 +331,35 @@ public final class CertUtils {
     }
 
     /**
+     * @deprecated This method should be applicable until 7.3.x is no longer supported
+     * <p> From that point onward its usages should be replaced with {@link #getHashes(List)} instead.
      * @param certs list of certificates
-     * @return list of certificate hashes for given list of certificates.
-     * @throws Exception in case of any errors
+     * @return list of certificate SHA-1 hashes for given list of certificates.
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
-    public static String[] getCertHashes(List<X509Certificate> certs) throws Exception {
+    @Deprecated
+    public static String[] getSha1Hashes(List<X509Certificate> certs)
+            throws CertificateEncodingException, IOException, OperatorCreationException {
+        String[] certHashes = new String[certs.size()];
+
+        for (int i = 0; i < certs.size(); i++) {
+            certHashes[i] = calculateCertSha1HexHash(certs.get(i));
+        }
+
+        return certHashes;
+    }
+
+    /**
+     * @param certs list of certificates
+     * @return list of certificate SHA-256 hashes for given list of certificates.
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
+     */
+    public static String[] getHashes(List<X509Certificate> certs)
+            throws CertificateEncodingException, IOException, OperatorCreationException {
         String[] certHashes = new String[certs.size()];
 
         for (int i = 0; i < certs.size(); i++) {

--- a/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CryptoUtils.java
+++ b/src/common/common-util/src/main/java/ee/ria/xroad/common/util/CryptoUtils.java
@@ -597,10 +597,12 @@ public final class CryptoUtils {
      * Calculates digest of the certificate and encodes it as lowercase hex.
      * @param cert the certificate
      * @return calculated certificate hex hash String
-     * @throws Exception if any errors occur
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
     public static String calculateCertHexHash(X509Certificate cert)
-            throws Exception {
+            throws CertificateEncodingException, IOException, OperatorCreationException {
         return calculateCertHexHash(cert.getEncoded());
     }
 
@@ -609,9 +611,12 @@ public final class CryptoUtils {
      * @param cert the certificate
      * @param delimiter the delimiter to use
      * @return calculated certificate hex hash String
-     * @throws Exception if any errors occur
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
-    public static String calculateDelimitedCertHexHash(X509Certificate cert, String delimiter) throws Exception {
+    public static String calculateDelimitedCertHexHash(X509Certificate cert, String delimiter)
+            throws CertificateEncodingException, IOException, OperatorCreationException {
         return String.join(delimiter, Splitter.fixedLength(2).split(calculateCertHexHash(cert).toUpperCase()));
     }
 
@@ -620,11 +625,43 @@ public final class CryptoUtils {
      * as lowercase hex.
      * @return calculated certificate hex hash String
      * @param bytes the bytes
-     * @throws Exception if any errors occur
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
-    public static String calculateCertHexHash(byte[] bytes)
-            throws Exception {
+    public static String calculateCertHexHash(byte[] bytes) throws IOException, OperatorCreationException {
         return hexDigest(DEFAULT_CERT_HASH_ALGORITHM_ID, bytes);
+    }
+
+    /**
+     * Calculates a sha-1 digest of the given bytes and encodes it
+     * as lowercase hex.
+     * @deprecated This method should be applicable until 7.3.x is no longer supported
+     * <p> From that point onward its usages should be replaced with {@link #calculateCertHexHash(X509Certificate)} instead.
+     * @return calculated certificate hex hash String
+     * @param cert the certificate
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws IOException if an I/O error occurred
+     */
+    @Deprecated
+    public static String calculateCertSha1HexHash(X509Certificate cert)
+            throws IOException, OperatorCreationException, CertificateEncodingException {
+        return calculateCertSha1HexHash(cert.getEncoded());
+    }
+
+    /**
+     * Calculates a sha-1 digest of the given bytes and encodes it
+     * as lowercase hex.
+     * @deprecated This method should be applicable until 7.3.x is no longer supported
+     * <p> From that point onward its usages should be replaced with {@link #calculateCertHexHash(byte[])} instead.
+     * @return calculated certificate hex hash String
+     * @param bytes the bytes
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
+     */
+    @Deprecated
+    public static String calculateCertSha1HexHash(byte[] bytes) throws IOException, OperatorCreationException {
+        return hexDigest(SHA1_ID, bytes);
     }
 
     /**
@@ -663,7 +700,9 @@ public final class CryptoUtils {
      * Calculates a digest of the given certificate.
      * @param cert the certificate
      * @return digest byte array of the certificate
-     * @throws Exception if any errors occur
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
     public static byte[] certHash(X509Certificate cert) throws CertificateEncodingException, IOException, OperatorCreationException {
         return certHash(cert.getEncoded());
@@ -683,10 +722,13 @@ public final class CryptoUtils {
     /**
      * Calculates sha-1 digest of the given certificate bytes.
      * @param bytes the bytes
+     * @deprecated This method should be applicable until 7.3.x is no longer supported
+     * <p> From that point onward its usages should be replaced with {@link #certHash(byte[])} instead.
      * @return digest byte array of the certificate
      * @throws OperatorCreationException if digest calculator cannot be created
      * @throws IOException if an I/O error occurred
      */
+    @Deprecated
     public static byte[] certSha1Hash(byte[] bytes) throws IOException, OperatorCreationException {
         return calculateDigest(SHA1_ID, bytes);
     }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConfImpl.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/conf/KeyConfImpl.java
@@ -47,8 +47,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static ee.ria.xroad.common.ErrorCodes.X_CANNOT_CREATE_SIGNATURE;
-import static ee.ria.xroad.common.util.CertUtils.getCertHashes;
-import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CertUtils.getSha1Hashes;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 import static ee.ria.xroad.common.util.CryptoUtils.decodeBase64;
 import static ee.ria.xroad.common.util.CryptoUtils.encodeBase64;
 import static ee.ria.xroad.common.util.CryptoUtils.loadPkcs12KeyStore;
@@ -108,7 +108,7 @@ class KeyConfImpl implements KeyConfProvider {
 
     @Override
     public OCSPResp getOcspResponse(X509Certificate cert) throws Exception {
-        return getOcspResponse(calculateCertHexHash(cert));
+        return getOcspResponse(calculateCertSha1HexHash(cert));
     }
 
     @Override
@@ -126,7 +126,7 @@ class KeyConfImpl implements KeyConfProvider {
     @Override
     public List<OCSPResp> getOcspResponses(List<X509Certificate> certs)
             throws Exception {
-        String[] responses = SignerProxy.getOcspResponses(getCertHashes(certs));
+        String[] responses = SignerProxy.getOcspResponses(getSha1Hashes(certs));
 
         List<OCSPResp> ocspResponses = new ArrayList<>();
         for (String base64Encoded : responses) {
@@ -150,7 +150,7 @@ class KeyConfImpl implements KeyConfProvider {
                     encodeBase64(responses.get(i).getEncoded());
         }
 
-        SignerProxy.setOcspResponses(getCertHashes(certs), base64EncodedResponses);
+        SignerProxy.setOcspResponses(getSha1Hashes(certs), base64EncodedResponses);
     }
 
     static SigningCtx createSigningCtx(ClientId subject, String keyId,

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
@@ -148,7 +148,7 @@ public class CertHashBasedOcspResponder implements StartStop {
     }
 
     private void doHandleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
-        String[] hashes = getCertHashes(request);
+        String[] hashes = getCertSha1Hashes(request);
         List<OCSPResp> ocspResponses = getOcspResponses(hashes);
 
         log.debug("Returning OCSP responses for cert hashes: " + Arrays.toString(hashes));
@@ -196,10 +196,10 @@ public class CertHashBasedOcspResponder implements StartStop {
         }
     }
 
-    private static List<OCSPResp> getOcspResponses(String[] hashes) throws Exception {
-        List<OCSPResp> ocspResponses = new ArrayList<>(hashes.length);
+    private static List<OCSPResp> getOcspResponses(String[] certHashes) throws Exception {
+        List<OCSPResp> ocspResponses = new ArrayList<>(certHashes.length);
 
-        for (String certHash : hashes) {
+        for (String certHash : certHashes) {
             ocspResponses.add(getOcspResponse(certHash));
         }
 
@@ -216,7 +216,8 @@ public class CertHashBasedOcspResponder implements StartStop {
         return ocsp;
     }
 
-    private static String[] getCertHashes(HttpServletRequest request) throws Exception {
+    private static String[] getCertSha1Hashes(HttpServletRequest request) throws Exception {
+        // TODO sha256 cert hashes should be read from "cert_hash" param instead once 7.3.x is no longer supported
         String[] paramValues = request.getParameterValues(CERT_PARAM);
 
         if (paramValues.length < 1) {

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/CertificateAuthorityService.java
@@ -125,7 +125,7 @@ public class CertificateAuthorityService {
 
         String[] base64EncodedOcspResponses;
         try {
-            String[] certHashes = CertUtils.getCertHashes(new ArrayList<>(filteredCerts));
+            String[] certHashes = CertUtils.getSha1Hashes(new ArrayList<>(filteredCerts));
             base64EncodedOcspResponses = signerProxyFacade.getOcspResponses(certHashes);
         } catch (Exception e) {
             throw new InconsistentCaDataException("failed to get read CA OCSP responses", e);

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspClientWorker.java
@@ -65,7 +65,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 import static ee.ria.xroad.common.util.CryptoUtils.encodeBase64;
 import static ee.ria.xroad.common.util.CryptoUtils.readCertificate;
 import static java.util.Collections.emptyList;
@@ -175,7 +175,7 @@ public class OcspClientWorker {
                 OCSPResp status = queryCertStatus(subject, new OcspVerifierOptions(
                         GlobalConfExtensions.getInstance().shouldVerifyOcspNextUpdate()));
                 if (status != null) {
-                    String subjectHash = calculateCertHexHash(subject);
+                    String subjectHash = calculateCertSha1HexHash(subject);
                     statuses.put(subjectHash, status);
                 } else {
                     failed = true;
@@ -346,7 +346,7 @@ public class OcspClientWorker {
                 return false;
             }
 
-            String subjectHash = calculateCertHexHash(subject);
+            String subjectHash = calculateCertSha1HexHash(subject);
             try {
                 // todo this should be separated from isValid check.
                 //  This seems to be the only place where expired Ocsp response is cleared from TokenManager.

--- a/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspResponseManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/certmanager/OcspResponseManager.java
@@ -37,7 +37,7 @@ import org.niis.xroad.signer.proto.SetOcspResponsesReq;
 import java.security.cert.X509Certificate;
 import java.util.Map.Entry;
 
-import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 import static ee.ria.xroad.common.util.CryptoUtils.decodeBase64;
 import static ee.ria.xroad.common.util.CryptoUtils.encodeBase64;
 
@@ -72,7 +72,7 @@ public class OcspResponseManager {
      * @throws Exception if an error occurs
      */
     public byte[] getOcspResponse(X509Certificate cert) throws Exception {
-        return getOcspResponse(calculateCertHexHash(cert));
+        return getOcspResponse(calculateCertSha1HexHash(cert));
     }
 
     /**

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
@@ -41,6 +41,7 @@ import java.security.cert.X509Certificate;
 
 import static ee.ria.xroad.common.ErrorCodes.translateException;
 import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 import static ee.ria.xroad.common.util.CryptoUtils.readCertificate;
 
 /**
@@ -76,10 +77,18 @@ public class Cert {
     private String status;
 
     /**
-     * Holds the precalculated hash of the certificate.
+     * Holds the precalculated sha1 hash of the certificate.
+     * @deprecated Use {@link #forNumber(int)} instead.
+     */
+    @Deprecated
+    @Setter(AccessLevel.PRIVATE)
+    private String sha1hash;
+
+    /**
+     * Holds the precalculated sha256 hash of the certificate.
      */
     @Setter(AccessLevel.PRIVATE)
-    private String hash;
+    private String sha256hash;
 
     /**
      * Holds the certificate instance.
@@ -98,7 +107,8 @@ public class Cert {
      */
     public void setCertificate(X509Certificate cert) {
         try {
-            hash = calculateCertHexHash(cert);
+            sha1hash = calculateCertSha1HexHash(cert);
+            sha256hash = calculateCertHexHash(cert);
             certificate = cert;
         } catch (Exception e) {
             throw translateException(e);

--- a/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/model/Cert.java
@@ -78,7 +78,7 @@ public class Cert {
 
     /**
      * Holds the precalculated sha1 hash of the certificate.
-     * @deprecated Use {@link #forNumber(int)} instead.
+     * @deprecated Use {@link #getSha256hash()} instead.
      */
     @Deprecated
     @Setter(AccessLevel.PRIVATE)

--- a/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ImportCertReqHandler.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/protocol/handler/ImportCertReqHandler.java
@@ -135,10 +135,9 @@ public class ImportCertReqHandler extends AbstractRpcHandler<ImportCertReq, Impo
 
     private void importCertificateToKey(KeyInfo keyInfo, X509Certificate cert,
                                         String initialStatus, ClientId.Conf memberId) throws Exception {
-        String certHash = calculateCertHexHash(cert.getEncoded());
+        String certHash = calculateCertHexHash(cert);
 
-        CertificateInfo existingCert =
-                TokenManager.getCertificateInfoForCertHash(certHash);
+        CertificateInfo existingCert = TokenManager.getCertificateInfoForCertHash(certHash);
         if (existingCert != null && existingCert.isSavedToConfiguration()) {
             throw CodedException.tr(X_CERT_EXISTS,
                     "cert_exists_under_key",

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/TokenManager.java
@@ -243,14 +243,13 @@ public final class TokenManager {
     }
 
     /**
-     * @param certHash the certificate hash
+     * @param certHash the certificate hash in HEX
      * @return the tokenInfo and key id, or throws exception if not found
      */
     public static synchronized TokenInfoAndKeyId findTokenAndKeyIdForCertHash(String certHash) {
         log.trace("findTokenAndKeyIdForCertHash({})", certHash);
 
-        String keyId = forCert((k, c) -> certHash.equals(c.getHash()),
-                (k, c) -> k.getId())
+        String keyId = forCert((k, c) -> certHash.equals(c.getSha256hash()), (k, c) -> k.getId())
                 .orElseThrow(() -> certWithHashNotFound(certHash));
 
         return forKey((t, k) -> k.getId().equals(keyId),
@@ -383,36 +382,30 @@ public final class TokenManager {
      * @param certId the certificate id
      * @return the certificate info for the certificate id or null if not found
      */
-    public static synchronized CertificateInfo getCertificateInfo(
-            String certId) {
+    public static synchronized CertificateInfo getCertificateInfo(String certId) {
         log.trace("getCertificateInfo({})", certId);
 
-        return forCert((k, c) -> c.getId().equals(certId), (k, c) -> c.toDTO())
-                .orElse(null);
+        return forCert((k, c) -> c.getId().equals(certId), (k, c) -> c.toDTO()).orElse(null);
     }
 
     /**
-     * @param certHash the certificate hash
+     * @param certHash the certificate hash in HEX
      * @return the certificate info for the certificate hash or null
      */
-    public static synchronized CertificateInfo getCertificateInfoForCertHash(
-            String certHash) {
+    public static synchronized CertificateInfo getCertificateInfoForCertHash(String certHash) {
         log.trace("getCertificateInfoForCertHash({})", certHash);
 
-        return forCert((k, c) -> certHash.equals(c.getHash()),
-                (k, c) -> c.toDTO()).orElse(null);
+        return forCert((k, c) -> certHash.equals(c.getSha256hash()), (k, c) -> c.toDTO()).orElse(null);
     }
 
     /**
-     * @param certHash the certificate hash
+     * @param certSha1Hash the certificate SHA-1 hash in HEX
      * @return the certificate for the certificate hash or null
      */
-    public static synchronized X509Certificate getCertificateForCertHash(
-            String certHash) {
-        log.trace("getCertificateForCertHash({})", certHash);
+    public static synchronized X509Certificate getCertificateForCerHash(String certSha1Hash) {
+        log.trace("getCertificateForCertHash({})", certSha1Hash);
 
-        return forCert((k, c) -> certHash.equals(c.getHash()),
-                (k, c) -> c.getCertificate()).orElse(null);
+        return forCert((k, c) -> certSha1Hash.equals(c.getSha1hash()), (k, c) -> c.getCertificate()).orElse(null);
     }
 
     /**
@@ -424,25 +417,23 @@ public final class TokenManager {
         return currentTokens.stream()
                 .flatMap(t -> t.getKeys().stream())
                 .flatMap(k -> k.getCerts().stream())
-                .map(c -> c.toDTO())
-                .collect(Collectors.toList());
+                .map(Cert::toDTO)
+                .toList();
     }
 
     /**
      * Sets the OCSP response for the certificate.
      *
-     * @param certHash the certificate hash
+     * @param certSha1Hash the certificate SHA-1 hash in HEX
      * @param response the OCSP response
      */
-    public static synchronized void setOcspResponse(String certHash,
-                                                    OCSPResp response) {
-        log.trace("setOcspResponse({})", certHash);
+    public static synchronized void setOcspResponse(String certSha1Hash, OCSPResp response) {
+        log.trace("setOcspResponse({})", certSha1Hash);
 
-        forCert((k, c) -> certHash.equals(c.getHash()),
-                (k, c) -> {
-                    c.setOcspResponse(response);
-                    return null;
-                });
+        forCert((k, c) -> certSha1Hash.equals(c.getSha1hash()), (k, c) -> {
+            c.setOcspResponse(response);
+            return null;
+        });
     }
 
     /**
@@ -450,8 +441,7 @@ public final class TokenManager {
      * @param memberId the member id
      * @return the certificate request info or null if not found
      */
-    public static synchronized CertRequestInfo getCertRequestInfo(String keyId,
-                                                                  ClientId memberId) {
+    public static synchronized CertRequestInfo getCertRequestInfo(String keyId, ClientId memberId) {
         log.trace("getCertRequestInfo({}, {})", keyId, memberId);
 
         Key key = findKey(keyId);
@@ -474,14 +464,13 @@ public final class TokenManager {
     }
 
     /**
-     * @param certHash the certificate hash
+     * @param certHash the certificate hash in HEX
      * @return key info for the certificate hash
      */
     public static synchronized KeyInfo getKeyInfoForCertHash(String certHash) {
         log.trace("getKeyInfoForCertHash({})", certHash);
 
-        return forCert((k, c) -> certHash.equals(c.getHash()),
-                (k, c) -> k.toDTO()).orElse(null);
+        return forCert((k, c) -> certHash.equals(c.getSha256hash()), (k, c) -> k.toDTO()).orElse(null);
     }
 
     /**

--- a/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/tokenmanager/module/AbstractModuleManager.java
@@ -211,7 +211,7 @@ public abstract class AbstractModuleManager implements WorkerWithLifecycle, Toke
 
         return new GetOcspResponses(certs.stream().map(cert -> {
             try {
-                return CryptoUtils.calculateCertHexHash(cert.getCertificate());
+                return CryptoUtils.calculateCertSha1HexHash(cert.getCertificate());
             } catch (Exception e) {
                 log.error("Failed to calculate hash for new certificate {}", cert, e);
 

--- a/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
+++ b/src/signer/src/main/java/ee/ria/xroad/signer/util/SignerUtil.java
@@ -36,10 +36,13 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
@@ -53,7 +56,7 @@ import static ee.ria.xroad.common.util.CryptoUtils.SHA384WITHRSAANDMGF1_ID;
 import static ee.ria.xroad.common.util.CryptoUtils.SHA384WITHRSA_ID;
 import static ee.ria.xroad.common.util.CryptoUtils.SHA512WITHRSAANDMGF1_ID;
 import static ee.ria.xroad.common.util.CryptoUtils.SHA512WITHRSA_ID;
-import static ee.ria.xroad.common.util.CryptoUtils.calculateCertHexHash;
+import static ee.ria.xroad.common.util.CryptoUtils.calculateCertSha1HexHash;
 
 /**
  * Collection of various utility methods.
@@ -198,18 +201,22 @@ public final class SignerUtil {
     }
 
     /**
+     * @param certSha1Hash the certificate SHA-1 hash in HEX
      * @return certificate matching certHash
+     * @throws CertificateEncodingException if a certificate encoding error occurs
+     * @throws OperatorCreationException if digest calculator cannot be created
+     * @throws IOException if an I/O error occurred
      */
-    public static X509Certificate getCertForCertHash(String certHash) throws Exception {
-        X509Certificate cert =
-                TokenManager.getCertificateForCertHash(certHash);
+    public static X509Certificate getCertForCertHash(String certSha1Hash)
+            throws CertificateEncodingException, IOException, OperatorCreationException {
+        X509Certificate cert = TokenManager.getCertificateForCerHash(certSha1Hash);
         if (cert != null) {
             return cert;
         }
 
         // not in key conf, look elsewhere
         for (X509Certificate caCert : GlobalConf.getAllCaCerts()) {
-            if (certHash.equals(calculateCertHexHash(caCert))) {
+            if (certSha1Hash.equals(calculateCertSha1HexHash(caCert))) {
                 return caCert;
             }
         }

--- a/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/TokenManagerMergeTest.java
+++ b/src/signer/src/test/java/ee/ria/xroad/signer/tokenmanager/TokenManagerMergeTest.java
@@ -199,6 +199,7 @@ public class TokenManagerMergeTest {
         assertNotNull("test setup failure", beforeKeyInfo);
 
         final String testCertId = "06700c12f395183c779884fcd49d4ca55fa485aa65617da5b75d84927bec2c91";
+        final String testCertSha1Hash = "e82e0b2b184d4387c2afd83708d4cfeaeb872cf7";
         CertificateInfo beforeCertInfo = TokenManager.getCertificateInfo(testCertId);
         assertNotNull("test setup failure", beforeCertInfo);
 
@@ -208,7 +209,7 @@ public class TokenManagerMergeTest {
         OCSPResp shouldMatchResponse = mock(OCSPResp.class);
         final byte[] shouldMatchOcspResponseBytes = "some example string  11 2 34".getBytes();
         when(shouldMatchResponse.getEncoded()).thenReturn(shouldMatchOcspResponseBytes);
-        TokenManager.setOcspResponse(testCertId, shouldMatchResponse);
+        TokenManager.setOcspResponse(testCertSha1Hash, shouldMatchResponse);
 
         final int beforeCertCount = TokenManager.getAllCerts().size();
 


### PR DESCRIPTION
Refs: XRDDEV-445