### PR TITLE
build(npmrc): Explicitly configure the Node version to use

### DIFF
--- a/src/.npmrc
+++ b/src/.npmrc
@@ -1,4 +1,4 @@
 # pnpm-related options
 shamefully-hoist=true
 strict-peer-dependencies=false
-engine-strict = true
+engine-strict=true

--- a/src/.npmrc
+++ b/src/.npmrc
@@ -2,3 +2,4 @@
 shamefully-hoist=true
 strict-peer-dependencies=false
 engine-strict=true
+use-node-version=20.13.1


### PR DESCRIPTION
While `package.json` files have `engines.node` set, that specifies a range of compatible runtime Node versions, but not the exact version to build the project.

Choose the current version from the 20 branch.