### PR TITLE
chore: Enable compiler warnings and apply minor fixes

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -102,6 +102,11 @@ configure(subprojects.findAll { !["shared-ui", "ui"].contains(it.name) }) {
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = "UTF-8"
+        // options.compilerArgs << "-Xlint:unchecked"
+        // options.compilerArgs << "-Xlint:deprecation"
+        // options.compilerArgs << "-Xlint:rawtypes"
+        options.compilerArgs << "-Xlint:fallthrough"
+        options.compilerArgs << "-Xlint:finally"
         options.compilerArgs << '-parameters'
     }
 

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -103,8 +103,8 @@ configure(subprojects.findAll { !["shared-ui", "ui"].contains(it.name) }) {
     tasks.withType(JavaCompile).configureEach {
         options.encoding = "UTF-8"
         // options.compilerArgs << "-Xlint:unchecked"
-        options.compilerArgs << "-Xlint:deprecation"
-        options.compilerArgs << "-Xlint:rawtypes"
+        // options.compilerArgs << "-Xlint:deprecation"
+        // options.compilerArgs << "-Xlint:rawtypes"
         options.compilerArgs << "-Xlint:fallthrough"
         options.compilerArgs << "-Xlint:finally"
         options.compilerArgs << '-parameters'

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -103,7 +103,7 @@ configure(subprojects.findAll { !["shared-ui", "ui"].contains(it.name) }) {
     tasks.withType(JavaCompile).configureEach {
         options.encoding = "UTF-8"
         // options.compilerArgs << "-Xlint:unchecked"
-        // options.compilerArgs << "-Xlint:deprecation"
+        options.compilerArgs << "-Xlint:deprecation"
         options.compilerArgs << "-Xlint:rawtypes"
         options.compilerArgs << "-Xlint:fallthrough"
         options.compilerArgs << "-Xlint:finally"

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -104,7 +104,7 @@ configure(subprojects.findAll { !["shared-ui", "ui"].contains(it.name) }) {
         options.encoding = "UTF-8"
         // options.compilerArgs << "-Xlint:unchecked"
         // options.compilerArgs << "-Xlint:deprecation"
-        // options.compilerArgs << "-Xlint:rawtypes"
+        options.compilerArgs << "-Xlint:rawtypes"
         options.compilerArgs << "-Xlint:fallthrough"
         options.compilerArgs << "-Xlint:finally"
         options.compilerArgs << '-parameters'

--- a/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/TargetTypeResolver.java
+++ b/src/central-server/admin-service/infra-api-rest/src/main/java/org/niis/xroad/cs/admin/rest/api/security/TargetTypeResolver.java
@@ -28,7 +28,7 @@ package org.niis.xroad.cs.admin.rest.api.security;
 
 import java.io.Serializable;
 
-public interface TargetTypeResolver<E extends Enum> {
+public interface TargetTypeResolver<E extends Enum<E>> {
 
     boolean canResolve(String targetType, Serializable id);
 

--- a/src/common/common-core/src/main/java/ee/ria/xroad/common/util/MimeUtils.java
+++ b/src/common/common-core/src/main/java/ee/ria/xroad/common/util/MimeUtils.java
@@ -168,7 +168,7 @@ public final class MimeUtils {
      * @return random boundary for use with MIME multiparts.
      */
     public static String randomBoundary() {
-        return RandomStringUtils.randomAlphabetic(RANDOM_BOUNDARY_LENGTH);
+        return RandomStringUtils.secure().nextAlphabetic(RANDOM_BOUNDARY_LENGTH);
     }
 
 }

--- a/src/proxy/application/src/intTest/java/org/niis/xroad/proxy/test/glue/ProxyStepDefs.java
+++ b/src/proxy/application/src/intTest/java/org/niis/xroad/proxy/test/glue/ProxyStepDefs.java
@@ -146,7 +146,7 @@ public class ProxyStepDefs extends BaseStepDefs {
 
         List<String> messages = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            messages.add("random-msg:" + RandomStringUtils.randomAlphabetic(100, 1000));
+            messages.add("random-msg:" + RandomStringUtils.secure().nextAlphabetic(100, 1000));
         }
 
         List<Callable<BatchSignResult>> callables = new ArrayList<>();

--- a/src/proxy/application/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
+++ b/src/proxy/application/src/main/java/ee/ria/xroad/proxy/clientproxy/ClientRestMessageProcessor.java
@@ -191,7 +191,7 @@ class ClientRestMessageProcessor extends AbstractClientMessageProcessor {
         // Add unique id to distinguish request/response pairs
         httpSender.addHeader(HEADER_REQUEST_ID, xRequestId);
 
-        final String contentType = MimeUtils.mpMixedContentType("xtop" + RandomStringUtils.randomAlphabetic(30));
+        final String contentType = MimeUtils.mpMixedContentType("xtop" + RandomStringUtils.secure().nextAlphabetic(30));
         opMonitoringData.setRequestOutTs(getEpochMillisecond());
         httpSender.doPost(getServiceAddress(addresses), new ProxyMessageEntity(contentType));
         opMonitoringData.setResponseInTs(getEpochMillisecond());

--- a/src/proxy/application/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactory.java
+++ b/src/proxy/application/src/main/java/ee/ria/xroad/proxy/clientproxy/FastestConnectionSelectingSSLSocketFactory.java
@@ -121,7 +121,7 @@ class FastestConnectionSelectingSSLSocketFactory
 
         if (log.isTraceEnabled()) {
             log.trace("addresses from context {} current thread id {}", addressesFromContext,
-                    Thread.currentThread().getId());
+                    Thread.currentThread().threadId());
         }
 
         // If URI cache is enabled, check for a previously selected host, avoiding the selection process.

--- a/src/proxy/application/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
+++ b/src/proxy/application/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
@@ -508,6 +508,7 @@ public class ProxyMessageDecoder {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void handleSignature(BodyDescriptor bd, InputStream is)
             throws CodedException {
         try {

--- a/src/proxy/application/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
+++ b/src/proxy/application/src/main/java/ee/ria/xroad/proxy/protocol/ProxyMessageDecoder.java
@@ -256,6 +256,7 @@ public class ProxyMessageDecoder {
         }
 
         @Override
+        @SuppressWarnings("fallthrough")
         public void body(BodyDescriptor bd, InputStream is)
                 throws MimeException, IOException {
             LOG.trace("body({}), next = {}", bd.getMimeType(), nextPart);

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/EndpointsApiController.java
@@ -91,7 +91,7 @@ public class EndpointsApiController implements EndpointsApi {
         } catch (EndpointNotFoundException e) {
             throw new ResourceNotFoundException(NOT_FOUND_ERROR_MSG + " " + id);
         }
-        return new ResponseEntity(endpoint, HttpStatus.OK);
+        return new ResponseEntity<>(endpoint, HttpStatus.OK);
     }
 
     @Override

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiController.java
@@ -72,7 +72,7 @@ public class MemberClassesApiController implements MemberClassesApi {
         if (!globalConfProvider.getInstanceIdentifiers().contains(instanceId)) {
             throw new ResourceNotFoundException("instance identifier not found: " + instanceId);
         }
-        Set<String> memberClasses = new HashSet(globalConfProvider.getMemberClasses(instanceId));
+        Set<String> memberClasses = new HashSet<>(globalConfProvider.getMemberClasses(instanceId));
         return new ResponseEntity<>(memberClasses, HttpStatus.OK);
     }
 }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AccessRightService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/AccessRightService.java
@@ -326,7 +326,7 @@ public class AccessRightService {
         validateServiceClientObjectType(subjectId);
 
         // verify that given service client objects exist, otherwise access cannot be added
-        identifierService.verifyServiceClientObjectsExist(clientType, new HashSet(Arrays.asList(subjectId)));
+        identifierService.verifyServiceClientObjectsExist(clientType, new HashSet<>(Arrays.asList(subjectId)));
 
         // prepare params for addAccessRightsInternal
         List<EndpointType> baseEndpoints = null;

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverterTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/converter/PossibleActionConverterTest.java
@@ -63,10 +63,10 @@ public class PossibleActionConverterTest {
 
     @Test
     public void convertAll() {
-        Set<PossibleAction> allItemsConverted = new HashSet(
+        Set<PossibleAction> allItemsConverted = new HashSet<>(
                 new PossibleActionConverter()
                         .convert(Arrays.asList(PossibleActionEnum.values())));
-        Set<PossibleAction> allOpenApiValues = new HashSet(
+        Set<PossibleAction> allOpenApiValues = new HashSet<>(
                 Arrays.asList(PossibleAction.values()));
         assertTrue(allOpenApiValues.containsAll(allItemsConverted));
         assertTrue(allItemsConverted.containsAll(allOpenApiValues));

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ApiValidationRestTemplateTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/ApiValidationRestTemplateTest.java
@@ -66,7 +66,7 @@ public class ApiValidationRestTemplateTest extends AbstractApiControllerTestCont
     @WithMockUser(authorities = {"ADD_LOCAL_GROUP"})
     public void validationWorksForAddLocalGroup() throws Exception {
         LocalGroupAdd groupWithTooLongCode = new LocalGroupAdd()
-                .code(RandomStringUtils.randomAlphabetic(256))
+                .code(RandomStringUtils.secure().nextAlphabetic(256))
                 .description("foo");
         ResponseEntity<Object> response = restTemplate.postForEntity(
                 "/api/v1/clients/FOO:BAR:BAZ:NONEXISTENT-CLIENT/local-groups",

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/KeysApiControllerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/KeysApiControllerTest.java
@@ -144,7 +144,7 @@ public class KeysApiControllerTest extends AbstractApiControllerTestContext {
         ResponseEntity<List<PossibleAction>> response = keysApiController
                 .getPossibleActionsForCsr(GOOD_SIGN_KEY_ID, GOOD_CSR_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Set<PossibleAction> allActions = new HashSet(Arrays.asList(PossibleAction.values()));
+        Set<PossibleAction> allActions = new HashSet<>(Arrays.asList(PossibleAction.values()));
         assertEquals(allActions, new HashSet<>(response.getBody()));
     }
 
@@ -154,7 +154,7 @@ public class KeysApiControllerTest extends AbstractApiControllerTestContext {
         ResponseEntity<List<PossibleAction>> response = keysApiController
                 .getPossibleActionsForKey(GOOD_SIGN_KEY_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Set<PossibleAction> allActions = new HashSet(Arrays.asList(PossibleAction.values()));
+        Set<PossibleAction> allActions = new HashSet<>(Arrays.asList(PossibleAction.values()));
         assertEquals(allActions, new HashSet<>(response.getBody()));
     }
 

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/MemberClassesApiControllerIntegrationTest.java
@@ -83,7 +83,7 @@ public class MemberClassesApiControllerIntegrationTest extends AbstractApiContro
                     if (classes == null) {
                         return new HashSet<>();
                     }
-                    return new HashSet(classes);
+                    return new HashSet<>(classes);
                 });
 
         when(globalConfProvider.getMemberClasses())

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TokenCertificatesApiControllerIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/openapi/TokenCertificatesApiControllerIntegrationTest.java
@@ -500,7 +500,7 @@ public class TokenCertificatesApiControllerIntegrationTest extends AbstractApiCo
         ResponseEntity<List<PossibleAction>> response = tokenCertificatesApiController
                 .getPossibleActionsForCertificate(MOCK_CERTIFICATE_HASH);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Set<PossibleAction> allActions = new HashSet(Arrays.asList(PossibleAction.values()));
+        Set<PossibleAction> allActions = new HashSet<>(Arrays.asList(PossibleAction.values()));
         assertEquals(allActions, new HashSet<>(response.getBody()));
     }
 

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ClientServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/ClientServiceIntegrationTest.java
@@ -1255,7 +1255,7 @@ public class ClientServiceIntegrationTest extends AbstractServiceIntegrationTest
 
     @Test
     public void getLocalClientMemberIds() {
-        Set<ClientId> expected = new HashSet();
+        Set<ClientId> expected = new HashSet<>();
         expected.add(ClientId.Conf.create(INSTANCE_FI,
                 MEMBER_CLASS_GOV, TestUtils.MEMBER_CODE_M1));
         expected.add(ClientId.Conf.create(INSTANCE_FI,

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/OrphanRemovalServiceTest.java
@@ -219,7 +219,7 @@ public class OrphanRemovalServiceTest extends AbstractServiceTestContext {
             clientType.setIdentifier(id);
             localClients.put(id, clientType);
         });
-        doReturn(new ArrayList(localClients.values())).when(clientRepository).getAllLocalClients();
+        doReturn(new ArrayList<>(localClients.values())).when(clientRepository).getAllLocalClients();
         doAnswer(invocation -> {
             ClientId clientId = (ClientId) invocation.getArguments()[0];
             return localClients.get(clientId);

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenCertificateServiceTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/TokenCertificateServiceTest.java
@@ -511,7 +511,7 @@ public class TokenCertificateServiceTest {
     @Test(expected = ActionNotPossibleException.class)
     @WithMockUser(authorities = {"DELETE_SIGN_CERT", "DELETE_AUTH_CERT"})
     public void deleteCertificateActionNotPossible() throws Exception {
-        EnumSet empty = EnumSet.noneOf(PossibleActionEnum.class);
+        EnumSet<PossibleActionEnum> empty = EnumSet.noneOf(PossibleActionEnum.class);
         doReturn(empty).when(possibleActionsRuleEngine).getPossibleCertificateActions(any(), any(), any());
         tokenCertificateService.deleteCertificate(EXISTING_CERT_HASH);
     }
@@ -724,7 +724,7 @@ public class TokenCertificateServiceTest {
 
     @Test(expected = ActionNotPossibleException.class)
     public void registerAuthCertificateNotPossible() throws Exception {
-        EnumSet empty = EnumSet.noneOf(PossibleActionEnum.class);
+        EnumSet<PossibleActionEnum> empty = EnumSet.noneOf(PossibleActionEnum.class);
         doReturn(empty).when(possibleActionsRuleEngine).getPossibleCertificateActions(any(), any(), any());
         doAnswer(answer -> authCert).when(signerProxyFacade).getCertForHash(any());
         tokenCertificateService.registerAuthCert(CertificateTestUtils.MOCK_AUTH_CERTIFICATE_HASH, GOOD_ADDRESS);

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TestUtils.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/util/TestUtils.java
@@ -243,7 +243,7 @@ public final class TestUtils {
      * @param endpointPath for example "/api/service-descriptions/12"
      * @param response
      */
-    public static void assertLocationHeader(String endpointPath, ResponseEntity response) {
+    public static <T> void assertLocationHeader(String endpointPath, ResponseEntity<T> response) {
         assertEquals(Collections.singletonList(TEST_API_URL + endpointPath),
                 response.getHeaders().get("Location"));
     }
@@ -255,7 +255,7 @@ public final class TestUtils {
      *
      * @param response
      */
-    public static void assertMissingLocationHeader(ResponseEntity response) {
+    public static <T> void assertMissingLocationHeader(ResponseEntity<T> response) {
         List<String> locationHeaders = response.getHeaders().get("Location");
         assertNull(locationHeaders);
     }

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidatorTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/wsdl/WsdlValidatorTest.java
@@ -89,6 +89,6 @@ public class WsdlValidatorTest {
     @Test
     public void shouldPassValidation() throws Exception {
         List<String> warnings = wsdlValidator.executeValidator("src/test/resources/wsdl/testservice.wsdl");
-        assertEquals(new ArrayList(), warnings);
+        assertEquals(new ArrayList<String>(), warnings);
     }
 }


### PR DESCRIPTION
* Add compilerArgument to the JavaTask in Gradle to enable different compilation warnings. e.g., `unchecked`, `deprecation`, etc.
* Fix minor warnings that does not affect the behavior
* Comment out some of the warnings to reduce logs until proper fix is applied