### PR TITLE
fix: ensure that auth cert hashes are not hashed again

### DIFF
--- a/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoader.java
+++ b/src/central-server/admin-service/globalconf-generator/src/main/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoader.java
@@ -26,6 +26,7 @@
  */
 package org.niis.xroad.cs.admin.globalconf.generator;
 
+import ee.ria.xroad.common.conf.globalconf.CertHash;
 import ee.ria.xroad.common.conf.globalconf.SharedParameters;
 import ee.ria.xroad.common.identifier.ClientId;
 
@@ -178,6 +179,7 @@ class SharedParametersLoader {
         result.setClients(getSecurityServerClients(ss.getId()));
         result.setAuthCertHashes(ss.getAuthCerts().stream()
                 .map(AuthCert::getCert)
+                .map(CertHash::new)
                 .toList());
         return result;
     }

--- a/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoaderTest.java
+++ b/src/central-server/admin-service/globalconf-generator/src/test/java/org/niis/xroad/cs/admin/globalconf/generator/SharedParametersLoaderTest.java
@@ -26,6 +26,7 @@
  */
 package org.niis.xroad.cs.admin.globalconf.generator;
 
+import ee.ria.xroad.common.conf.globalconf.CertHash;
 import ee.ria.xroad.common.conf.globalconf.SharedParameters;
 import ee.ria.xroad.common.identifier.ClientId;
 
