### PR TITLE
chore: fix missing code coverage issue for SonarQube

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -32,7 +32,7 @@ sonarqube {
         property "sonar.dependencyCheck.reportPath", "build/reports/owasp-dependency-check/dependency-check-report.xml"
         property "sonar.dependencyCheck.htmlReportPath", "build/reports/owasp-dependency-check/dependency-check-report.html"
         property "sonar.exclusions", "**/build/generated-sources/**"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${rootProject.layout.buildDirectory.get().asFile}/reports/jacoco/jacocoAggregatedReport/jacocoAggregatedReport.xml"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${rootProject.layout.buildDirectory.get().asFile}/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"
 
         property "sonar.issue.ignore.multicriteria", "e1"
         //# ignore 'Local-Variable Type Inference should be used"

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -278,3 +278,4 @@ tasks.register("installGitHooks", Copy) {
     fileMode 0775
 }
 assemble.dependsOn installGitHooks
+sonar.dependsOn testCodeCoverageReport

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -278,4 +278,4 @@ tasks.register("installGitHooks", Copy) {
     fileMode 0775
 }
 assemble.dependsOn installGitHooks
-sonar.dependsOn testCodeCoverageReport
+tasks.sonar.dependsOn testCodeCoverageReport

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -4,7 +4,7 @@ xroadVersion=7.5.0
 xroadBuildType=SNAPSHOT
 
 # SonarQube defaults
-sonarqubeHost=https://sonarqube.niis.org
+sonarqubeHost=https://sonarcloud.io
 sonarqubeProjectKey=xroad
 sonarqubeOrganization=
 # Dependency check


### PR DESCRIPTION
This adds a dependency to run the coverage report to the `sonar` task and updates the path to the correct one. Additionally, I updated the default sonar host to `sonarcloud.io` since we no longer have an internal instance.

Fixes issue where `sonarcloud.io` always reports coverage as 0%.