### PR TITLE
fix: Ensure consistent order for configuration signing keys in shared params to prevent its hash dynamism

### DIFF
--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKey.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/domain/ConfigurationSigningKey.java
@@ -39,6 +39,7 @@ import java.time.Instant;
 @NoArgsConstructor
 @EqualsAndHashCode
 public class ConfigurationSigningKey {
+    private int id;
     private String keyIdentifier;
     private byte[] cert;
     private Instant keyGeneratedAt;

--- a/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationService.java
+++ b/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/service/ConfigurationService.java
@@ -39,7 +39,7 @@ import java.util.Set;
 
 public interface ConfigurationService {
 
-    Map<String, List<ConfigurationSigningKey>> getNodeAddressesWithConfigurationSigningKeys();
+    Map<String, List<ConfigurationSigningKey>> getNodeAddressesWithOrderedConfigurationSigningKeys();
 
     boolean hasSigningKeys(ConfigurationSourceType sourceType);
 

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImpl.java
@@ -69,6 +69,7 @@ import static ee.ria.xroad.common.conf.globalconf.ConfigurationConstants.CONTENT
 import static ee.ria.xroad.common.conf.globalconf.ConfigurationConstants.FILE_NAME_PRIVATE_PARAMETERS;
 import static ee.ria.xroad.common.conf.globalconf.ConfigurationConstants.FILE_NAME_SHARED_PARAMETERS;
 import static ee.ria.xroad.common.util.CryptoUtils.DEFAULT_UPLOAD_FILE_HASH_ALGORITHM;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -103,11 +104,13 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     private final ConfigurationSigningKeyMapper configurationSigningKeyMapper;
 
     @Override
-    public Map<String, List<ConfigurationSigningKey>> getNodeAddressesWithConfigurationSigningKeys() {
+    public Map<String, List<ConfigurationSigningKey>> getNodeAddressesWithOrderedConfigurationSigningKeys() {
         return configurationSourceRepository.findAll().stream().collect(toMap(
                 src -> systemParameterService.getCentralServerAddress(src.getHaNodeName()),
                 src -> src.getConfigurationSigningKeys().stream()
                         .map(configurationSigningKeyMapper::toTarget)
+                        // ensure consistent order to prevent shared-params hash's dynamism
+                        .sorted(comparing(ConfigurationSigningKey::getId))
                         .collect(toList()),
                 (signingKeys1, signingKeys2) -> {
                     signingKeys1.addAll(signingKeys2);

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/ConfigurationServiceImplTest.java
@@ -43,6 +43,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.niis.xroad.common.exception.NotFoundException;
 import org.niis.xroad.common.exception.ServiceException;
+import org.niis.xroad.cs.admin.api.domain.ConfigurationSigningKey;
 import org.niis.xroad.cs.admin.api.dto.ConfigurationParts;
 import org.niis.xroad.cs.admin.api.dto.File;
 import org.niis.xroad.cs.admin.api.dto.GlobalConfDownloadUrl;
@@ -76,6 +77,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -213,14 +215,22 @@ class ConfigurationServiceImplTest {
         }
 
         @Test
-        void getNodeAddressesWithConfigurationSigningKeys() {
-            when(configurationSourceRepository.findAll()).thenReturn(List.of(configurationSource, configurationSource));
-            when(configurationSource.getConfigurationSigningKeys()).thenReturn(Set.of(new ConfigurationSigningKeyEntity()));
+        void getNodeAddressesWithOrderedConfigurationSigningKeys() {
+            ConfigurationSigningKeyEntity confSigningkey1 = mock(ConfigurationSigningKeyEntity.class);
+            when(confSigningkey1.getId()).thenReturn(2);
+
+            ConfigurationSigningKeyEntity confSigningkey2 = mock(ConfigurationSigningKeyEntity.class);
+            when(confSigningkey2.getId()).thenReturn(1);
+
+            when(configurationSourceRepository.findAll()).thenReturn(List.of(configurationSource));
+            when(configurationSource.getConfigurationSigningKeys()).thenReturn(Set.of(confSigningkey1, confSigningkey2));
             when(configurationSource.getHaNodeName()).thenReturn(HA_NODE_NAME);
             when(systemParameterService.getCentralServerAddress(HA_NODE_NAME)).thenReturn(CENTRAL_SERVICE);
 
-            assertThat(configurationServiceHa.getNodeAddressesWithConfigurationSigningKeys().get(CENTRAL_SERVICE))
-                    .hasSize(2);
+            List<ConfigurationSigningKey> configurationSigningKeys =
+                    configurationServiceHa.getNodeAddressesWithOrderedConfigurationSigningKeys().get(CENTRAL_SERVICE);
+            assertThat(configurationSigningKeys).hasSize(2);
+            assertThat(configurationSigningKeys.get(0).getId()).isLessThan(configurationSigningKeys.get(1).getId());
         }
     }
 

--- a/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoader.java
+++ b/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoader.java
@@ -87,7 +87,7 @@ class SharedParametersLoader {
     }
 
     private List<SharedParameters.ConfigurationSource> getSources() {
-        return configurationService.getNodeAddressesWithConfigurationSigningKeys().entrySet().stream()
+        return configurationService.getNodeAddressesWithOrderedConfigurationSigningKeys().entrySet().stream()
                 .map(this::toSource)
                 .toList();
     }

--- a/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoaderTest.java
+++ b/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoaderTest.java
@@ -120,7 +120,7 @@ class SharedParametersLoaderTest {
     @Test
     void loadSharedParameters() {
         when(systemParameterService.getInstanceIdentifier()).thenReturn(XROAD_INSTANCE);
-        when(configurationService.getNodeAddressesWithConfigurationSigningKeys())
+        when(configurationService.getNodeAddressesWithOrderedConfigurationSigningKeys())
                 .thenReturn(getNodeAddressesWithConfigurationSigningKeys());
         when(certificationServicesService.findAll()).thenReturn(List.of(getCertificationService()));
 


### PR DESCRIPTION
Refs: XRDDEV-2592