### PR TITLE
fix: Test CA and CS nginx mismatch causes testservers to fail when setup

### DIFF
--- a/src/packages/src/xroad/ubuntu/generic/control
+++ b/src/packages/src/xroad/ubuntu/generic/control
@@ -46,7 +46,7 @@ Description: X-Road configuration client components
 
 Package: xroad-nginx
 Architecture: amd64 arm64
-Pre-Depends: nginx-light (>=1.5.10)
+Pre-Depends: nginx-light (>=1.5.10) | nginx-core (>=1.5.10)
 Depends: ${misc:Depends}, xroad-base (=${binary:Version})
 Replaces: xroad-common (<= 6.17.0-0.20171018082348git2ecf68ed)
 Breaks: xroad-common (<= 6.17.0-0.20171018082348git2ecf68ed)


### PR DESCRIPTION
acme2certifier used by Test CA uses nginx module that is missing from nginx-light, but present in nginx-core. But on some of our testservers Test CA and CS sit on the same server and CS install adds nginx-light, since it is it's dependency. It does that even when nginx-core is already present. Nginx-light installation removes nginx-core and vice versa. 
This change adds nginx-core as an alternative dependency so that when it is present on the server, it doesn't add nginx-light, which makes sense, because nginx-core already has all the functionality that nginx-light has. 
When installing CS without neither nginx versions present, it installed nginx-light like before (Tested on local docker container with Noble.)