@@ -88,7 +89,7 @@ class SharedParametersLoaderTest {
     private static final String SECURITY_SERVER_ADDRESS = "security-server-address";
     private static final String SECURITY_SERVER_CODE = "SS1";
     private static final int SECURITY_SERVER_ID = 1;
-    private static final byte[] SECURITY_SERVER_AUTH_CERT = "auth cert".getBytes(UTF_8);
+    private static final CertHash SECURITY_SERVER_AUTH_CERT = new CertHash("auth cert".getBytes(UTF_8));
     private static final String GLOBAL_GROUP_CODE = "GG";
     private static final String GLOBAL_GROUP_DESCRIPTION = "GG description";
     private static final int GLOBAL_GROUP_ID = 2;
@@ -337,7 +338,7 @@ class SharedParametersLoaderTest {
         securityServer.setId(SECURITY_SERVER_ID);
         securityServer.setAddress(SECURITY_SERVER_ADDRESS);
         var authCert = new AuthCert();
-        authCert.setCert(SECURITY_SERVER_AUTH_CERT);
+        authCert.setCert("auth cert".getBytes(UTF_8));
         securityServer.setAuthCerts(Set.of(authCert));
         return List.of(securityServer);
     }

--- a/src/common/common-globalconf/build.gradle
+++ b/src/common/common-globalconf/build.gradle
@@ -14,5 +14,6 @@ dependencies {
     api project(':common:common-jetty')
 
     testImplementation project(':common:common-test')
+    testImplementation(libs.junit.jupiter.params)
 }
 

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/CertHash.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/CertHash.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.conf.globalconf;
+
+import ee.ria.xroad.common.util.CryptoUtils;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+
+@EqualsAndHashCode(doNotUseGetters = true)
+public class CertHash {
+    final byte[] cert;
+
+    final String algorithm;
+    final byte[] hash;
+
+    public CertHash(byte @NonNull [] cert) {
+        this.cert = cert;
+
+        this.algorithm = null;
+        this.hash = null;
+    }
+
+    public CertHash(@NonNull String algorithm, byte @NonNull [] hash) {
+        this.algorithm = algorithm;
+        this.hash = hash;
+
+        this.cert = null;
+    }
+
+    @SneakyThrows
+    public byte[] getHash(@NonNull String algorithmId) {
+        if (cert != null) {
+            return CryptoUtils.calculateDigest(algorithmId, cert);
+        } else if (algorithmId.equals(this.algorithm)) {
+            return hash;
+        }
+        throw new IllegalStateException("Hash for algorithm " + algorithmId + " is not available");
+    }
+
+    public byte[] getHash() {
+        if (hash != null) {
+            return hash;
+        }
+        throw new IllegalStateException("Default hash is not available");
+    }
+}

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParameters.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParameters.java
@@ -143,7 +143,7 @@ public class SharedParameters {
         private ClientId owner;
         private String serverCode;
         private String address;
-        private List<byte[]> authCertHashes;
+        private List<CertHash> authCertHashes;
         private List<ClientId> clients;
     }
 

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersCache.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersCache.java
@@ -138,8 +138,8 @@ public class SharedParametersCache {
 
     private void cacheSecurityServers() {
         for (SharedParameters.SecurityServer securityServer : sharedParameters.getSecurityServers()) {
-            for (byte[] certHash : securityServer.getAuthCertHashes()) {
-                serverByAuthCert.put(encodeBase64(certHash), securityServer);
+            for (CertHash certHash : securityServer.getAuthCertHashes()) {
+                serverByAuthCert.put(encodeBase64(certHash.getHash()), securityServer);
             }
 
             // Add owner of the security server
@@ -163,8 +163,8 @@ public class SharedParametersCache {
         }
 
         // Add the mapping from client to authentication certificate.
-        for (byte[] authCert : server.getAuthCertHashes()) {
-            addToMap(memberAuthCerts, client, authCert);
+        for (CertHash authCert : server.getAuthCertHashes()) {
+            addToMap(memberAuthCerts, client, authCert.getHash());
         }
 
         SecurityServerId securityServerId = SecurityServerId.Conf.create(

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2Converter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2Converter.java
@@ -47,6 +47,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA1_ID;
+
 public class SharedParametersV2Converter {
 
     SharedParameters convert(SharedParametersTypeV2 source) throws CertificateEncodingException, IOException {
@@ -188,7 +190,7 @@ public class SharedParametersV2Converter {
         target.setOwner(toClientId(instanceIdentifier, (MemberType) source.getOwner()));
         target.setServerCode(source.getServerCode());
         target.setAddress(source.getAddress());
-        target.setAuthCertHashes(source.getAuthCertHash());
+        target.setAuthCertHashes(source.getAuthCertHash().stream().map(hash -> new CertHash(SHA1_ID, hash)).toList());
         if (source.getClient() != null) {
             List<ClientId> clients = new ArrayList<>();
             for (JAXBElement<?> client : source.getClient()) {

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2ToXmlConverter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2ToXmlConverter.java
@@ -108,15 +108,15 @@ abstract class SharedParametersV2ToXmlConverter {
     }
 
     @Named("toAuthCertHashes")
-    protected List<byte[]> toAuthCertHashes(List<byte[]> authCerts) {
+    protected List<byte[]> toAuthCertHashes(List<CertHash> authCerts) {
         return authCerts.stream()
                 .map(this::toAuthCertHash)
                 .toList();
     }
 
     @SneakyThrows
-    private byte[] toAuthCertHash(byte[] authCert) {
-        return CryptoUtils.certSha1Hash(authCert);
+    private byte[] toAuthCertHash(CertHash authCert) {
+        return authCert.getHash(CryptoUtils.SHA1_ID);
     }
 
     private Map<ClientId, Object> createClientIdMap(SharedParameters sharedParameters) {

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3Converter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3Converter.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
+
 public class SharedParametersV3Converter {
 
     SharedParameters convert(SharedParametersTypeV3 source) throws CertificateEncodingException, IOException {
@@ -218,7 +220,7 @@ public class SharedParametersV3Converter {
         target.setOwner(toClientId(instanceIdentifier, (MemberType) source.getOwner()));
         target.setServerCode(source.getServerCode());
         target.setAddress(source.getAddress());
-        target.setAuthCertHashes(source.getAuthCertHash());
+        target.setAuthCertHashes(source.getAuthCertHash().stream().map(hash -> new CertHash(SHA256_ID, hash)).toList());
         if (source.getClient() != null) {
             List<ClientId> clients = new ArrayList<>();
             for (JAXBElement<?> client : source.getClient()) {

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3ToXmlConverter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3ToXmlConverter.java
@@ -118,15 +118,15 @@ abstract class SharedParametersV3ToXmlConverter {
     }
 
     @Named("toAuthCertHashes")
-    protected List<byte[]> toAuthCertHashes(List<byte[]> authCerts) {
+    protected List<byte[]> toAuthCertHashes(List<CertHash> authCerts) {
         return authCerts.stream()
                 .map(this::toAuthCertHash)
                 .toList();
     }
 
     @SneakyThrows
-    private byte[] toAuthCertHash(byte[] authCert) {
-        return CryptoUtils.certHash(authCert);
+    private byte[] toAuthCertHash(CertHash authCert) {
+        return authCert.getHash(CryptoUtils.SHA256_ID);
     }
 
     private Map<ClientId, Object> createClientIdMap(SharedParameters sharedParameters) {

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4Converter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4Converter.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
+
 public class SharedParametersV4Converter {
 
     SharedParameters convert(SharedParametersTypeV4 source) throws CertificateEncodingException, IOException {
@@ -220,7 +222,7 @@ public class SharedParametersV4Converter {
         target.setOwner(toClientId(instanceIdentifier, (MemberType) source.getOwner()));
         target.setServerCode(source.getServerCode());
         target.setAddress(source.getAddress());
-        target.setAuthCertHashes(source.getAuthCertHash());
+        target.setAuthCertHashes(source.getAuthCertHash().stream().map(hash -> new CertHash(SHA256_ID, hash)).toList());
         if (source.getClient() != null) {
             List<ClientId> clients = new ArrayList<>();
             for (JAXBElement<?> client : source.getClient()) {

--- a/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4ToXmlConverter.java
+++ b/src/common/common-globalconf/src/main/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4ToXmlConverter.java
@@ -118,15 +118,15 @@ abstract class SharedParametersV4ToXmlConverter {
     }
 
     @Named("toAuthCertHashes")
-    protected List<byte[]> toAuthCertHashes(List<byte[]> authCerts) {
+    protected List<byte[]> toAuthCertHashes(List<CertHash> authCerts) {
         return authCerts.stream()
                 .map(this::toAuthCertHash)
                 .toList();
     }
 
     @SneakyThrows
-    private byte[] toAuthCertHash(byte[] authCert) {
-        return CryptoUtils.certHash(authCert);
+    private byte[] toAuthCertHash(CertHash authCert) {
+        return authCert.getHash(CryptoUtils.SHA256_ID);
     }
 
     private Map<ClientId, Object> createClientIdMap(SharedParameters sharedParameters) {

--- a/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/CertHashTest.java
+++ b/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/CertHashTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.conf.globalconf;
+
+import org.junit.jupiter.api.Test;
+
+import static ee.ria.xroad.common.util.CryptoUtils.SHA1_ID;
+import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
+import static ee.ria.xroad.common.util.CryptoUtils.decodeBase64;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CertHashTest {
+    public static final byte[] CERT_BYTES = {1, 2, 3};
+    public static final byte[] SHA1_HASH = decodeBase64("cDeAcZjCKn0rCAc3HXY3eahP388=");
+    public static final byte[] SHA256_HASH = decodeBase64("A5BYxvLAy0ksUzsKTRTvd8wPeKvMztUofYShogEc+4E=");
+
+    @Test
+    void calculateHash() {
+        CertHash certHash = new CertHash(CERT_BYTES);
+
+        assertThat(certHash.getHash(SHA256_ID)).isEqualTo(SHA256_HASH);
+        assertThat(certHash.getHash(SHA1_ID)).isEqualTo(SHA1_HASH);
+    }
+
+    @Test
+    void getHash() {
+        CertHash certHash = new CertHash(SHA256_ID, SHA256_HASH);
+
+        var hash = certHash.getHash(SHA256_ID);
+
+        assertThat(hash).isEqualTo(SHA256_HASH);
+    }
+
+    @Test
+    void getHashInvalidAlgorithm() {
+        CertHash certHash = new CertHash(SHA256_ID, SHA256_HASH);
+
+        assertThatThrownBy(() -> certHash.getHash(SHA1_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Hash for algorithm " + SHA1_ID + " is not available");
+    }
+
+}

--- a/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersMarshallRoundTripTest.java
+++ b/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersMarshallRoundTripTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ee.ria.xroad.common.conf.globalconf;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Paths;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SharedParametersMarshallRoundTripTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "src/test/resources/globalconf_good_v4/EE/shared-params.xml",
+            "src/test/resources/globalconf_good_v3/EE/shared-params.xml",
+            "src/test/resources/globalconf_good_v2/EE/shared-params.xml"
+    })
+    void shouldEqualAfterXmlMarshalling(String sharedParamsPath) throws Exception {
+        var path = Paths.get(sharedParamsPath);
+        var version = VersionedConfigurationDirectory.getVersion(path);
+        var content = FileUtils.readFileToByteArray(path.toFile());
+        var parametersProviderFactory = ParametersProviderFactory.forGlobalConfVersion(version);
+        var sharedParametersProvider = parametersProviderFactory.sharedParametersProvider(content);
+
+        var initial = sharedParametersProvider.getSharedParameters();
+        var xml = sharedParametersProvider.getMarshaller().marshall(initial);
+        var afterMarshalling = parametersProviderFactory.sharedParametersProvider(xml.getBytes(UTF_8)).getSharedParameters();
+
+        assertThat(initial)
+                .usingRecursiveComparison()
+                .isEqualTo(afterMarshalling);
+
+    }
+
+
+}

--- a/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2ToXmlConverterTest.java
+++ b/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV2ToXmlConverterTest.java
@@ -29,7 +29,6 @@ package ee.ria.xroad.common.conf.globalconf;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v2.ObjectFactory;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v2.SharedParametersTypeV2;
 import ee.ria.xroad.common.identifier.ClientId;
-import ee.ria.xroad.common.util.CryptoUtils;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA1_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -100,7 +100,7 @@ class SharedParametersV2ToXmlConverterTest {
 
         assertIdReferences(xmlType);
         assertThat(xmlType.getSecurityServer().get(0).getAuthCertHash().get(0))
-                .isEqualTo(CryptoUtils.certSha1Hash(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0)));
+                .isEqualTo(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0).getHash(SHA1_ID));
     }
 
     @Test
@@ -192,7 +192,7 @@ class SharedParametersV2ToXmlConverterTest {
         securityServer.setServerCode("security-server-code");
         securityServer.setAddress("security-server-address");
         securityServer.setClients(List.of(subsystemId(memberId(), "SUB1")));
-        securityServer.setAuthCertHashes(List.of("ss-auth-cert".getBytes(UTF_8)));
+        securityServer.setAuthCertHashes(List.of(new CertHash("ss-auth-cert".getBytes(UTF_8))));
         return securityServer;
     }
 

--- a/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3ToXmlConverterTest.java
+++ b/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV3ToXmlConverterTest.java
@@ -29,7 +29,6 @@ package ee.ria.xroad.common.conf.globalconf;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v3.ObjectFactory;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v3.SharedParametersTypeV3;
 import ee.ria.xroad.common.identifier.ClientId;
-import ee.ria.xroad.common.util.CryptoUtils;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,7 +104,7 @@ class SharedParametersV3ToXmlConverterTest {
 
         assertIdReferences(xmlType);
         assertThat(xmlType.getSecurityServer().get(0).getAuthCertHash().get(0))
-                .isEqualTo(CryptoUtils.certHash(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0)));
+                .isEqualTo(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0).getHash(SHA256_ID));
     }
 
     @Test
@@ -205,7 +205,7 @@ class SharedParametersV3ToXmlConverterTest {
         securityServer.setServerCode("security-server-code");
         securityServer.setAddress("security-server-address");
         securityServer.setClients(List.of(subsystemId(memberId(), "SUB1")));
-        securityServer.setAuthCertHashes(List.of("ss-auth-cert".getBytes(UTF_8)));
+        securityServer.setAuthCertHashes(List.of(new CertHash("ss-auth-cert".getBytes(UTF_8))));
         return securityServer;
     }
 

--- a/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4ToXmlConverterTest.java
+++ b/src/common/common-globalconf/src/test/java/ee/ria/xroad/common/conf/globalconf/SharedParametersV4ToXmlConverterTest.java
@@ -29,7 +29,6 @@ package ee.ria.xroad.common.conf.globalconf;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v4.ObjectFactory;
 import ee.ria.xroad.common.conf.globalconf.sharedparameters.v4.SharedParametersTypeV4;
 import ee.ria.xroad.common.identifier.ClientId;
-import ee.ria.xroad.common.util.CryptoUtils;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static ee.ria.xroad.common.util.CryptoUtils.SHA256_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,7 +104,7 @@ class SharedParametersV4ToXmlConverterTest {
 
         assertIdReferences(xmlType);
         assertThat(xmlType.getSecurityServer().get(0).getAuthCertHash().get(0))
-                .isEqualTo(CryptoUtils.certHash(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0)));
+                .isEqualTo(sharedParameters.getSecurityServers().get(0).getAuthCertHashes().get(0).getHash(SHA256_ID));
     }
 
     @Test
@@ -205,7 +205,7 @@ class SharedParametersV4ToXmlConverterTest {
         securityServer.setServerCode("security-server-code");
         securityServer.setAddress("security-server-address");
         securityServer.setClients(List.of(subsystemId(memberId(), "SUB1")));
-        securityServer.setAuthCertHashes(List.of("ss-auth-cert".getBytes(UTF_8)));
+        securityServer.setAuthCertHashes(List.of(new CertHash("ss-auth-cert".getBytes(UTF_8))));
         return securityServer;
     }
 

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ springCloud-bom = { module = "org.springframework.cloud:spring-cloud-dependencie
 
 junit-jupiterEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 junit-vintageEngine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junitJupiter" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 
 xmlunit-core = { module = "org.xmlunit:xmlunit-core", version.ref = "xmlUnit" }
 xmlunit-matchers = { module = "org.xmlunit:xmlunit-matchers", version.ref = "xmlUnit" }


### PR DESCRIPTION
Security server authentication cert hashes were hashed again when global configuration was rewritten to disk. Bug appeared in configuration proxy federated setup.

Refs: XRDDEV-2534