### PR TITLE
fix(serverconf): Correct the `hibernate-tools` dependency

### DIFF
--- a/src/central-server/admin-service/ui/package.json
+++ b/src/central-server/admin-service/ui/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@fontsource/open-sans": "^5.0.12",
     "@mdi/font": "^7.2.96",
-    "@niis/shared-ui": "file:../../../shared-ui/niis-shared-ui-3.0.0.tgz",
+    "@niis/shared-ui": "../../../shared-ui",
     "@vee-validate/i18n": "~4.11.6",
     "@vee-validate/rules": "~4.11.6",
     "axios": "~1.4.0",

--- a/src/central-server/admin-service/ui/yarn.lock
+++ b/src/central-server/admin-service/ui/yarn.lock
@@ -829,9 +829,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@niis/shared-ui@file:../../../shared-ui/niis-shared-ui-3.0.0.tgz::locator=xroad-centralserver-admin-ui%40workspace%3A.":
+"@niis/shared-ui@file:../../../shared-ui::locator=xroad-centralserver-admin-ui%40workspace%3A.":
   version: 3.0.0
-  resolution: "@niis/shared-ui@file:../../../shared-ui/niis-shared-ui-3.0.0.tgz#../../../shared-ui/niis-shared-ui-3.0.0.tgz::hash=94638d&locator=xroad-centralserver-admin-ui%40workspace%3A."
+  resolution: "@niis/shared-ui@file:../../../shared-ui#../../../shared-ui::hash=d30b31&locator=xroad-centralserver-admin-ui%40workspace%3A."
   dependencies:
     "@fontsource/open-sans": "npm:^5.0.12"
     "@mdi/font": "npm:^7.2.96"
@@ -840,7 +840,7 @@ __metadata:
     vue: ^3.3.4
     vue-i18n: ^9.4.0
     vuetify: ^3.3.19
-  checksum: efb5cbfa2bd2dd3fc7f385f23090d4d04f8752513ff64e7a1363a8f75b9666ebcae6f8f09cfcb67cfa8a2956b8fc66bfdaf1d7260e2238dcdacdf32399360ca1
+  checksum: 1700d63a338d7d4749d8e9176ca9974b018a7a8b77f190b06b584acff108fc6989a67133655cdee9d5bc85e8004c56681ac38672fd0a396364742c98c6200477
   languageName: node
   linkType: hard
 
@@ -5833,7 +5833,7 @@ __metadata:
     "@fontsource/open-sans": "npm:^5.0.12"
     "@intlify/eslint-plugin-vue-i18n": "npm:^2.0.0"
     "@mdi/font": "npm:^7.2.96"
-    "@niis/shared-ui": "file:../../../shared-ui/niis-shared-ui-3.0.0.tgz"
+    "@niis/shared-ui": ../../../shared-ui
     "@rushstack/eslint-patch": "npm:^1.3.3"
     "@tsconfig/node18": "npm:^2.0.1"
     "@types/node": "npm:^18.17.8"

--- a/src/security-server/admin-service/ui/package.json
+++ b/src/security-server/admin-service/ui/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@fontsource/open-sans": "~4.5.0",
-    "@niis/shared-ui": "file:../../../shared-ui/niis-shared-ui-3.0.0.tgz",
+    "@niis/shared-ui": "../../../shared-ui",
     "@vee-validate/i18n": "~4.12.2",
     "@vee-validate/rules": "~4.11.6",
     "axios": "~1.4.0",

--- a/src/security-server/admin-service/ui/yarn.lock
+++ b/src/security-server/admin-service/ui/yarn.lock
@@ -760,9 +760,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@niis/shared-ui@file:../../../shared-ui/niis-shared-ui-3.0.0.tgz::locator=frontend%40workspace%3A.":
+"@niis/shared-ui@file:../../../shared-ui::locator=frontend%40workspace%3A.":
   version: 3.0.0
-  resolution: "@niis/shared-ui@file:../../../shared-ui/niis-shared-ui-3.0.0.tgz#../../../shared-ui/niis-shared-ui-3.0.0.tgz::hash=bd2153&locator=frontend%40workspace%3A."
+  resolution: "@niis/shared-ui@file:../../../shared-ui#../../../shared-ui::hash=d30b31&locator=frontend%40workspace%3A."
   dependencies:
     "@fontsource/open-sans": "npm:^5.0.12"
     "@mdi/font": "npm:^7.2.96"
@@ -771,7 +771,7 @@ __metadata:
     vue: ^3.3.4
     vue-i18n: ^9.4.0
     vuetify: ^3.3.19
-  checksum: f4a48b9c7621724e588b7f567a6d0ef6b019e5aff87b2edec18c895a79a56f1ee040735fe7db73bff16c1c8588b99862ec4fda18829e44b4c6222abb0ddd7153
+  checksum: 1700d63a338d7d4749d8e9176ca9974b018a7a8b77f190b06b584acff108fc6989a67133655cdee9d5bc85e8004c56681ac38672fd0a396364742c98c6200477
   languageName: node
   linkType: hard
 
@@ -2873,7 +2873,7 @@ __metadata:
     "@fontsource/open-sans": "npm:~4.5.0"
     "@intlify/eslint-plugin-vue-i18n": "npm:^2.0.0"
     "@mdi/font": "npm:~6.5.95"
-    "@niis/shared-ui": "file:../../../shared-ui/niis-shared-ui-3.0.0.tgz"
+    "@niis/shared-ui": ../../../shared-ui
     "@rushstack/eslint-patch": "npm:^1.3.3"
     "@types/jest": "npm:^27.0.0"
     "@types/node": "npm:^18.16.17"

--- a/src/serverconf/build.gradle
+++ b/src/serverconf/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 }
 
 task schemaExport() {
+    dependsOn configurations.schema
+
     doLast {
         ant.taskdef(name: 'schemaExport', classname: 'org.hibernate.tool.ant.HibernateToolTask', classpath: configurations.schema.asPath)
 

--- a/src/serverconf/build.gradle
+++ b/src/serverconf/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     schema project(':common:common-util')
     schema "org.apache.ant:ant:1.10.11"
     schema "org.hibernate:hibernate-hikaricp:$hibernateVersion"
-    schema "org.hibernate:hibernate-tools:$hibernateVersion"
+    schema "org.hibernate.tool:hibernate-tools-ant:$hibernateVersion"
     schema 'commons-collections:commons-collections:3.2.2'
     schema "ch.qos.logback:logback-classic:${logbackVersion}"
     schema "org.hsqldb:hsqldb:$hsqldbVersion"


### PR DESCRIPTION
As discovered by an analysis with ORT [1], the `hibernate-tools` dependency does not exist in the currently set version "6.2.9.Final", making the `:serverconf:schemaExport` Gradle task fail. It was only available until version "5.6.15.Final", see [2]. The successor providing `org.hibernate.tool.ant.HibernateToolTask` seems to be `hibernate-tools-ant` [3], so use that instead.

However, this does not fully fix running `:serverconf:schemaExport` as it still fails with

    * What went wrong:
    Execution failed for task ':serverconf:schemaExport'.
    > java.lang.NoClassDefFoundError: ee/ria/xroad/common/identifier/ClientId$Conf

which is something that needs to be investigated separately.

[1]: https://github.com/oss-review-toolkit/ort
[2]: https://mvnrepository.com/artifact/org.hibernate/hibernate-tools
[3]: https://mvnrepository.com/artifact/org.hibernate.tool/hibernate-tools-ant