### PR TITLE
chore: fix hurl Dockerfile path in GMT usage_scenarios.yml broke with PR #2234

### DIFF
--- a/usage_scenario.yml
+++ b/usage_scenario.yml
@@ -19,6 +19,9 @@ services:
     volumes:
       - ./Docker/xrd-dev-stack/wiremock_mappings:/home/wiremock/mappings
   hurl:
+    build:
+      context: ./Docker/xrd-dev-stack/.
+      dockerfile: ./hurl/Dockerfile
     volumes:
       - ./Docker/xrd-dev-stack/hurl-src:/hurl-src:ro
       - ca-volume:/hurl-files/ca:ro


### PR DESCRIPTION
Updates `usage_scenarios.yml` to point to correct path the Hurl Dockerfile.