### PR TITLE
fix: do not print out DB user password on backup

### DIFF
--- a/src/packages/src/xroad/common/center/usr/share/xroad/scripts/backup_db.sh
+++ b/src/packages/src/xroad/common/center/usr/share/xroad/scripts/backup_db.sh
@@ -20,8 +20,6 @@ if [[ -n "${ADMIN_USER}" && -n "${ADMIN_PASSWORD}" ]]; then
   PASSWORD=${ADMIN_PASSWORD}
 fi
 
-echo "$PASSWORD"
-
 # Reading custom libpq ENV variables
 if [ -f /etc/xroad/db_libpq.env ]; then
   source /etc/xroad/db_libpq.env


### PR DESCRIPTION
Refs: XRDSD-439