### PR TITLE
XRDDEV-2689: Ignore unknown ACME properties and adding ACME enabling info to sidecar documentation

### DIFF
--- a/doc/Sidecar/security_server_sidecar_user_guide.md
+++ b/doc/Sidecar/security_server_sidecar_user_guide.md
@@ -50,7 +50,7 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
   * [3.1 Enabling ACME Support](#31-enabling-acme-support)
 * [4 Upgrading](#4-upgrading)
   * [4.1 Upgrading from version 6.26.0 to 7.0.0](#41-upgrading-from-version-6260-to-700)
-  * [4.2 Upgrading from version 7.4.2 to 7.5.x with local database](4#2-Upgrading-from-version-742-to-75x-with-local-database)
+  * [4.2 Upgrading from version 7.4.2 to 7.5.x with local database](#42-Upgrading-from-version-742-to-75x-with-local-database)
 * [5 High Availability Setup](#5-high-availability-setup)
 
 <!-- vim-markdown-toc -->
@@ -340,7 +340,7 @@ See [IG-SS](#Ref_IG-SS) for configuration details.
 ### 3.1 Enabling ACME Support
 
 Automated Certificate Management Environment (ACME) protocol enables partly automated certificate management of the authentication and sign
-certificates on the Security Server. More information about the required configuration is available in the [Security Server User Guide](ug-ss_x-road_6_security_server_user_guide.md#24-configuring-acme).
+certificates on the Security Server. More information about the required configuration is available in the [Security Server User Guide](../Manuals/ug-ss_x-road_6_security_server_user_guide.md#24-configuring-acme).
 
 ## 4 Upgrading
 

--- a/doc/Sidecar/security_server_sidecar_user_guide.md
+++ b/doc/Sidecar/security_server_sidecar_user_guide.md
@@ -1,6 +1,6 @@
 # Security Server Sidecar User Guide <!-- omit in toc -->
 
-Version: 1.12  
+Version: 1.13  
 Doc. ID: UG-SS-SIDECAR
 
 ## Version history <!-- omit in toc -->
@@ -20,6 +20,7 @@ Doc. ID: UG-SS-SIDECAR
 | 06.07.2023 | 1.10    | Sidecar repo migration                                  | Eneli Reimets             |
 | 22.02.2024 | 1.11    | Local database files mapping with docker volume         | Eneli Reimets             |
 | 13.05.2024 | 1.12    | Add additional upgrade details for Sidecar 7.5          | Ovidijus Narkevicius      |
+| 22.08.2024 | 1.13    | Add a section about enabling ACME support               | Eneli Reimets             |
 
 ## License
 
@@ -46,8 +47,10 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
   * [2.8 Automatic backups](#28-automatic-backups)
   * [2.9 Message log archives](#29-message-log-archives)
 * [3 Initial configuration](#3-initial-configuration)
+  * [3.1 Enabling ACME Support](#31-enabling-acme-support)
 * [4 Upgrading](#4-upgrading)
   * [4.1 Upgrading from version 6.26.0 to 7.0.0](#41-upgrading-from-version-6260-to-700)
+  * [4.2 Upgrading from version 7.4.2 to 7.5.x with local database](4#2-Upgrading-from-version-742-to-75x-with-local-database)
 * [5 High Availability Setup](#5-high-availability-setup)
 
 <!-- vim-markdown-toc -->
@@ -126,11 +129,13 @@ The table below lists the required connections between different components.
 | Inbound    | Other Security Servers      | Sidecar                      | 5500, 5577       | tcp          |                         |
 | Inbound    | Consumer Information System | Sidecar                      | 8080, 8443       | tcp          | From "internal" network |
 | Inbound    | Admin                       | Sidecar                      | 4000             | https        | From "internal" network |
+| Inbound    | ACME Server                 | Sidecar                      | 80               | http         |                         |
 | Outbound   | Sidecar                     | Central Server               | 80, 4001         | http(s)      |                         |
 | Outbound   | Sidecar                     | OCSP Service                 | 80 / 443 / other | http(s)      |                         |
 | Outbound   | Sidecar                     | Timestamping Service         | 80 / 443 / other | http(s)      | Not used by *slim*      |
 | Outbound   | Sidecar                     | Other Security Server(s)     | 5500, 5577       | tcp          |                         |
 | Outbound   | Sidecar                     | Producer Information System  | 80, 443, other   | http(s)      | To "internal" network   |
+| Outbound   | Sidecar                     | ACME Server                  | 80 / 443         | http(s)      |                         |
 
 Notes:
 * Using a firewall to protect the Security Server is recommended. The firewall can be applied to both incoming and outgoing connections, depending on the security requirements of the environment where the Security Server will be deployed.
@@ -331,6 +336,11 @@ It is recommended to store the archives to a volume by adding a volume mapping f
 
 To configure the X-Road Security Server Sidecar, open a browser to `https://127.0.0.1:<admin port>` (assuming the container admin port 4000 is published to localhost) and log in using the admin credentials.
 See [IG-SS](#Ref_IG-SS) for configuration details.
+
+### 3.1 Enabling ACME Support
+
+Automated Certificate Management Environment (ACME) protocol enables partly automated certificate management of the authentication and sign
+certificates on the Security Server. More information about the required configuration is available in the [Security Server User Guide](ug-ss_x-road_6_security_server_user_guide.md#24-configuring-acme).
 
 ## 4 Upgrading
 

--- a/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -833,6 +833,10 @@ public final class SystemProperties {
         return Long.parseLong(System.getProperty(PROXY_UI_API_ACME_ACCOUNT_KEY_PAIR_EXPIRATION_IN_DAYS, "365"));
     }
 
+    public static boolean isAcmeChallengePortEnabled() {
+        return "true".equalsIgnoreCase(System.getProperty(PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED, "false"));
+    }
+
     /**
      * @return path to the configuration anchor file, '/etc/xroad/configuration-anchor.xml' by default.
      */

--- a/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -315,6 +315,7 @@ public final class SystemProperties {
     private static final String HSM_HEALTH_CHECK_ENABLED = PREFIX + "proxy.hsm-health-check-enabled";
 
     private static final String DEFAULT_HSM_HEALTH_CHECK_ENABLED = "false";
+    private static final String DEFAULT_PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED = "false";
     private static final String DEFAULT_PROXY_BACKUP_ENCRYPTED = "false";
     private static final String DEFAULT_CENTER_TRUSTED_ANCHORS_ALLOWED = "false";
 
@@ -834,7 +835,8 @@ public final class SystemProperties {
     }
 
     public static boolean isAcmeChallengePortEnabled() {
-        return "true".equalsIgnoreCase(System.getProperty(PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED, "false"));
+        return "true".equalsIgnoreCase(System.getProperty(PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED,
+                DEFAULT_PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED));
     }
 
     /**

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeConfig.java
@@ -70,7 +70,7 @@ public class AcmeConfig {
     public AcmeProperties acmeProperties() {
         Resource path = new FileSystemResource(SystemProperties.getConfPath() + "conf.d/acme.yml");
         if (!SystemProperties.isAcmeChallengePortEnabled() && !path.exists()) {
-            log.warn("Configuration {} not exists ", path);
+            log.warn("Configuration {} not exists", path);
             return new AcmeProperties();
         }
         Constructor constructor = createAcmeYamlConstructor();

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeConfig.java
@@ -69,12 +69,16 @@ public class AcmeConfig {
     @Bean
     public AcmeProperties acmeProperties() {
         Resource path = new FileSystemResource(SystemProperties.getConfPath() + "conf.d/acme.yml");
+        if (!SystemProperties.isAcmeChallengePortEnabled() && !path.exists()) {
+            log.warn("Configuration {} not exists ", path);
+            return new AcmeProperties();
+        }
         Constructor constructor = createAcmeYamlConstructor();
         Yaml yaml = new Yaml(constructor);
         try (InputStream input = Files.newInputStream(path.getFile().toPath())) {
             return yaml.loadAs(input, AcmeProperties.class);
         } catch (Exception e) {
-            log.warn("Failed to load yaml configuration from " + path, e);
+            log.warn("Failed to load yaml configuration from {}", path, e);
             return new AcmeProperties();
         }
     }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeProperties.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeProperties.java
@@ -25,6 +25,7 @@
  */
 package org.niis.xroad.securityserver.restapi.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 import org.niis.xroad.common.exception.NotFoundException;
@@ -36,6 +37,7 @@ import static org.niis.xroad.securityserver.restapi.service.AcmeDeviationMessage
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AcmeProperties {
 
     private EabCredentials eabCredentials;

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeProperties.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeProperties.java
@@ -25,7 +25,6 @@
  */
 package org.niis.xroad.securityserver.restapi.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 import org.niis.xroad.common.exception.NotFoundException;
@@ -37,7 +36,6 @@ import static org.niis.xroad.securityserver.restapi.service.AcmeDeviationMessage
 
 @Getter
 @Setter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AcmeProperties {
 
     private EabCredentials eabCredentials;

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AcmeConfigTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AcmeConfigTest.java
@@ -1,11 +1,36 @@
+/*
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.niis.xroad.securityserver.restapi.config;
+
+import ee.ria.xroad.common.SystemProperties;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-
-import ee.ria.xroad.common.SystemProperties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AcmeConfigTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/config/AcmeConfigTest.java
@@ -1,0 +1,60 @@
+package org.niis.xroad.securityserver.restapi.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import ee.ria.xroad.common.SystemProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AcmeConfigTest {
+    private AcmeConfig acmeConfig;
+
+    private ListAppender<ILoggingEvent> appender;
+    private final Logger logger = (Logger) LoggerFactory.getLogger(AcmeConfig.class);
+
+    @Before
+    public void setup() {
+        acmeConfig = new AcmeConfig();
+
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @After
+    public void teardown() {
+        logger.detachAppender(appender);
+        appender.stop();
+    }
+
+
+    @Test
+    public void whenProxyUiApiAcmeChallengePortEnabledAndAcmeYmlNotExists() {
+        System.setProperty(SystemProperties.PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED, "true");
+
+        acmeConfig.acmeProperties();
+
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(0).getMessage()).isEqualTo("Failed to load yaml configuration from {}");
+    }
+
+    @Test
+    public void whenProxyUiApiAcmeChallengePortNotEnabledAndAcmeYmlNotExists() {
+        System.setProperty(SystemProperties.PROXY_UI_API_ACME_CHALLENGE_PORT_ENABLED, "false");
+
+        acmeConfig.acmeProperties();
+
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(0).getMessage()).isEqualTo("Configuration {} not exists");
+
+    }
+}


### PR DESCRIPTION
Refs: XRDDEV-2689