### PR TITLE
fix: Remove double warning icon from diagnostics page

### DIFF
--- a/src/security-server/admin-service/ui/src/views/Diagnostics/DiagnosticsView.vue
+++ b/src/security-server/admin-service/ui/src/views/Diagnostics/DiagnosticsView.vue
@@ -444,16 +444,6 @@
                       location="right"
                     >
                       <template #activator="{ props }">
-                        <v-icon
-                          size="small"
-                          :class="
-                            messageLogEncryptionTooltipIconType(
-                              messageLogEnabled,
-                            )
-                          "
-                          v-bind="props"
-                          icon="icon-Error"
-                        />
                         <xrd-icon-base
                           v-bind="props"
                           :class="


### PR DESCRIPTION
Refs: XRDDEV-2603