### PR TITLE
chore: update references of palveluvayla.com to x-road.global in documentation

### DIFF
--- a/doc/EnvironmentalMonitoring/Monitoring-architecture.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-architecture.md
@@ -234,7 +234,7 @@ xmlns:prod="http://vrk-test.x-road.fi/producer">
 </SOAP-ENV:Envelope>
 ```
 
-For monitoring queries this is not enough. In a clustered security server configuration, one service can be served from multiple security servers. When X-Road routes the message, it picks one candidate based on which one answers the quickest. When executing monitoring queries, we need to be able to fetch monitoring data from a specific security server in a cluster. To make this possible the Security server targeting extension for the X-Road message protocol \[[PR-TARGETSS](#12-references)\] is used, which adds a new SOAP header element `securityServer`. Using this element, the caller identifies which security server should respond with the monitoring data (`servercode` = `fdev-ss1.i.palveluvayla.com`). To execute a query, we call service `getSecurityServerMetrics`:
+For monitoring queries this is not enough. In a clustered security server configuration, one service can be served from multiple security servers. When X-Road routes the message, it picks one candidate based on which one answers the quickest. When executing monitoring queries, we need to be able to fetch monitoring data from a specific security server in a cluster. To make this possible the Security server targeting extension for the X-Road message protocol \[[PR-TARGETSS](#12-references)\] is used, which adds a new SOAP header element `securityServer`. Using this element, the caller identifies which security server should respond with the monitoring data (`servercode` = `fdev-ss1.i.x-road.global`). To execute a query, we call service `getSecurityServerMetrics`:
 
 ```xml
 <SOAP-ENV:Envelope
@@ -258,7 +258,7 @@ For monitoring queries this is not enough. In a clustered security server config
             <id:xRoadInstance>fdev</id:xRoadInstance>
             <id:memberClass>GOV</id:memberClass>
             <id:memberCode>1710128-9</id:memberCode>
-            <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+            <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
         </xrd:securityServer>
         <xrd:id>ID11234</xrd:id>
         <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -293,7 +293,7 @@ The response looks like:
          <id:xRoadInstance>fdev</id:xRoadInstance>
          <id:memberClass>GOV</id:memberClass>
          <id:memberCode>1710128-9</id:memberCode>
-         <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+         <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
       </xrd:securityServer>
       <xrd:id>ID11234</xrd:id>
       <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -302,7 +302,7 @@ The response looks like:
    <SOAP-ENV:Body>
       <m:getSecurityServerMetricsResponse>
          <m:metricSet>
-            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.palveluvayla.com</m:name>
+            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.x-road.global</m:name>
             <m:stringMetric>
                <m:name>proxyVersion</m:name>
                <m:value>6.7.7-1.20151201075839gitb72b28e</m:value>

--- a/doc/EnvironmentalMonitoring/Monitoring-messages.md
+++ b/doc/EnvironmentalMonitoring/Monitoring-messages.md
@@ -81,7 +81,7 @@ An optional `outputSpec` child element can be used to request a subset of the me
             <id:xRoadInstance>fdev</id:xRoadInstance>
             <id:memberClass>GOV</id:memberClass>
             <id:memberCode>1710128-9</id:memberCode>
-            <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+            <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
         </xrd:securityServer>
 
         <xrd:id>ID11234</xrd:id>
@@ -128,7 +128,7 @@ The response `Body` contains one `getSecurityServerMetricsResponse` element whic
          <id:xRoadInstance>fdev</id:xRoadInstance>
          <id:memberClass>GOV</id:memberClass>
          <id:memberCode>1710128-9</id:memberCode>
-         <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+         <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
       </xrd:securityServer>
       <xrd:id>ID11234</xrd:id>
       <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -137,7 +137,7 @@ The response `Body` contains one `getSecurityServerMetricsResponse` element whic
    <SOAP-ENV:Body>
       <m:getSecurityServerMetricsResponse>
          <m:metricSet>
-            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.palveluvayla.com</m:name>
+            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.x-road.global</m:name>
             <m:stringMetric>
                <m:name>proxyVersion</m:name>
                <m:value>6.7.7-1.20151201075839gitb72b28e</m:value>

--- a/doc/Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md
+++ b/doc/Protocols/SecurityServerExtension/pr-targetss_security_server_targeting_extension_for_the_x-road_protocol.md
@@ -178,7 +178,7 @@ Below are examples from a request and response related to the Environmental Moni
             <id:xRoadInstance>fdev</id:xRoadInstance>
             <id:memberClass>GOV</id:memberClass>
             <id:memberCode>1710128-9</id:memberCode>
-            <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+            <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
         </xrd:securityServer>
         <xrd:id>ID11234</xrd:id>
         <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -211,7 +211,7 @@ Below are examples from a request and response related to the Environmental Moni
          <id:xRoadInstance>fdev</id:xRoadInstance>
          <id:memberClass>GOV</id:memberClass>
          <id:memberCode>1710128-9</id:memberCode>
-         <id:serverCode>fdev-ss1.i.palveluvayla.com</id:serverCode>
+         <id:serverCode>fdev-ss1.i.x-road.global</id:serverCode>
       </xrd:securityServer>
       <xrd:id>ID11234</xrd:id>
       <xrd:protocolVersion>4.0</xrd:protocolVersion>
@@ -220,7 +220,7 @@ Below are examples from a request and response related to the Environmental Moni
    <SOAP-ENV:Body>
       <m:getSecurityServerMetricsResponse>
          <m:metricSet>
-            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.palveluvayla.com</m:name>
+            <m:name>SERVER:fdev/GOV/1710128-9/fdev-ss1.i.x-road.global</m:name>
             <m:stringMetric>
                <m:name>proxyVersion</m:name>
                <m:value>6.7.7-1.20151201075839gitb72b28e</m:value>


### PR DESCRIPTION
The domain palveluvayla.com will no longer be maintained, so migrating documentation examples to reference x-road.global.