### PR TITLE
chore: fix dependabot grouping rules, update github-actions update rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,20 @@ updates:
     directory: "/src"
     schedule:
       interval: "daily"
+    groups:
+      javascript-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
     reviewers:
       - "nordic-institute/xrd-developers"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       interval: "weekly"
     groups:
-      javascript-minor-patch:
+      actions-minor-patch:
         applies-to: version-updates
         update-types:
           - "minor"


### PR DESCRIPTION
Noticed that I had added the grouping rules for javascript under the wrong block.