### PR TITLE
feat: Acme challenge improvements based on security audit

### DIFF
--- a/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/util/CommonDeviationMessage.java
+++ b/src/common/common-domain/src/main/java/org/niis/xroad/common/exception/util/CommonDeviationMessage.java
@@ -53,6 +53,7 @@ public enum CommonDeviationMessage implements DeviationProvider {
 
     ERROR_RESOURCE_READ("resource_read_failed", "Failed to read resource"),
     ERROR_INVALID_ADDRESS_CHAR("invalid_address_char", "Address contains invalid characters"),
+    INVALID_URL("invalid_url", "Invalid url"),
 
     ANCHOR_NOT_FOR_EXTERNAL_SOURCE("conf_verification.anchor_not_for_external_source",
             "Configuration verification failed: anchor_not_for_external_source"),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeChallangeFilter.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeChallangeFilter.java
@@ -50,6 +50,11 @@ public class AcmeChallangeFilter implements Filter {
             ((HttpServletResponse) response).sendError(404);
             return;
         }
+        if (request.getServerPort() != 80 && isAcmeChallenge) {
+            log.warn("ACME challenge endpoint should not be accessible from any port other than 80!");
+            ((HttpServletResponse) response).sendError(404);
+            return;
+        }
         chain.doFilter(request, response);
     }
 }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/AcmeChallengeController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/controller/AcmeChallengeController.java
@@ -25,6 +25,7 @@
  */
 package org.niis.xroad.securityserver.restapi.controller;
 
+import org.niis.xroad.common.exception.ValidationFailureException;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,16 +33,24 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.niis.xroad.common.exception.util.CommonDeviationMessage.INVALID_URL;
 
 @RestController
 public class AcmeChallengeController {
 
     @GetMapping(value = "/.well-known/acme-challenge/{token}")
     public ResponseEntity<String> getChallenge(@PathVariable("token") String token) throws IOException {
-        FileSystemResource fileSystemResource = new FileSystemResource("/etc/xroad/acme-challenge/" + token);
-        return new ResponseEntity<>(fileSystemResource.getContentAsString(Charset.defaultCharset()), HttpStatus.OK);
+        String baseDirectory = "/etc/xroad/acme-challenge";
+        File file = new File(baseDirectory, token);
+        if (!file.getParent().equals(baseDirectory)) {
+            throw new ValidationFailureException(INVALID_URL);
+        }
+        FileSystemResource fileSystemResource = new FileSystemResource(file);
+        return new ResponseEntity<>(fileSystemResource.getContentAsString(StandardCharsets.UTF_8), HttpStatus.OK);
     }
 
 }


### PR DESCRIPTION
As a Developer I want to disable port 4000 for ACME challenges so that we don't expose it needlessly;
As a Developer I want to harden the way we handle use input in ACME challenges so that we don't leave a potential opening in the future

refs: XRDDEV-2732, XRDDEV-2733