### PR TITLE
fix: don't close request input stream before reading in full

### DIFF
--- a/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerHandler.java
+++ b/src/addons/messagelog/messagelog-addon/src/main/java/ee/ria/xroad/proxy/clientproxy/AsicContainerHandler.java
@@ -27,12 +27,12 @@ package ee.ria.xroad.proxy.clientproxy;
 
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import static ee.ria.xroad.common.ErrorCodes.X_INVALID_REQUEST;
 import static ee.ria.xroad.common.util.JettyUtils.getTarget;
@@ -51,10 +51,10 @@ public class AsicContainerHandler extends AbstractClientProxyHandler {
     }
 
     @Override
-    MessageProcessorBase createRequestProcessor(Request request, Response response,
+    MessageProcessorBase createRequestProcessor(RequestWrapper request, ResponseWrapper response,
                                                 OpMonitoringData opMonitoringData) throws Exception {
         var target = getTarget(request);
-        log.trace("createRequestProcessor({})", getTarget(request));
+        log.trace("createRequestProcessor({})", target);
 
         // opMonitoringData is null, do not use it.
 
@@ -67,9 +67,10 @@ public class AsicContainerHandler extends AbstractClientProxyHandler {
                     "Target must not be null");
         }
 
-        AsicContainerClientRequestProcessor processor =
-                new AsicContainerClientRequestProcessor(target, request,
-                        response);
+        AsicContainerClientRequestProcessor processor = new AsicContainerClientRequestProcessor(
+                target,
+                request,
+                response);
 
         if (processor.canProcess()) {
             log.trace("Processing with AsicContainerRequestProcessor");

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataHandler.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/clientproxy/MetadataHandler.java
@@ -27,12 +27,12 @@ package ee.ria.xroad.proxy.clientproxy;
 
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import static ee.ria.xroad.common.ErrorCodes.X_INVALID_REQUEST;
 import static ee.ria.xroad.common.util.JettyUtils.getTarget;
@@ -51,7 +51,7 @@ public class MetadataHandler extends AbstractClientProxyHandler {
     }
 
     @Override
-    MessageProcessorBase createRequestProcessor(Request request, Response response,
+    MessageProcessorBase createRequestProcessor(RequestWrapper request, ResponseWrapper response,
                                                 OpMonitoringData opMonitoringData) {
         var target = getTarget(request);
         log.trace("createRequestProcessor({})", target);

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerImpl.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/MetadataServiceHandlerImpl.java
@@ -44,6 +44,7 @@ import ee.ria.xroad.common.metadata.MethodListType;
 import ee.ria.xroad.common.metadata.ObjectFactory;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.MimeTypes;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.common.util.XmlUtils;
 import ee.ria.xroad.proxy.common.WsdlRequestData;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
@@ -64,7 +65,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
-import org.eclipse.jetty.server.Request;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -160,7 +160,7 @@ class MetadataServiceHandlerImpl implements ServiceHandler {
     }
 
     @Override
-    public void startHandling(Request servletRequest,
+    public void startHandling(RequestWrapper servletRequest,
                               ProxyMessage proxyRequestMessage, HttpClient opMonitorClient,
                               OpMonitoringData opMonitoringData) throws Exception {
 

--- a/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerImpl.java
+++ b/src/addons/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerImpl.java
@@ -36,6 +36,7 @@ import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.CachingStream;
 import ee.ria.xroad.common.util.MimeTypes;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 import ee.ria.xroad.proxy.protocol.ProxyMessageDecoder;
 import ee.ria.xroad.proxy.protocol.ProxyMessageEncoder;
@@ -56,7 +57,6 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
-import org.eclipse.jetty.server.Request;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -123,7 +123,7 @@ public class RestMetadataServiceHandlerImpl implements RestServiceHandler {
     }
 
     @Override
-    public void startHandling(Request servletRequest, ProxyMessage requestProxyMessage,
+    public void startHandling(RequestWrapper servletRequest, ProxyMessage requestProxyMessage,
                               ProxyMessageDecoder messageDecoder, ProxyMessageEncoder messageEncoder,
                               HttpClient restClient, HttpClient opMonitorClient,
                               OpMonitoringData opMonitoringData) throws Exception {
@@ -171,8 +171,8 @@ public class RestMetadataServiceHandlerImpl implements RestServiceHandler {
         );
     }
 
-    private void handleGetOpenApi(ProxyMessage requestProxyMessage) throws IOException,
-            HttpClientCreator.HttpClientCreatorException, URISyntaxException {
+    private void handleGetOpenApi(ProxyMessage requestProxyMessage)
+            throws IOException, HttpClientCreator.HttpClientCreatorException, URISyntaxException {
         List<NameValuePair> pairs = URLEncodedUtils.parse(requestProxyMessage.getRest().getQuery(),
                 StandardCharsets.UTF_8);
         String targetServiceCode = null;

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/clientproxy/MetadataHandlerTest.java
@@ -27,6 +27,8 @@ package ee.ria.xroad.proxy.clientproxy;
 
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.testsuite.TestSuiteGlobalConf;
 import ee.ria.xroad.proxy.testsuite.TestSuiteKeyConf;
@@ -34,8 +36,6 @@ import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
 import org.apache.http.client.HttpClient;
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,9 +61,9 @@ public class MetadataHandlerTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private HttpClient httpClientMock;
-    private Request mockRequest;
+    private RequestWrapper mockRequest;
     private HttpURI mockHttpUri;
-    private Response mockResponse;
+    private ResponseWrapper mockResponse;
 
 
     /**
@@ -75,8 +75,8 @@ public class MetadataHandlerTest {
         KeyConf.reload(new TestSuiteKeyConf());
 
         httpClientMock = mock(HttpClient.class);
-        mockRequest = mock(Request.class);
-        mockResponse = mock(Response.class);
+        mockRequest = mock(RequestWrapper.class);
+        mockResponse = mock(ResponseWrapper.class);
         mockHttpUri = mock(HttpURI.class);
 
         when(mockRequest.getHttpURI()).thenReturn(mockHttpUri);

--- a/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/RestMetadataServiceHandlerTest.java
@@ -36,6 +36,8 @@ import ee.ria.xroad.common.message.RestResponse;
 import ee.ria.xroad.common.metadata.RestServiceDetailsListType;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.CachingStream;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 import ee.ria.xroad.proxy.protocol.ProxyMessageDecoder;
@@ -55,8 +57,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -114,8 +114,8 @@ public class RestMetadataServiceHandlerTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private HttpClient httpClientMock;
-    private Request mockRequest;
-    private Response mockResponse;
+    private RequestWrapper mockRequest;
+    private ResponseWrapper mockResponse;
     private ProxyMessage mockProxyMessage;
     private WireMockServer mockServer;
 
@@ -154,8 +154,8 @@ public class RestMetadataServiceHandlerTest {
         });
         var mockHeaders = mock(HttpFields.class);
         httpClientMock = mock(HttpClient.class);
-        mockRequest = mock(Request.class);
-        mockResponse = mock(Response.class);
+        mockRequest = mock(RequestWrapper.class);
+        mockResponse = mock(ResponseWrapper.class);
         mockProxyMessage = mock(ProxyMessage.class);
 
         when(mockRequest.getHeaders()).thenReturn(mockHeaders);

--- a/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/serverproxy/OpMonitoringServiceHandlerImpl.java
+++ b/src/addons/op-monitoring/src/main/java/ee/ria/xroad/proxy/serverproxy/OpMonitoringServiceHandlerImpl.java
@@ -34,12 +34,12 @@ import ee.ria.xroad.common.opmonitoring.OpMonitoringSystemProperties;
 import ee.ria.xroad.common.util.AbstractHttpSender;
 import ee.ria.xroad.common.util.HttpSender;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -96,7 +96,7 @@ public class OpMonitoringServiceHandlerImpl implements ServiceHandler {
     }
 
     @Override
-    public void startHandling(Request servletRequest, ProxyMessage proxyRequestMessage,
+    public void startHandling(RequestWrapper servletRequest, ProxyMessage proxyRequestMessage,
                               HttpClient opMonitorClient, OpMonitoringData opMonitoringData) throws Exception {
         log.trace("startHandling({})", proxyRequestMessage.getSoap().getService());
 
@@ -128,7 +128,7 @@ public class OpMonitoringServiceHandlerImpl implements ServiceHandler {
         return new HttpSender(opMonitorClient);
     }
 
-    private void sendRequest(Request servletRequest, ProxyMessage proxyRequestMessage,
+    private void sendRequest(RequestWrapper servletRequest, ProxyMessage proxyRequestMessage,
                              OpMonitoringData opMonitoringData) throws Exception {
         log.trace("sendRequest {}", OP_MONITOR_ADDRESS);
 

--- a/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerImpl.java
+++ b/src/addons/proxymonitor/metaservice/src/main/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerImpl.java
@@ -36,6 +36,7 @@ import ee.ria.xroad.common.message.SoapMessageEncoder;
 import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.message.SoapUtils;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.common.util.XmlUtils;
 import ee.ria.xroad.proxy.ProxyMain;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
@@ -51,7 +52,6 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -111,9 +111,8 @@ public class ProxyMonitorServiceHandlerImpl implements ServiceHandler {
     }
 
     @Override
-    public void startHandling(Request servletRequest,
-                              ProxyMessage proxyRequestMessage, HttpClient opMonitorClient,
-                              OpMonitoringData opMonitoringData) throws Exception {
+    public void startHandling(RequestWrapper servletRequest, ProxyMessage proxyRequestMessage,
+                              HttpClient opMonitorClient, OpMonitoringData opMonitoringData) throws Exception {
 
         // It's required that in case of proxy monitor service (where SOAP
         // message is not forwarded) the requestOutTs must be equal with the

--- a/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerMetricsTest.java
+++ b/src/addons/proxymonitor/metaservice/src/test/java/ee/ria/xroad/proxy/serverproxy/ProxyMonitorServiceHandlerMetricsTest.java
@@ -36,6 +36,7 @@ import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.metadata.ObjectFactory;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.MimeTypes;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 import ee.ria.xroad.proxy.testsuite.TestSuiteGlobalConf;
@@ -55,7 +56,6 @@ import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -117,7 +117,7 @@ public class ProxyMonitorServiceHandlerMetricsTest {
     @Rule
     public final RestoreMonitorClientAfterTest monitorClientRestoreRule = new RestoreMonitorClientAfterTest();
 
-    private Request mockRequest;
+    private RequestWrapper mockRequest;
     private ProxyMessage mockProxyMessage;
 
     /**
@@ -151,7 +151,7 @@ public class ProxyMonitorServiceHandlerMetricsTest {
             }
         });
 
-        mockRequest = mock(Request.class);
+        mockRequest = mock(RequestWrapper.class);
         mockProxyMessage = mock(ProxyMessage.class);
 
         when(mockProxyMessage.getSoapContentType()).thenReturn(MimeTypes.TEXT_XML_UTF8);

--- a/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/AdminPort.java
+++ b/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/AdminPort.java
@@ -49,7 +49,7 @@ public class AdminPort implements StartStop {
      * Base class for AdminPort callbacks
      */
     public abstract static class AdminPortCallback {
-        public abstract void handle(Request request, Response response) throws Exception;
+        public abstract void handle(RequestWrapper request, ResponseWrapper response) throws Exception;
     }
 
     /**
@@ -145,7 +145,7 @@ public class AdminPort implements StartStop {
                     AdminPortCallback handler = handlers.get(target);
                     if (handler != null) {
                         if (handler instanceof SynchronousCallback) {
-                            handler.handle(request, response);
+                            handler.handle(RequestWrapper.of(request), ResponseWrapper.of(response));
                         } else {
                             LOG.warn("Unknown handler detected for target '{}', skipping handling delegation", target);
                         }

--- a/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
+++ b/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/HandlerBase.java
@@ -28,9 +28,7 @@ package ee.ria.xroad.common.util;
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.message.SoapFault;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -38,9 +36,6 @@ import org.eclipse.jetty.util.Callback;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.List;
 
 import static ee.ria.xroad.common.util.JettyUtils.setContentLength;
 import static ee.ria.xroad.common.util.JettyUtils.setContentType;
@@ -90,19 +85,6 @@ public abstract class HandlerBase extends Handler.Abstract {
         setContentType(response, MimeTypes.TEXT_PLAIN_UTF8);
         setContentLength(response, messageBytes.length);
         response.write(true, ByteBuffer.wrap(messageBytes), callback);
-    }
-
-    /**
-     * Returns the client certificate from the SSL context.
-     */
-    protected List<X509Certificate> getClientCertificates(HttpServletRequest request) {
-        Object attribute = request.getAttribute(EndPoint.SslSessionData.ATTRIBUTE);
-
-        if (attribute != null) {
-            return List.of(((EndPoint.SslSessionData) attribute).peerCertificates());
-        } else {
-            return new ArrayList<>();
-        }
     }
 
     protected void failure(Request request, Response response, Callback callback, CodedException ex)

--- a/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/JettyUtils.java
+++ b/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/JettyUtils.java
@@ -65,6 +65,13 @@ public final class JettyUtils {
                 .orElse(null);
     }
 
+    public static String getTarget(final RequestWrapper request) {
+        return Optional.of(request)
+                .map(RequestWrapper::getHttpURI)
+                .map(HttpURI::getPath)
+                .orElse(null);
+    }
+
     public static void setContentType(final Response response, final MimeTypes.Type contentType) {
         setContentType(response, contentType == null ? null : contentType.asString());
     }

--- a/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/RequestWrapper.java
+++ b/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/RequestWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.util;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ProxyInputStream;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.server.Request;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+public interface RequestWrapper {
+    InputStream getInputStream();
+
+    HttpURI getHttpURI();
+
+    String getMethod();
+
+    String getContentType();
+
+    HttpFields getHeaders();
+
+    Object getAttribute(String attributeName);
+
+    String getParameter(String name) throws Exception;
+
+    Map<String, String[]> getParametersMap() throws Exception;
+
+    static RequestWrapper of(Request request) {
+        var in = new ProxyInputStream(Request.asInputStream(request)) {
+            @Override
+            public void close() throws IOException {
+                // Consume the input stream to the end before closing it.
+                IOUtils.consume(in);
+                super.close();
+            }
+        };
+
+        return new RequestWrapper() {
+            @Override
+            public InputStream getInputStream() {
+                return in;
+            }
+
+            @Override
+            public HttpURI getHttpURI() {
+                return request.getHttpURI();
+            }
+
+            @Override
+            public String getMethod() {
+                return request.getMethod();
+            }
+
+            @Override
+            public String getContentType() {
+                return JettyUtils.getContentType(request);
+            }
+
+            @Override
+            public HttpFields getHeaders() {
+                return request.getHeaders();
+            }
+
+            @Override
+            public Object getAttribute(String attributeName) {
+                return request.getAttribute(attributeName);
+            }
+
+            @Override
+            public String getParameter(String name) throws Exception {
+                return Request.getParameters(request).getValue(name);
+            }
+
+            @Override
+            public Map<String, String[]> getParametersMap() throws Exception {
+                return Request.getParameters(request).toStringArrayMap();
+            }
+        };
+    }
+}

--- a/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/ResponseWrapper.java
+++ b/src/common/common-jetty/src/main/java/ee/ria/xroad/common/util/ResponseWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.util;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Response;
+
+import java.io.OutputStream;
+
+public interface ResponseWrapper {
+    OutputStream getOutputStream();
+
+    void setStatus(int status);
+    void setContentLength(int length);
+    void setContentType(String contentType);
+    void setContentType(MimeTypes.Type contentType);
+    void setContentType(String contentType, String charset);
+
+    void putHeader(String headerName, String headerValue);
+    void addHeader(String headerName, String headerValue);
+
+    static ResponseWrapper of(Response response) {
+        var out = Content.Sink.asOutputStream(response);
+
+        return new ResponseWrapper() {
+            @Override
+            public OutputStream getOutputStream() {
+                return out;
+            }
+
+            @Override
+            public void setStatus(int status) {
+                response.setStatus(status);
+            }
+
+            @Override
+            public void setContentLength(int length) {
+                JettyUtils.setContentLength(response, length);
+            }
+
+            @Override
+            public void setContentType(String contentType) {
+                JettyUtils.setContentType(response, contentType);
+            }
+
+            @Override
+            public void setContentType(MimeTypes.Type contentType) {
+                JettyUtils.setContentType(response, contentType);
+            }
+
+            @Override
+            public void setContentType(String contentType, String charset) {
+                JettyUtils.setContentType(response, contentType, charset);
+            }
+
+            @Override
+            public void putHeader(String headerName, String headerValue) {
+                response.getHeaders().put(headerName, headerValue);
+            }
+
+            @Override
+            public void addHeader(String headerName, String headerValue) {
+                response.getHeaders().add(headerName, headerValue);
+            }
+        };
+    }
+}

--- a/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
+++ b/src/configuration-client/src/main/java/ee/ria/xroad/common/conf/globalconf/ConfigurationClientMain.java
@@ -33,6 +33,8 @@ import ee.ria.xroad.common.Version;
 import ee.ria.xroad.common.util.AdminPort;
 import ee.ria.xroad.common.util.JobManager;
 import ee.ria.xroad.common.util.JsonUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.common.util.TimeUtils;
 
 import lombok.extern.slf4j.Slf4j;
@@ -42,9 +44,6 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.http.MimeTypes;
-import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.niis.xroad.schedule.backup.ProxyConfigurationBackupJob;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -68,7 +67,6 @@ import static ee.ria.xroad.common.ErrorCodes.translateException;
 import static ee.ria.xroad.common.SystemProperties.CONF_FILE_PROXY;
 import static ee.ria.xroad.common.conf.globalconf.ConfigurationConstants.CONTENT_ID_PRIVATE_PARAMETERS;
 import static ee.ria.xroad.common.conf.globalconf.ConfigurationConstants.CONTENT_ID_SHARED_PARAMETERS;
-import static ee.ria.xroad.common.util.JettyUtils.setContentType;
 
 /**
  * Main program of configuration client.
@@ -273,7 +271,7 @@ public final class ConfigurationClientMain {
 
         adminPort.addHandler("/execute", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 log.info("handler /execute");
 
                 try {
@@ -286,11 +284,11 @@ public final class ConfigurationClientMain {
 
         adminPort.addHandler("/status", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
-                try (var writer = new PrintWriter(Content.Sink.asOutputStream(response))) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
+                try (var writer = new PrintWriter(response.getOutputStream())) {
                     log.info("handler /status");
 
-                    setContentType(response, MimeTypes.Type.APPLICATION_JSON_UTF_8);
+                    response.setContentType(MimeTypes.Type.APPLICATION_JSON_UTF_8);
                     JsonUtils.getObjectWriter().writeValue(writer, ConfigurationClientJobListener.getStatus());
                 } catch (Exception e) {
                     log.error("Error getting conf client status", e);

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/OpMonitorDaemonRequestHandler.java
@@ -31,6 +31,8 @@ import ee.ria.xroad.common.util.HandlerBase;
 import ee.ria.xroad.common.util.JsonUtils;
 import ee.ria.xroad.common.util.MimeTypes;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -111,7 +113,7 @@ class OpMonitorDaemonRequestHandler extends HandlerBase {
 
             log.info("Received query request from {}", getRemoteAddr(request));
 
-            new QueryRequestProcessor(request, response,
+            new QueryRequestProcessor(RequestWrapper.of(request), ResponseWrapper.of(response),
                     healthMetricRegistry).process();
         } catch (Throwable t) { // We want to catch serious errors as well
             log.error("Error while handling query request", t);
@@ -142,7 +144,7 @@ class OpMonitorDaemonRequestHandler extends HandlerBase {
             log.info("Received store request from {}", getRemoteAddr(request));
 
             new StoreRequestProcessor(
-                    request, healthMetricRegistry).process();
+                    RequestWrapper.of(request), healthMetricRegistry).process();
         } catch (Throwable t) { // We want to catch serious errors as well
             log.error("Error while handling data store request", t);
 

--- a/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/StoreRequestProcessor.java
+++ b/src/op-monitor-daemon/src/main/java/ee/ria/xroad/opmonitordaemon/StoreRequestProcessor.java
@@ -26,13 +26,13 @@
 package ee.ria.xroad.opmonitordaemon;
 
 import ee.ria.xroad.common.util.JsonUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectReader;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Request;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -50,14 +50,14 @@ class StoreRequestProcessor {
     /**
      * The servlet request.
      */
-    private Request request;
+    private RequestWrapper request;
 
     /**
      * The registry of health data.
      */
     private MetricRegistry healthMetricRegistry;
 
-    StoreRequestProcessor(Request request,
+    StoreRequestProcessor(RequestWrapper request,
                           MetricRegistry healthMetricRegistry) {
         this.request = request;
         this.healthMetricRegistry = healthMetricRegistry;
@@ -70,7 +70,8 @@ class StoreRequestProcessor {
      * @throws Exception in case of any errors
      */
     void process() throws Exception {
-        String rawJson = Content.Source.asString(request, StandardCharsets.UTF_8);
+        String rawJson = IOUtils.toString(request.getInputStream(),
+                StandardCharsets.UTF_8);
 
         log.trace("Incoming JSON: {}", rawJson);
 

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyAdminPortConfig.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/ProxyAdminPortConfig.java
@@ -35,6 +35,8 @@ import ee.ria.xroad.common.PortNumbers;
 import ee.ria.xroad.common.conf.serverconf.ServerConf;
 import ee.ria.xroad.common.util.AdminPort;
 import ee.ria.xroad.common.util.JsonUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.common.util.healthcheck.HealthCheckPort;
 import ee.ria.xroad.proxy.messagelog.MessageLog;
@@ -42,9 +44,6 @@ import ee.ria.xroad.proxy.messagelog.MessageLog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.http.MimeTypes;
-import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -52,12 +51,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static ee.ria.xroad.common.util.JettyUtils.setContentType;
 
 @Slf4j
 @Configuration
@@ -93,7 +89,7 @@ public class ProxyAdminPortConfig {
     private void addAddOnStatusHandler(AdminPort adminPort) {
         adminPort.addHandler("/addonstatus", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 writeJsonResponse(addOnStatus, response);
             }
         });
@@ -102,7 +98,7 @@ public class ProxyAdminPortConfig {
     private void addBackupEncryptionStatus(AdminPort adminPort) {
         adminPort.addHandler("/backup-encryption-status", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 writeJsonResponse(backupEncryptionStatusDiagnostics, response);
             }
         });
@@ -111,7 +107,7 @@ public class ProxyAdminPortConfig {
     private void addMessageLogEncryptionStatus(AdminPort adminPort) {
         adminPort.addHandler("/message-log-encryption-status", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 writeJsonResponse(messageLogEncryptionStatusDiagnostics, response);
             }
         });
@@ -120,13 +116,11 @@ public class ProxyAdminPortConfig {
     private void addClearCacheHandler(AdminPort adminPort) {
         adminPort.addHandler("/clearconfcache", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 ServerConf.clearCache();
-                try {
-                    setContentType(response, MimeTypes.Type.APPLICATION_JSON_UTF_8);
-                    Content.Sink.write(response, true, StandardCharsets.UTF_8.encode("Configuration cache cleared"));
-                } catch (IOException e) {
-                    logResponseIOError(e);
+                try (var pw = new PrintWriter(response.getOutputStream())) {
+                    response.setContentType(MimeTypes.Type.APPLICATION_JSON_UTF_8);
+                    pw.println("Configuration cache cleared");
                 }
             }
         });
@@ -135,19 +129,17 @@ public class ProxyAdminPortConfig {
     private void addMaintenanceHandler(AdminPort adminPort) {
         adminPort.addHandler("/maintenance", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) throws Exception {
+            public void handle(RequestWrapper request, ResponseWrapper response) throws Exception {
 
                 String result = "Invalid parameter 'targetState', request ignored";
-                String param = Request.getParameters(request).get("targetState").getValue();
+                String param = request.getParameter("targetState");
 
                 if (param != null && (param.equalsIgnoreCase("true") || param.equalsIgnoreCase("false"))) {
                     result = setHealthCheckMaintenanceMode(Boolean.parseBoolean(param));
                 }
-                try {
-                    setContentType(response, MimeTypes.Type.APPLICATION_JSON_UTF_8);
-                    Content.Sink.write(response, true, StandardCharsets.UTF_8.encode(result));
-                } catch (IOException e) {
-                    logResponseIOError(e);
+                try (var pw = new PrintWriter(response.getOutputStream())) {
+                    response.setContentType(MimeTypes.Type.APPLICATION_JSON_UTF_8);
+                    pw.println(result);
                 }
             }
         });
@@ -161,7 +153,7 @@ public class ProxyAdminPortConfig {
     private void addTimestampStatusHandler(AdminPort adminPort) {
         adminPort.addHandler("/timestampstatus", new AdminPort.SynchronousCallback() {
             @Override
-            public void handle(Request request, Response response) {
+            public void handle(RequestWrapper request, ResponseWrapper response) {
                 log.info("/timestampstatus");
 
                 Map<String, DiagnosticsStatus> statusesFromSimpleConnectionCheck = checkConnectionToTimestampUrl();
@@ -195,9 +187,9 @@ public class ProxyAdminPortConfig {
         });
     }
 
-    private void writeJsonResponse(Object jsonObj, Response response) {
-        try (var writer = new PrintWriter(Content.Sink.asOutputStream(response))) {
-            setContentType(response, MimeTypes.Type.APPLICATION_JSON_UTF_8);
+    private void writeJsonResponse(Object jsonObj, ResponseWrapper response) {
+        try (var writer = new PrintWriter(response.getOutputStream())) {
+            response.setContentType(MimeTypes.Type.APPLICATION_JSON_UTF_8);
             JsonUtils.getObjectWriter().writeValue(writer, jsonObj);
         } catch (IOException e) {
             logResponseIOError(e);

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/AbstractClientMessageProcessor.java
@@ -38,6 +38,8 @@ import ee.ria.xroad.common.identifier.ServiceId;
 import ee.ria.xroad.common.message.SoapUtils;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.HttpSender;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.ProxyMain;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
@@ -45,8 +47,6 @@ import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -62,7 +62,6 @@ import static ee.ria.xroad.common.ErrorCodes.X_INVALID_SECURITY_SERVER;
 import static ee.ria.xroad.common.ErrorCodes.X_UNKNOWN_MEMBER;
 import static ee.ria.xroad.common.SystemProperties.getServerProxyPort;
 import static ee.ria.xroad.common.SystemProperties.isSslEnabled;
-import static ee.ria.xroad.common.util.JettyUtils.getContentType;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_HASH_ALGO_ID;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_ORIGINAL_CONTENT_TYPE;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_PROXY_VERSION;
@@ -85,9 +84,9 @@ abstract class AbstractClientMessageProcessor extends MessageProcessorBase {
         }
     }
 
-    protected AbstractClientMessageProcessor(Request request, Response response,
-                                             HttpClient httpClient, IsAuthenticationData clientCert, OpMonitoringData opMonitoringData)
-            throws Exception {
+    protected AbstractClientMessageProcessor(RequestWrapper request, ResponseWrapper response,
+                                             HttpClient httpClient, IsAuthenticationData clientCert,
+                                             OpMonitoringData opMonitoringData) throws Exception {
         super(request, response, httpClient);
 
         this.clientCert = clientCert;
@@ -137,7 +136,7 @@ abstract class AbstractClientMessageProcessor extends MessageProcessorBase {
         // Preserve the original content type in the "x-original-content-type"
         // HTTP header, which will be used to send the request to the
         // service provider
-        httpSender.addHeader(HEADER_ORIGINAL_CONTENT_TYPE, getContentType(jRequest));
+        httpSender.addHeader(HEADER_ORIGINAL_CONTENT_TYPE, jRequest.getContentType());
 
         return addresses;
     }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientMessageHandler.java
@@ -30,12 +30,12 @@ import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.conf.globalconf.AuthKey;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
 
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import static ee.ria.xroad.common.ErrorCodes.X_INVALID_HTTP_METHOD;
 import static ee.ria.xroad.common.ErrorCodes.X_SSL_AUTH_FAILED;
@@ -54,7 +54,7 @@ class ClientMessageHandler extends AbstractClientProxyHandler {
 
     @Override
     MessageProcessorBase createRequestProcessor(
-            Request request, Response response,
+            RequestWrapper request, ResponseWrapper response,
             OpMonitoringData opMonitoringData) throws Exception {
         verifyCanProcess(request);
 
@@ -62,7 +62,7 @@ class ClientMessageHandler extends AbstractClientProxyHandler {
                 getIsAuthenticationData(request), opMonitoringData);
     }
 
-    private void verifyCanProcess(Request request) {
+    private void verifyCanProcess(RequestWrapper request) {
         if (!isPostRequest(request)) {
             throw new ClientException(X_INVALID_HTTP_METHOD,
                     "Must use POST request method instead of %s",

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageHandler.java
@@ -33,6 +33,8 @@ import ee.ria.xroad.common.message.RestMessage;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.JsonUtils;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.common.util.XmlUtils;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
@@ -79,7 +81,7 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
     }
 
     @Override
-    MessageProcessorBase createRequestProcessor(Request request, Response response,
+    MessageProcessorBase createRequestProcessor(RequestWrapper request, ResponseWrapper response,
                                                 OpMonitoringData opMonitoringData) throws Exception {
         final var target = getTarget(request);
         if (target != null && target.startsWith("/r" + RestMessage.PROTOCOL_VERSION + "/")) {
@@ -135,6 +137,8 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
                 responseOut.write(XmlUtils.prettyPrintXml(doc, "UTF-8", 0).getBytes());
             } catch (Exception e) {
                 log.error("Unable to generate XML document");
+            } finally {
+                callback.failed(ex);
             }
         } else {
             try (JsonGenerator jsonGenerator = JsonUtils.getObjectWriter()
@@ -144,6 +148,8 @@ class ClientRestMessageHandler extends AbstractClientProxyHandler {
                 jsonGenerator.writeStringField("message", ex.getFaultString());
                 jsonGenerator.writeStringField("detail", ex.getFaultDetail());
                 jsonGenerator.writeEndObject();
+            } finally {
+                callback.succeeded();
             }
         }
     }

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
@@ -38,6 +38,8 @@ import ee.ria.xroad.common.util.CachingStream;
 import ee.ria.xroad.common.util.CryptoUtils;
 import ee.ria.xroad.common.util.HttpSender;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.messagelog.MessageLog;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
@@ -54,8 +56,6 @@ import org.apache.http.message.BasicHeader;
 import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.util.io.TeeInputStream;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,8 +79,6 @@ import static ee.ria.xroad.common.util.MimeUtils.HEADER_ORIGINAL_CONTENT_TYPE;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_REQUEST_ID;
 import static ee.ria.xroad.common.util.MimeUtils.VALUE_MESSAGE_TYPE_REST;
 import static ee.ria.xroad.common.util.TimeUtils.getEpochMillisecond;
-import static org.eclipse.jetty.io.Content.Sink.asOutputStream;
-import static org.eclipse.jetty.io.Content.Source.asInputStream;
 
 @Slf4j
 class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
@@ -96,9 +94,9 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
     private String xRequestId;
     private byte[] restBodyDigest;
 
-    ClientRestMessageProcessor(Request request, Response response,
-                               HttpClient httpClient, IsAuthenticationData clientCert, OpMonitoringData opMonitoringData)
-            throws Exception {
+    ClientRestMessageProcessor(RequestWrapper request, ResponseWrapper response,
+                               HttpClient httpClient, IsAuthenticationData clientCert,
+                               OpMonitoringData opMonitoringData) throws Exception {
         super(request, response, httpClient, clientCert, opMonitoringData);
         this.xRequestId = UUID.randomUUID().toString();
     }
@@ -271,13 +269,15 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
 
         for (Header h : rest.getHeaders()) {
             if ("Date".equalsIgnoreCase(h.getName())) {
-                jResponse.getHeaders().put(h.getName(), h.getValue());
+                jResponse.putHeader(h.getName(), h.getValue());
             } else {
-                jResponse.getHeaders().add(h.getName(), h.getValue());
+                jResponse.addHeader(h.getName(), h.getValue());
             }
         }
         if (response.hasRestBody()) {
-            IOUtils.copy(response.getRestBody(), asOutputStream(jResponse));
+            try (var out = jResponse.getOutputStream()) {
+                IOUtils.copy(response.getRestBody(), out);
+            }
         }
     }
 
@@ -317,7 +317,7 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
 
                 //Optimize the case without request body (e.g. simple get requests)
                 //TBD: Optimize the case without body logging
-                try (InputStream in = asInputStream(jRequest)) {
+                try (InputStream in = jRequest.getInputStream()) {
                     @SuppressWarnings("checkstyle:magicnumber")
                     byte[] buf = new byte[4096];
                     int count = in.read(buf);
@@ -357,7 +357,7 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
         }
     }
 
-    private List<Header> headers(Request req) {
+    private List<Header> headers(RequestWrapper req) {
         return req.getHeaders().stream()
                 .map(f -> new BasicHeader(f.getName(), f.getValue()))
                 .collect(Collectors.toCollection(ArrayList::new));

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/RestServiceHandler.java
@@ -29,12 +29,12 @@ import ee.ria.xroad.common.identifier.ServiceId;
 import ee.ria.xroad.common.message.RestResponse;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.CachingStream;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 import ee.ria.xroad.proxy.protocol.ProxyMessageDecoder;
 import ee.ria.xroad.proxy.protocol.ProxyMessageEncoder;
 
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
 
 /**
  * Rest service handler interface
@@ -48,7 +48,7 @@ public interface RestServiceHandler {
 
     boolean canHandle(ServiceId requestServiceId, ProxyMessage requestMessage);
 
-    void startHandling(Request request,
+    void startHandling(RequestWrapper request,
                        ProxyMessage requestMessage,
                        ProxyMessageDecoder messageDecoder,
                        ProxyMessageEncoder messageEncoder,

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerMessageProcessor.java
@@ -45,6 +45,8 @@ import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.message.SoapUtils;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.HttpSender;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.common.util.TimeUtils;
 import ee.ria.xroad.proxy.conf.KeyConf;
 import ee.ria.xroad.proxy.conf.SigningCtx;
@@ -58,8 +60,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -94,15 +94,11 @@ import static ee.ria.xroad.common.ErrorCodes.translateWithPrefix;
 import static ee.ria.xroad.common.util.AbstractHttpSender.CHUNKED_LENGTH;
 import static ee.ria.xroad.common.util.CryptoUtils.encodeBase64;
 import static ee.ria.xroad.common.util.CryptoUtils.getDigestAlgorithmURI;
-import static ee.ria.xroad.common.util.JettyUtils.getContentType;
-import static ee.ria.xroad.common.util.JettyUtils.setContentType;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_HASH_ALGO_ID;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_ORIGINAL_CONTENT_TYPE;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_ORIGINAL_SOAP_ACTION;
 import static ee.ria.xroad.common.util.MimeUtils.HEADER_REQUEST_ID;
 import static ee.ria.xroad.common.util.TimeUtils.getEpochMillisecond;
-import static org.eclipse.jetty.io.Content.Sink.asOutputStream;
-import static org.eclipse.jetty.io.Content.Source.asInputStream;
 
 @Slf4j
 class ServerMessageProcessor extends MessageProcessorBase {
@@ -128,9 +124,9 @@ class ServerMessageProcessor extends MessageProcessorBase {
     private HttpClient opMonitorHttpClient;
     private OpMonitoringData opMonitoringData;
 
-    ServerMessageProcessor(Request request, Response response,
-                           HttpClient httpClient, X509Certificate[] clientSslCerts, HttpClient opMonitorHttpClient,
-                           OpMonitoringData opMonitoringData) {
+    ServerMessageProcessor(RequestWrapper request, ResponseWrapper response,
+                           HttpClient httpClient, X509Certificate[] clientSslCerts,
+                           HttpClient opMonitorHttpClient, OpMonitoringData opMonitoringData) {
         super(request, response, httpClient);
 
         this.clientSslCerts = clientSslCerts;
@@ -142,7 +138,7 @@ class ServerMessageProcessor extends MessageProcessorBase {
 
     @Override
     public void process() throws Exception {
-        log.info("process({})", getContentType(jRequest));
+        log.info("process({})", jRequest.getContentType());
 
         xRequestId = jRequest.getHeaders().get(HEADER_REQUEST_ID);
 
@@ -201,10 +197,10 @@ class ServerMessageProcessor extends MessageProcessorBase {
 
     @Override
     protected void preprocess() {
-        encoder = new ProxyMessageEncoder(asOutputStream(jResponse), SoapUtils.getHashAlgoId());
+        encoder = new ProxyMessageEncoder(jResponse.getOutputStream(), SoapUtils.getHashAlgoId());
 
-        setContentType(jResponse, encoder.getContentType());
-        jResponse.getHeaders().add(HEADER_HASH_ALGO_ID, SoapUtils.getHashAlgoId());
+        jResponse.setContentType(encoder.getContentType());
+        jResponse.addHeader(HEADER_HASH_ALGO_ID, SoapUtils.getHashAlgoId());
     }
 
     @Override
@@ -287,10 +283,10 @@ class ServerMessageProcessor extends MessageProcessorBase {
             }
         };
 
-        decoder = new ProxyMessageDecoder(requestMessage, getContentType(jRequest), false,
+        decoder = new ProxyMessageDecoder(requestMessage, jRequest.getContentType(), false,
                 getHashAlgoId(jRequest));
         try {
-            decoder.parse(asInputStream(jRequest));
+            decoder.parse(jRequest.getInputStream());
         } catch (CodedException e) {
             throw e.withPrefix(X_SERVICE_FAILED_X);
         }
@@ -450,7 +446,7 @@ class ServerMessageProcessor extends MessageProcessorBase {
         preprocess();
 
         // Preserve the original content type of the service response
-        jResponse.getHeaders().add(HEADER_ORIGINAL_CONTENT_TYPE, handler.getResponseContentType());
+        jResponse.addHeader(HEADER_ORIGINAL_CONTENT_TYPE, handler.getResponseContentType());
 
         try (SoapMessageHandler messageHandler = new SoapMessageHandler()) {
             SoapMessageDecoder soapMessageDecoder = new SoapMessageDecoder(handler.getResponseContentType(),
@@ -526,7 +522,7 @@ class ServerMessageProcessor extends MessageProcessorBase {
         return clientSslCerts != null ? clientSslCerts[0] : null;
     }
 
-    private static String getHashAlgoId(Request request) {
+    private static String getHashAlgoId(RequestWrapper request) {
         String hashAlgoId = request.getHeaders().get(HEADER_HASH_ALGO_ID);
 
         if (hashAlgoId == null) {
@@ -561,7 +557,7 @@ class ServerMessageProcessor extends MessageProcessorBase {
         }
 
         @Override
-        public void startHandling(Request request, ProxyMessage proxyRequestMessage,
+        public void startHandling(RequestWrapper request, ProxyMessage proxyRequestMessage,
                                   HttpClient opMonitorClient, OpMonitoringData monitoringData) throws Exception {
             sender = createHttpSender();
 

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServerProxyHandler.java
@@ -30,6 +30,8 @@ import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.conf.globalconf.GlobalConf;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.HandlerBase;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 import ee.ria.xroad.proxy.opmonitoring.OpMonitoring;
 import ee.ria.xroad.proxy.util.MessageProcessorBase;
 import ee.ria.xroad.proxy.util.PerformanceLogger;
@@ -85,7 +87,8 @@ class ServerProxyHandler extends HandlerBase {
             GlobalConf.verifyValidity();
 
             ClientProxyVersionVerifier.check(request);
-            final MessageProcessorBase processor = createRequestProcessor(request, response, opMonitoringData);
+            final MessageProcessorBase processor = createRequestProcessor(RequestWrapper.of(request),
+                    ResponseWrapper.of(response), opMonitoringData);
             processor.process();
         } catch (Throwable e) { // We want to catch serious errors as well
             CodedException cex = translateWithPrefix(SERVER_SERVERPROXY_X, e);
@@ -107,7 +110,7 @@ class ServerProxyHandler extends HandlerBase {
         return true;
     }
 
-    private MessageProcessorBase createRequestProcessor(Request request, Response response,
+    private MessageProcessorBase createRequestProcessor(RequestWrapper request, ResponseWrapper response,
                                                         OpMonitoringData opMonitoringData) {
 
         if (VALUE_MESSAGE_TYPE_REST.equals(request.getHeaders().get(HEADER_MESSAGE_TYPE))) {
@@ -125,7 +128,7 @@ class ServerProxyHandler extends HandlerBase {
         sendErrorResponse(request, response, callback, e);
     }
 
-    private static X509Certificate[] getClientSslCertChain(Request request) {
+    private static X509Certificate[] getClientSslCertChain(RequestWrapper request) {
         Object attribute = request.getAttribute(EndPoint.SslSessionData.ATTRIBUTE);
         if (attribute != null) {
             return ((EndPoint.SslSessionData) attribute).peerCertificates();

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandler.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/serverproxy/ServiceHandler.java
@@ -27,10 +27,10 @@ package ee.ria.xroad.proxy.serverproxy;
 
 import ee.ria.xroad.common.identifier.ServiceId;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
+import ee.ria.xroad.common.util.RequestWrapper;
 import ee.ria.xroad.proxy.protocol.ProxyMessage;
 
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
 
 import java.io.InputStream;
 
@@ -44,9 +44,8 @@ interface ServiceHandler {
 
     boolean canHandle(ServiceId requestServiceId, ProxyMessage requestMessage);
 
-    void startHandling(Request request,
-                       ProxyMessage requestMessage, HttpClient opMonitorClient,
-                       OpMonitoringData opMonitoringData) throws Exception;
+    void startHandling(RequestWrapper request, ProxyMessage requestMessage,
+                       HttpClient opMonitorClient, OpMonitoringData opMonitoringData) throws Exception;
 
     void finishHandling() throws Exception;
 

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/CertHashBasedOcspResponder.java
@@ -156,17 +156,16 @@ public class CertHashBasedOcspResponder implements StartStop {
 
         log.debug("Returning OCSP responses for cert hashes: " + hashes);
 
-        MultiPartOutputStream mpResponse = new MultiPartOutputStream(Content.Sink.asOutputStream(response));
+        try (MultiPartOutputStream mpResponse = new MultiPartOutputStream(Content.Sink.asOutputStream(response))) {
 
-        JettyUtils.setContentType(response, MimeUtils.mpRelatedContentType(mpResponse.getBoundary(), MimeTypes.OCSP_RESPONSE));
-        response.setStatus(OK_200);
+            JettyUtils.setContentType(response, MimeUtils.mpRelatedContentType(mpResponse.getBoundary(), MimeTypes.OCSP_RESPONSE));
+            response.setStatus(OK_200);
 
-        for (OCSPResp ocsp : ocspResponses) {
-            mpResponse.startPart(MimeTypes.OCSP_RESPONSE);
-            mpResponse.write(ocsp.getEncoded());
+            for (OCSPResp ocsp : ocspResponses) {
+                mpResponse.startPart(MimeTypes.OCSP_RESPONSE);
+                mpResponse.write(ocsp.getEncoded());
+            }
         }
-
-        mpResponse.close();
     }
 
     private final class RequestHandler extends Handler.Abstract {

--- a/src/proxy/src/main/java/ee/ria/xroad/proxy/util/MessageProcessorBase.java
+++ b/src/proxy/src/main/java/ee/ria/xroad/proxy/util/MessageProcessorBase.java
@@ -35,11 +35,11 @@ import ee.ria.xroad.common.message.SoapMessageImpl;
 import ee.ria.xroad.common.opmonitoring.OpMonitoringData;
 import ee.ria.xroad.common.util.HttpSender;
 import ee.ria.xroad.common.util.MimeUtils;
+import ee.ria.xroad.common.util.RequestWrapper;
+import ee.ria.xroad.common.util.ResponseWrapper;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -54,16 +54,16 @@ import static ee.ria.xroad.common.ErrorCodes.X_INVALID_SOAPACTION;
 public abstract class MessageProcessorBase {
 
     /** The servlet request. */
-    protected final Request jRequest;
+    protected final RequestWrapper jRequest;
 
     /** The servlet response. */
-    protected final Response jResponse;
+    protected final ResponseWrapper jResponse;
 
     /** The http client instance. */
     protected final HttpClient httpClient;
 
-    protected MessageProcessorBase(Request request,
-                                   Response response,
+    protected MessageProcessorBase(RequestWrapper request,
+                                   ResponseWrapper response,
                                    HttpClient httpClient) {
         this.jRequest = request;
         this.jResponse = response;
@@ -183,13 +183,13 @@ public abstract class MessageProcessorBase {
     protected static boolean checkIdentifier(final XRoadId id) {
         if (id != null) {
             if (!validateIdentifierField(id.getXRoadInstance())) {
-                log.warn("Invalid character(s) in identifier {}", id.toString());
+                log.warn("Invalid character(s) in identifier {}", id);
                 return false;
             }
 
             for (String f : id.getFieldsForStringFormat()) {
                 if (f != null && !validateIdentifierField(f)) {
-                    log.warn("Invalid character(s) in identifier {}", id.toString());
+                    log.warn("Invalid character(s) in identifier {}", id);
                     return false;
                 }
             }


### PR DESCRIPTION
Wrapper for Jetty's response/request to hide some complexities and also make it more friendly to mockito