### PR TITLE
fix: nginx fails to restart after upgrade

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/xroad-center.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-center.postinst
@@ -184,6 +184,24 @@ EOF
     fi
 }
 
+migrate_internal_crt() {
+  if [[ -f /etc/xroad/ssl/internal.crt && -f /etc/xroad/ssl/internal.key ]]; then
+    if [[ ! -r /etc/xroad/ssl/management-service.crt || ! -r /etc/xroad/ssl/management-service.key || ! -r /etc/xroad/ssl/management-service.p12 ]]; then
+      echo "found existing internal.crt and internal.key, migrating those to management-service.crt, key and p12"
+      # Copying instead of moving because nginx configuration is not updated until
+      # registration-service and management service packages are installed.
+      # internal.* files are removed in xroad-centralserver.postinst
+      cp /etc/xroad/ssl/internal.crt /etc/xroad/ssl/management-service.crt
+      cp /etc/xroad/ssl/internal.key /etc/xroad/ssl/management-service.key
+      openssl pkcs12 -export -in /etc/xroad/ssl/management-service.crt -inkey /etc/xroad/ssl/management-service.key -name management-service -out /etc/xroad/ssl/management-service.p12 -passout pass:management-service
+      chmod -f 640 /etc/xroad/ssl/management-service.key /etc/xroad/ssl/management-service.crt /etc/xroad/ssl/management-service.p12
+      chown -f xroad:xroad /etc/xroad/ssl/management-service.key /etc/xroad/ssl/management-service.crt /etc/xroad/ssl/management-service.p12
+    else
+        echo "found existing management-service.key, crt and p12, keeping those and not migrating internal.key and crt"
+    fi
+  fi
+}
+
 # check certificates and request necessary subject information from the user
 create_certificates() {
     HOST=$(hostname -f)
@@ -244,22 +262,6 @@ create_certificates() {
         fi
     done
 
-    if [[ -f /etc/xroad/ssl/internal.crt && -f /etc/xroad/ssl/internal.key ]]; then
-        if [[ ! -r /etc/xroad/ssl/management-service.crt || ! -r /etc/xroad/ssl/management-service.key || ! -r /etc/xroad/ssl/management-service.p12 ]]
-            then
-            echo "found existing internal.crt and internal.key, migrating those to management-service.crt, key and p12"
-            mv -f /etc/xroad/ssl/internal.crt /etc/xroad/ssl/management-service.crt
-            mv -f /etc/xroad/ssl/internal.key /etc/xroad/ssl/management-service.key
-            rm -f /etc/xroad/ssl/internal.p12
-            openssl pkcs12 -export -in /etc/xroad/ssl/management-service.crt -inkey /etc/xroad/ssl/management-service.key -name management-service -out /etc/xroad/ssl/management-service.p12 -passout pass:management-service
-            chmod -f 640 /etc/xroad/ssl/management-service.key /etc/xroad/ssl/management-service.crt /etc/xroad/ssl/management-service.p12
-            chown -f xroad:xroad /etc/xroad/ssl/management-service.key /etc/xroad/ssl/management-service.crt /etc/xroad/ssl/management-service.p12
-
-        else
-            echo "found existing management-service.key, crt and p12, keeping those and not migrating internal.key and crt"
-        fi
-    fi
-
     if [[ ! -r /etc/xroad/ssl/management-service.crt || ! -r /etc/xroad/ssl/management-service.key || ! -r /etc/xroad/ssl/management-service.p12 ]]; then
         log "Generating new management-service.[crt|key|p12] files "
 
@@ -307,6 +309,9 @@ create_certificates() {
 
 case "$1" in
 configure | reconfigure)
+    if dpkg --compare-versions "$2" lt-nl "7.4.0"; then
+      migrate_internal_crt
+    fi
     create_certificates
     setup_database
 

--- a/src/packages/src/xroad/ubuntu/generic/xroad-centralserver.postinst
+++ b/src/packages/src/xroad/ubuntu/generic/xroad-centralserver.postinst
@@ -4,6 +4,11 @@
 if [ "$1" = "configure" ]; then
   deb-systemd-invoke stop xroad-confclient
   deb-systemd-invoke disable xroad-confclient
+
+  if dpkg --compare-versions "$2" lt-nl "7.4.0"; then
+    # see xroad-center.postinst migrate_internal_crt
+    rm -f /etc/xroad/ssl/internal.{crt,key,p12}
+  fi
 fi
 
 if [ "$1" = abort-upgrade ]; then


### PR DESCRIPTION
internal.crt file was migrated to management-service.crt in xroad-center.postinst, but related ngingx configurations were in management-service and registration-service packages. This caused nginx failing to restart because of invalid configuration.

Refs: XRDDEV-2553