### PR TITLE
chore: fix issues in X-Road documentation

### DIFF
--- a/doc/DataModels/dm-cs_x-road_central_server_configuration_data_model.md
+++ b/doc/DataModels/dm-cs_x-road_central_server_configuration_data_model.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server Configuration Data Model
 
-Version: 1.13  
+Version: 1.14
 Doc. ID: DM-CS
 
 | Date       | Version | Description                                                                      | Author               |
@@ -27,6 +27,7 @@ Doc. ID: DM-CS
 | 30.05.2023 | 1.11    | Remove security_server_client_names table                                        | Ovidijus Narkevičius | 
 | 14.06.2023 | 1.12    | New Central Server updates                                                       | Eneli Reimets        |
 | 08.12.2023 | 1.13    | Added enabled field to server_clients table                                      | Madis Loitmaa        |
+| 09.01.2025 | 1.14    | Restructure heading levels to work better with the documentation platform        | Raido Kaju           |
 
 ## Table of Contents
 
@@ -114,13 +115,13 @@ Doc. ID: DM-CS
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# 1 General
+## 1 General
 
-## 1.1 Preamble
+### 1.1 Preamble
 
 This document describes the database model of the X-Road Central Server.
 
-## 1.2 Terms and abbreviations
+### 1.2 Terms and abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
@@ -128,17 +129,17 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
-## 1.4 Database Version
+### 1.4 Database Version
 
 This database assumes PostgreSQL version 12 or later. Default settings are used in simple setup, while a custom configuration is used in HA setup.
 
-## 1.5 Creating, Backing Up and Restoring the Database
+### 1.5 Creating, Backing Up and Restoring the Database
 
 This database is integrated into X-Road Central Server application. The database management functions are embedded into the application user interface.
 The database, the database user and the data model is created by the application's installer. The database updates are packaged as application updates and are applied when the application is upgraded. From the technical point of view, the database structure is created and updated using [Liquibase](http://www.liquibase.org/) tool. The migration scripts can be found both in application source and in file system of the installed application.
 Database backup functionality is built into the application. The backup operation can be invoked from the web-based user interface or from the command line. The backup contains dump of all the database structure and contents. When restoring the application, first the software is installed and then the configuration database is restored together with all the other necessary files. This produces a working Central Server.
 
-## 1.6 Saving Database History
+### 1.6 Saving Database History
 
 This section describes the general mechanism for storing the history of the database tables. All the history-aware tables have an associated trigger update_history that records all the modifications to data. All the tables of central database are history-aware, except for
 
@@ -147,7 +148,7 @@ This section describes the general mechanism for storing the history of the data
 
 When a row is created, updated or deleted in one of the history-aware tables, the trigger update_history is activated and invokes the stored procedure add_history_rows. For each changed column, add_history_rows inserts a row into the history table. The details of the stored procedures are described in section 1.9.
 
-## 1.7 High Availability Support
+### 1.7 High Availability Support
 
 The High Availability (HA) solution for the X-Road Central Server relies on a shared, optionally highly available database. There can be multiple Central Server nodes each connecting to the same database instance. Furthermore, the database can be set up in high-availability mode where there is the primary node with read/write access and one or more secondary read-only nodes replicating the primary data as it changes.
 
@@ -157,7 +158,7 @@ The logic of taking into account the value of ha_node_name where applicable, has
 
 Database history records are aware of the node name in an HA setup and are replicated just like other records. Thus each node contains the full history of database changes. Because replication events happen at a lower level than insertions of records, the replication of history records themselves does not trigger any subsequent insertions of history records on target nodes.
 
-## 1.8 Entity-Relationship Diagram
+### 1.8 Entity-Relationship Diagram
 
 The data model is described in two entity relationship diagrams (ERD). The first diagram contains tables related to Security Servers and Security Server clients. The second diagram contains the rest of the tables.
 
@@ -165,7 +166,7 @@ The data model is described in two entity relationship diagrams (ERD). The first
 
 Figure 1. ERD describing the database tables in the Central Server database
 
-## 1.9 List of Stored Procedures
+### 1.9 List of Stored Procedures
 
 The following stored procedures are present in the database, regardless of whether a given Central Server has been installed in standalone or HA setup.
 
@@ -175,28 +176,28 @@ The following stored procedures are present in the database, regardless of wheth
 - the default value in standalone systems
 - the name of the cluster node that initiated the insertion, in an HA setup.
 
-## 1.10 List of Triggers
+### 1.10 List of Triggers
 
 The following triggers are present in the database, regardless of whether a given Central Server has been installed in standalone or HA setup.
 
 1. `update_history`: Invokes the `add_history_rows` stored procedure upon insertions, updates and deletions of records. Created for each history-aware table.
 2. `insert_node_name`: Invokes the `insert_node_name` stored procedure upon insertions. Created for each table with the ha_node_name field.
 
-# 2 Description of Entities
+## 2 Description of Entities
 
-## 2.1 ANCHOR_URL_CERTS
+### 2.1 ANCHOR_URL_CERTS
 
 Certificate belonging to a configuration source that is represented in database by an anchor URL. The certificates are used to verify signed configuration downloaded from a given URL.
 
 The record is created when an X-Road security officer has received trusted anchor from federation partner and uploads it in the user interface. The record is deleted when the federation contract between two X-Road instances has come to an end and an X-Road security officer deletes the anchor associated with the record in the user interface. The record is never modified. Records in tables trusted_anchors and anchor_urls are created and deleted in exactly the same way. See also documentation of these tables.
 
-### 2.1.1 Indexes
+#### 2.1.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_anchor_url_certs_on_anchor_url_id | anchor_url_id |
 
-### 2.1.2 Attributes
+#### 2.1.2 Attributes
 
 | Name               |  Type   | Modifiers        | Description          |
 |:-------------------|:-------:|:----------- |:-----------------:|
@@ -204,19 +205,19 @@ The record is created when an X-Road security officer has received trusted ancho
 | anchor_url_id [FK] | integer |  | ID of the configuration anchor URL the certificate belongs to. References id attribute of anchor_urls entity. As every anchor URL certificate must belong to particular anchor URL, the column cannot be NULL (currently set in the data model layer of the user interface). |
 | cert               |  bytea  |  |                                                                                                                                                                                                                                                                              |
 
-## 2.2 ANCHOR_URLS
+### 2.2 ANCHOR_URLS
 
 URL pointing to a configuration source that is described by a trusted anchor. Anchor URL is HTTP URL that can be used to download signed configuration.
 
 The record is created or modified exactly the same way as described in the documentation of table anchor_url_certs. The record is never modified.
 
-### 2.2.1 Indexes
+#### 2.2.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_anchor_urls_on_trusted_anchor_id | trusted_anchor_id |
 
-### 2.2.2 Attributes
+#### 2.2.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -224,11 +225,11 @@ The record is created or modified exactly the same way as described in the docum
 | trusted_anchor_id [FK] | integer |  | ID of the trusted anchor that contains this anchor URL. References id attribute of trusted_anchors entity. Cannot be NULL. |
 | url | character varying(255) | | The URL that can be used by the configuration client to download the configuration from the configuration source. Must correspond to the URL format (See also URL specification: http://www.w3.org/Addressing/URL/url-spec.txt). Cannot be NULL. |
 
-## 2.3 APIKEY
+### 2.3 APIKEY
 
 API key which grants access to REST API operations.
 
-### 2.3.1 Attributes
+#### 2.3.1 Attributes
 
 | Name        | Type           | Modifiers |   Description    |
 |:----------- |:-----------------:|:----------|:----------------:|
@@ -236,17 +237,17 @@ API key which grants access to REST API operations.
 | encodedkey | character varying(255) | NOT NULL  | Encoded API key. |
 
 
-## 2.4 APIKEY_ROLES
+### 2.4 APIKEY_ROLES
 
 Roles linked to one API key.
 
-### 2.4.1 Indexes
+#### 2.4.1 Indexes
 
 | Name               |     Columns     |
 |:-------------------|:---------------:|
 | unique_apikey_role | apikey_id, role |
 
-### 2.4.2 Attributes
+#### 2.4.2 Attributes
 
 | Name           |          Type          | Modifiers |                             Description                              |
 |:---------------|:----------------------:|:----------|:--------------------------------------------------------------------:|
@@ -255,7 +256,7 @@ Roles linked to one API key.
 | role           | character varying(255) | NOT NULL  | Role name. Check constraint `valid_role` limits value to valid ones. |
 
 
-## 2.5 APPROVED_CAS
+### 2.5 APPROVED_CAS
 
 Approved certification authority (CA) that is used when verifying authentication and signing certificates. Exactly one top-level CA certificate is associated with each approved CA. Multiple intermediate CA certificates can be associated with each approved CA. The intermediate CA certificates form a hierarchy with top-level CA used as a trust anchor. The intermediate CAs are used for certificate path building and for finding OCSP responders.
 
@@ -264,13 +265,13 @@ New record creation process starts when an X-Road system administrator receives 
 1. Flag “authentication only”, see also documentation of the column authentication_only of this table.
 2. Certificate profile info class name, see also documentation of the column cert_profile_info of this table.
 
-### 2.5.1 Indexes
+#### 2.5.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_approved_cas_on_top_ca_id | top_ca_id |
 
-### 2.5.2 Attributes
+#### 2.5.2 Attributes
 
 | Name                                              | Type           | Modifiers        | Description           |
 |:--------------------------------------------------|:-----------------:|:----------- |:-----------------:|
@@ -282,13 +283,13 @@ New record creation process starts when an X-Road system administrator receives 
 | created_at                                        | timestamp without time zone | NOT NULL | Record creation time, managed automatically. |
 | updated_at                                        | timestamp without time zone | NOT NULL | Record last modified time, managed automatically. |
 
-## 2.6 APPROVED_TSAS
+### 2.6 APPROVED_TSAS
 
 Approved time-stamping authority (TSA). The certificate of the approved CA is used for time-stamping signed messages.
 
 New record creation process starts when an X-Road system administrator receives a certificate from a TSA which is going to be trusted by the X‑Road instance. Having received the certificate, an X-Road system administrator uploads it in the user interface. The record is created when the user adds new approved TSA in the user interface. The record is deleted when for any reason the governing authority of the X-Road instance does not trust the TSA any more. Then an X-Road system administrator deletes the approved TSA in the user interface. The record is modified when the user changes URL or uploads new certificate.
 
-### 2.6.1 Attributes
+#### 2.6.1 Attributes
 
 | Name        | Columns           | Name        | Columns           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -301,19 +302,19 @@ New record creation process starts when an X-Road system administrator receives 
 | created_at | timestamp without time zone | NOT NULL | Record creation time, managed automatically. |
 | updated_at | timestamp without time zone | NOT NULL | Record last modified time, managed automatically. |
 
-## 2.7 AUTH_CERTS
+### 2.7 AUTH_CERTS
 
 Authentication certificate that is used by a Security Server to establish secure connection. Each authentication certificate belongs to a particular Security Server.
 
 The record is created when X-Road registration officer approves the request in the user interface. The record is removed whenever there is need to remove the Security Server the record belongs to or when the authentication certificate cannot be used any more. An X-Road registration officer can either remove Security Server or send authentication certificate deletion request for the Security Server in the user interface. The latter is done when only authentication certificate (without Security Server) is going to be deleted. The record is never modified. See also documentation of table security_servers.
 
-### 2.7.1 Indexes
+#### 2.7.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_auth_certs_on_security_server_id | security_server_id |
 
-### 2.7.2 Attributes
+#### 2.7.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -323,7 +324,7 @@ The record is created when X-Road registration officer approves the request in t
 | created_at | timestamp without time zone | NOT NULL | Record creation time, managed automatically. |
 | updated_at | timestamp without time zone | NOT NULL | Record last modified time, managed automatically. |
 
-## 2.8 CA_INFOS
+### 2.8 CA_INFOS
 
 CA certificates with additional data that is displayed in the user interface. The CA info can describe either certificate of a top-level CA or an intermediate CA. The record is created when a new top-level CA or an intermediate CA is added in the user interface.
 The record is created on two occasions:
@@ -333,13 +334,13 @@ The record is created on two occasions:
 
 Accordingly, the record is deleted when either the approved CA is deleted (see also documentation of table approved_cas) or the intermediate CA is deleted in the user interface. The latter can happen when certification chain for approved CA changes. The record is never modified.
 
-### 2.8.1 Indexes
+#### 2.8.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_ca_infos_on_intermediate_ca_id | intermediate_ca_id |
 
-### 2.8.2 Attributes
+#### 2.8.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -351,19 +352,19 @@ Accordingly, the record is deleted when either the approved CA is deleted (see a
 | created_at  | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 
-## 2.9 CONFIGURATION_SIGNING_KEYS
+### 2.9 CONFIGURATION_SIGNING_KEYS
 
 Signing context (key identifier used by the signer and signing certificate) for signing the global configuration. A signing key belongs to a configuration source. A configuration signing key is used when it is marked as active in the user interface. Technically it is done by designating the key as active key in the configuration_sources table, see also documentation of table configuration_sources.
 
 The record is created when a new key for signing global configuration is needed (either no keys are present or any of present ones cannot be used). Then an X-Road security officer generates a new signing key in the user interface. Non-active configuration signing keys that are no longer necessary can be deleted by an X-Road security officer in the user interface. The record is never modified.
 
-### 2.9.1 Indexes
+#### 2.9.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_configuration_signing_keys_on_configuration_source_id | configuration_source_id |
 
-### 2.9.2 Attributes
+#### 2.9.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -374,7 +375,7 @@ The record is created when a new key for signing global configuration is needed 
 | key_generated_at  | timestamp without time zone |  | The signing key generation time.  |
 | token_identifier  | character varying(255) |  | Unique identifier of hardware or software token used for signing the configuration.  |
 
-## 2.10 CONFIGURATION_SOURCES
+### 2.10 CONFIGURATION_SOURCES
 
 Configuration source that the Central Server uses to distribute the global configuration. Stores (with associated configuration_signing_keys table) all the data necessary to generate configuration anchors for the Central Server. The configuration distributed by the source can be either internal configuration or external configuration. The internal configuration is distributed to Security Servers of this X-Road instance. The external configuration is distributed to the other X-Road instances (federation partners).
 
@@ -383,13 +384,13 @@ The configuration source is associated with several configuration signing keys. 
 In an HA setup, each node of the cluster uses separate keys for signing configuration, and configuration anchors contain entries for each node of the cluster.
 The record is created when the configuration source tab (either for internal or external configuration) is opened in the UI for the first time. The configuration source tab can be opened for viewing or editing configuration anchor or signing keys information for the configuration source. The record is modified when signing keys information of the configuration source is changed and a new configuration anchor is generated by the system. Also, the record is modified when an X-Road security officer generates a new configuration anchor in the user interface. The record is never deleted.
 
-### 2.10.1 Indexes
+#### 2.10.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_configuration_sources_on_active_key_id | active_key_id |
 
-### 2.10.2 Attributes
+#### 2.10.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -401,7 +402,7 @@ The record is created when the configuration source tab (either for internal or 
 | anchor_generated_at  | timestamp without time zone |  | Configuration anchor generation time. Updated when the configuration anchor is re-generated. |
 | ha_node_name | character varying(255) |  | Name of the cluster node that initiated the insertion in an HA setup; the default value in standalone setup. |
 
-## 2.11 DISTRIBUTED_FILES
+### 2.11 DISTRIBUTED_FILES
 
 Stores global configuration files that are distributed to the X-Road members. There are three kinds of distributed files:
 
@@ -416,7 +417,7 @@ The record can be created in two different ways:
 
 The record is always deleted before new record with particular file name is created. The record is never modified.
 
-### 2.11.1 Attributes
+#### 2.11.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -428,20 +429,20 @@ The record is always deleted before new record with particular file name is crea
 | ha_node_name | character varying(255) |  | Name of the cluster node that initiated the insertion in an HA setup; the default value in standalone setup. |
 | version | integer | NOT NULL | Version of the distributed file. Cannot be NULL. Default is 0 which means it is not versioned and belongs to all versions of global configuration. |
 
-## 2.12 GLOBAL_GROUP_MEMBERS
+### 2.12 GLOBAL_GROUP_MEMBERS
 
 Join table that associates global group member identifier with the global group the member belongs to. See also documentation of the table global_groups.
 
 The record is created when a new member needs to be added to a global group. Then an X-Road registration officer adds global group member in the user interface. The record is deleted when a global group member or the group where the member belongs to is deleted in the user interface. The record is never modified.
 
-### 2.12.1 Indexes
+#### 2.12.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_global_group_members_on_global_group_id | global_group_id |
 | index_global_group_members_on_group_member_id | group_member_id |
 
-### 2.12.2 Attributes
+#### 2.12.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -451,13 +452,13 @@ The record is created when a new member needs to be added to a global group. The
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 | global_group_id [FK] | integer |  | ID of the global group the member referenced by group_member_id belongs to. References id attribute of global_groups entity. Cannot be NULL. |
 
-## 2.13 GLOBAL_GROUPS
+### 2.13 GLOBAL_GROUPS
 
 Global group of access rights subjects that can be added to access control lists at Security Servers.
 
 The record is created when a new global group needs to be added to the X-Road instance. Then an X-Road registration officer adds new global group in the user interface. The record is modified when the group description is edited or members are added to or removed from the group by an X‑Road registration officer in the user interface. The record is deleted when the global group is deleted in the user interface by an X-Road registration officer.
 
-### 2.13.1 Attributes
+#### 2.13.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -467,13 +468,13 @@ The record is created when a new global group needs to be added to the X-Road in
 | created_at | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at | timestamp without time zone | NOT NULL | Record last modified time, managed automatically. |
 
-## 2.14 HISTORY
+### 2.14 HISTORY
 
 Operation (insertion, update or deletions of a record) on the tables of this database, for the purpose of auditing. Each row corresponds to the change of a single field.
 
 The record is created in the manner described above in this document. The record can be neither modified nor deleted.
 
-### 2.14.1 Attributes
+#### 2.14.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -488,11 +489,11 @@ The record is created in the manner described above in this document. The record
 | timestamp  | timestamp without time zone | NOT NULL | Date and time of the operation.  |
 | ha_node_name | character varying(255) |  | Name of the cluster node that initiated the insertion in an HA setup; the default value in standalone setup. |
 
-## 2.15 IDENTIFIERS
+### 2.15 IDENTIFIERS
 
 Identifier that can be used to identify various objects on X-Road. An identifier record is only created together with records of other entities. There is no check of duplicates when new identifier record is added. The record is deleted when any record associated with the identifier is deleted. For example, when an entity of global_group_members is deleted, respective identifier is deleted as well. The record is never modified.
 
-### 2.15.1 Attributes
+#### 2.15.1 Attributes
 
 | Name            | Type                        | Modifiers | Description           |
 |:----------------|:---------------------------:|:--------- |:-----------------:|
@@ -508,13 +509,13 @@ Identifier that can be used to identify various objects on X-Road. An identifier
 | updated_at      | timestamp without time zone | NOT NULL  | Record last modified time, managed automatically.  |
 | service_version | character varying(255)      |           | X-Road service version. May be present in identifiers of 'SERVICE' type. |
 
-## 2.16 MEMBER_CLASSES
+### 2.16 MEMBER_CLASSES
 
 Member class supported by this X-Road instance. Member class has the purpose of grouping members with similar properties. A member class must have unique code inside the X-Road instance.
 
 The record is added when the X-Road instance needs new member class. Then an X-Road system administrator adds a new member class in the user interface. The record is deleted when the member class is no longer necessary for this X-Road instance. Then an X-Road system administrator deletes the member class in the user interface. The description of the member class can be edited in the user interface.
 
-### 2.16.1 Attributes
+#### 2.16.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -524,19 +525,19 @@ The record is added when the X-Road instance needs new member class. Then an X-R
 | created_at  | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically. |
 
-## 2.17 OCSP_INFOS
+### 2.17 OCSP_INFOS
 
 Information about OCSP service that is offered by a particular CA. See also documentation of table approved_cas.
 
 The record is created when a new OCSP responder needs to be registered for either top CA or intermediate CA of approved CA (see also documentation of tables approved_cas and ca_infos). Then an X-Road system administrator adds new OCSP info in the user interface. The record can be modified or deleted in the user interface.
 
-### 2.17.1 Indexes
+#### 2.17.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_ocsp_infos_on_ca_info_id | ca_info_id |
 
-### 2.17.2 Attributes
+#### 2.17.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -547,7 +548,7 @@ The record is created when a new OCSP responder needs to be registered for eithe
 | created_at  | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 
-## 2.18 REQUEST_PROCESSINGS
+### 2.18 REQUEST_PROCESSINGS
 
 Processing status of the management request. Management requests are means of managing clients and authentication certificates of Security Servers. See also documentation of the table requests. 
 - In older version request processing binds together two management requests that refer to the same data but have different origin (Security Server or user interface of the Central Server). If one request associated with the processing is from Central Server, the other one must be from Security Server and vice versa. 
@@ -563,7 +564,7 @@ Request processing can have one of following statuses:
 
 Request processing record is created (registration requests for X-Road client and Security Server authentication certificate) from Security Server. Modifications to the record are related to changes of the request processing status and are described above in this section. The record is never deleted.
 
-### 2.18.1 Attributes
+#### 2.18.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -573,7 +574,7 @@ Request processing record is created (registration requests for X-Road client an
 | created_at | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 
-## 2.19 REQUESTS
+### 2.19 REQUESTS
 
 Management request for creating or deleting association between X-Road member and Security Server. Management requests are divided into registration and deletion requests.
 
@@ -586,7 +587,7 @@ Management request for creating or deleting association between X-Road member an
 The record is created in the manner described above in this section. Starting in X-Road version 7.3.0 the record is never modified.
 The record is never deleted.
 
-### 2.19.1 Indexes
+#### 2.19.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
@@ -594,7 +595,7 @@ The record is never deleted.
 | index_requests_on_sec_serv_user_id | sec_serv_user_id |
 | index_requests_on_security_server_id | security_server_id |
 
-### 2.19.2 Attributes
+#### 2.19.2 Attributes
 
 | Name        | Type           | Modifiers        |                                                                                                                                                                              Description                                                                                                                                                                              |
 |:----------- |:-----------------:|:----------- |:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
@@ -610,7 +611,7 @@ The record is never deleted.
 | created_at  | timestamp without time zone | NOT NULL |                                                                                                                                                             Record creation time, managed automatically.                                                                                                                                                              |
 | updated_at   | timestamp without time zone | NOT NULL |                                                                                                                                                           Record last modified time, managed automatically.                                                                                                                                                           |
 
-## 2.20 SECURITY_SERVER_CLIENTS
+### 2.20 SECURITY_SERVER_CLIENTS
 
 Contains X-Road members or subsystems. The subject that can be associated with a Security Server. There are two types of associations:
 
@@ -626,7 +627,7 @@ The record is modified when the X-Road registration officer edits the member's n
 
 The record can be deleted in the user interface by an X-Road registration officer.
 
-### 2.20.1 Indexes
+#### 2.20.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
@@ -634,7 +635,7 @@ The record can be deleted in the user interface by an X-Road registration office
 | index_security_server_clients_on_server_client_id | server_client_id |
 | index_security_server_clients_on_xroad_member_id | xroad_member_id |
 
-### 2.20.2 Attributes
+#### 2.20.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -650,19 +651,19 @@ The record can be deleted in the user interface by an X-Road registration office
 | created_at  | timestamp without time zone | NOT NULL | Record creation time, managed automatically.  |
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 
-## 2.21 SECURITY_SERVERS
+### 2.21 SECURITY_SERVERS
 
 Information about a Security Server registered in this X-Road instance. Security Server always belongs to a particular X-Road member. For Security Server to function properly, it needs at least one authentication certificate. Security Server may have clients (subsystems).
 
 A prerequisite for creating the record is that the authentication certificate registration request for not yet existing Security Server are approved (see also documentation of tables requests and request_processings). The record is created when request is approved by an X-Road registration officer in the user interface. The record is modified when an X-Road registration officer edits Security Server address in the user interface. The record can be deleted in the user interface by an X-Road registration officer.
 
-### 2.21.1 Indexes
+#### 2.21.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_security_servers_on_xroad_member_id | xroad_member_id |
 
-### 2.21.2 Attributes
+#### 2.21.2 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -674,20 +675,20 @@ A prerequisite for creating the record is that the authentication certificate re
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 
 
-## 2.22 SERVER_CLIENTS
+### 2.22 SERVER_CLIENTS
 
 Join table enabling many-to-many relationship between Security Servers and Security Server clients. In other words, associates Security Servers with its clients.
 
 The record is created when a new client is added to the Security Server. It requires approval of a client registration request (see documentation of tables requests and request_processings for details). An X-Road registration officer can do it in the user interface. The record is deleted when a client of a Security Server is deleted in the user interface by an X-Road registration officer. The record is never modified.
 
-### 2.22.1 Indexes
+#### 2.22.1 Indexes
 
 | Name        | Columns           |
 |:----------- |:-----------------:|
 | index_server_clients_on_security_server_client_id | security_server_client_id |
 | index_server_clients_on_security_server_id | security_server_id |
 
-### 2.22.2 Attributes
+#### 2.22.2 Attributes
 
 | Name                           |  Type   | Modifiers | Description                                                                                          |
 |:-------------------------------|:-------:|:----------|:-----------------------------------------------------------------------------------------------------|
@@ -696,7 +697,7 @@ The record is created when a new client is added to the Security Server. It requ
 | security_server_client_id [FK] | integer | NOT NULL  | ID of the client the Security Server has. References id attribute of security_server_clients entity. |
 | enabled                        | boolean | NOT NULL  | Indicates whether client (subsystem) is enabled (true) or temporarily disabled (false)               |
 
-## 2.23 SYSTEM_PARAMETERS
+### 2.23 SYSTEM_PARAMETERS
 
 System configuration parameter necessary for proper functioning of Central Server and entire X-Road for that matter. System parameters are stored as key-value pairs. Following is the list of supported system parameters. In an HA setup, the name of the node that initiated a particular insertion, is not significant, except for where stated explicitly.
 
@@ -715,7 +716,7 @@ System configuration parameter necessary for proper functioning of Central Serve
 
 Some system parameters can be modified by an X-Road security officer in the user interface. All the system parameters that cannot be changed in the user interface, are assigned default values during the initialization of the Central Server. Later these can only be changed from the database. As these parameters are critical for functioning of entire X-Road instance, these must be modified with extreme care.
 
-### 2.23.1 Attributes
+#### 2.23.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -726,13 +727,13 @@ Some system parameters can be modified by an X-Road security officer in the user
 | updated_at  | timestamp without time zone | NOT NULL | Record last modified time, managed automatically.  |
 | ha_node_name | character varying(255) |  | Name of the cluster node that initiated the insertion in an HA setup; the default value in standalone setup. |
 
-## 2.24 TRUSTED_ANCHORS
+### 2.24 TRUSTED_ANCHORS
 
 Trusted anchor of a federation partner. A trusted anchor is the configuration anchor of the configuration source distributing the external configuration of a federation partner.
 
 The record is created or modified exactly the same way as described in the documentation of table anchor_url_certs. The record is never modified.
 
-### 2.24.1 Attributes
+#### 2.24.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|
@@ -744,13 +745,13 @@ The record is created or modified exactly the same way as described in the docum
 | updated_at  | timestamp without time zone |  | Record last modified time, managed automatically.  |
 | generated_at  | timestamp without time zone |  | Anchor generation time (read from the anchor file).  |
 
-## 2.25 UI_USERS
+### 2.25 UI_USERS
 
 UI user name with its last used locale. Maps possible user interface (UI) user names with locales so that when UI user is logged in next time, the locale it has been used is remembered. If a user with no assigned locale logs in, the first available locale is selected to this user. Later user can change its locale in the user interface.
 
 The record is created when the user is logged in the user interface for the first time. The record is modified when the user logged in changes its locale in the user interface. The record is never deleted.
 
-### 2.25.1 Attributes
+#### 2.25.1 Attributes
 
 | Name        | Type           | Modifiers        | Description           |
 |:----------- |:-----------------:|:----------- |:-----------------:|

--- a/doc/DataModels/dm-ml_x-road_message_log_data_model.md
+++ b/doc/DataModels/dm-ml_x-road_message_log_data_model.md
@@ -1,6 +1,6 @@
 # X-Road: Message Log Data Model
 
-Version: 1.10
+Version: 1.11
 Doc. ID: DM-ML
 
 | Date       | Version | Description                                                  | Author             |
@@ -23,7 +23,9 @@ Doc. ID: DM-ML
 | 11.09.2019 | 1.8     | Remove Ubuntu 14.04 support                                  | Jarkko Hyöty       |
 | 06.09.2021 | 1.9     | Update data model due to encryption features                 | Ilkka Seppälä      |
 | 26.09.2022 | 1.10    | Remove Ubuntu 18.04 support                                  | Andres Rosenthal   |
+| 09.01.2025 | 1.11    | Heading level changes for the documentation platform         | Raido Kaju         |
 
+## Table of Contents
 <!-- vim-markdown-toc GFM -->
 
 - [X-Road: Message Log Data Model](#x-road-message-log-data-model)
@@ -49,13 +51,13 @@ Doc. ID: DM-ML
 
 <!-- vim-markdown-toc -->
 
-# 1. General
+## 1. General
 
-## 1.1 Preamble
+### 1.1 Preamble
 
 This document describes database model of X-Road message log.
 
-## 1.2 Terms and abbreviations
+### 1.2 Terms and abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
@@ -63,11 +65,11 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
 1. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 
-## 1.4 Database Version
+### 1.4 Database Version
 
 This database assumes PostgreSQL version 9.2 or later.
 
-## 1.5 Creating, Backing Up and Restoring the Database
+### 1.5 Creating, Backing Up and Restoring the Database
 
 This database is integrated into X-Road message log component.
 
@@ -75,7 +77,7 @@ The database, the database user and the data model is created by the component's
 
 The database is used for logging purposes only and does not contain any configuration. Backing-up and restoring the database is not necessary for the functioning of the component.
 
-## 1.6 Message Logging and Timestamping
+### 1.6 Message Logging and Timestamping
 
 The input to the message log component consists of a message and its corresponding signature (along with hash chain and hash chain result if the signature is a batch signature). Depending on the security policy, timestamping can be asynchronous (one or more signatures are batch timestamped) or synchronous (to guarantee the timestamp).
 
@@ -90,17 +92,17 @@ When timestamping synchronously, the logging call will block until the timestamp
 1. The system saves the message and signature in the message log.
 2. System timestamps the message synchronously.
 
-## 1.7 Entity-Relationship Diagram
+### 1.7 Entity-Relationship Diagram
 
 ![Entity-Relationship Diagram](img/messagelog-er.svg)
 
-# 2. Description of Entities
+## 2. Description of Entities
 
-## 2.1 LOGRECORD
+### 2.1 LOGRECORD
 
 Log record can either be a message record or a timestamp record. A message record is created when the system processes an X-Road message. A timestamp record is created when the system timestamps the message records created since the last timestamping. A message record is modified by adding a reference to a timestamp record after it has been timestamped. All the records are modified by changing the archived flag after they have been archived. All the records are eventually deleted after they have been timestamped and archived.
 
-### 2.1.1 Indexes
+#### 2.1.1 Indexes
 
 | Name                           | Columns                                    | Partial index details  |
 | ------------------------------ |:------------------------------------------:| ----------------------:|
@@ -115,7 +117,7 @@ Log record can either be a message record or a timestamp record. A message recor
 | IX_NOT_ARCHIVED_LOGRECORD      | id                                         | where discriminator = 't' and archived = false |
 | IX_NOT_TIMESTAMPED_LOGRECORD   | id, discriminator, signaturehash           | where discriminator = 'm' and signaturehash is not null |
 
-### 2.1.2 Attributes
+#### 2.1.2 Attributes
 
 | Name                 | Type                   | Modifiers  | Description |
 | -------------------- |:----------------------:| ----------:| -----------:|
@@ -140,20 +142,20 @@ Log record can either be a message record or a timestamp record. A message recor
 | keyid                | character varying(255) |            | ID of the key used to encrypt/decrypt the message. |
 | ciphermessage        | bytea                  |            | The SOAP message body or REST request data in encrypted form. Only present for message records. Created only when encryption is switched on. |
 
-## 2.2 LAST_ARCHIVE_DIGEST
+### 2.2 LAST_ARCHIVE_DIGEST
 
 Records the last digest of the archive file. When archiving signatures, the message log links them together using cryptographic hash functions. When creating an archive, the last link is saved in the last_archive_digest table. This makes it possible to continue the hash chain for the next archive file.
 
 The record is created when the first archive file is created. The record is modified every time when an archive file s created. The record is never deleted.
 
-### 2.2.1 Indexes
+#### 2.2.1 Indexes
 
 | Name                              | Columns                                    | Partial index details  |
 | --------------------------------- |:------------------------------------------:| ----------------------:|
 | last_archive_digestpk             | id                                         | N/A                    |
 | last_archive_digest_groupname_key | groupname                                  | N/A                    |
 
-### 2.2.2 Attributes
+#### 2.2.2 Attributes
 
 | Name        | Type                   | Modifiers  | Description |
 | ----------- |:----------------------:| ----------:| -----------:|
@@ -162,11 +164,11 @@ The record is created when the first archive file is created. The record is modi
 | filename    | character varying(255) |            | The filename of the last archive. |
 | groupname   | character varying(255) |            | The name of the archive group. |
 
-## 2.3 DATABASECHANGELOG
+### 2.3 DATABASECHANGELOG
 
 Liquibase migration of the database. A record is created when the administrator updates the software package containing this database and the database structure needs to be modified. The record is never modified or deleted. This table has a technical nature and is not managed by X-Road application software.
 
-### 2.3.1 Attributes
+#### 2.3.1 Attributes
 
 | Name          | Type                     | Modifiers  | Description |
 | ------------- |:------------------------:| ----------:| -----------:|
@@ -185,11 +187,11 @@ Liquibase migration of the database. A record is created when the administrator 
 | labels        | character varying(255)   |            | Label(s) used to execute the changeset. |
 | deployment_id | character varying(10)    |            | Changesets deployed together will have the same unique identifier. |
 
-## 2.4 DATABASECHANGELOGLOCK
+### 2.4 DATABASECHANGELOGLOCK
 
 Lock used by Liquibase to allow only one migration of the database to run at a time. This table has a technical nature and is not managed by X-Road application software.
 
-### 2.4.1 Attributes
+#### 2.4.1 Attributes
 
 | Name        | Type                     | Modifiers  | Description |
 | ----------- |:------------------------:| ----------:| -----------:|

--- a/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
+++ b/doc/Manuals/ug-cs_x-road_6_central_server_user_guide.md
@@ -1,6 +1,6 @@
 # X-Road: Central Server User Guide <!-- omit in toc --> 
 
-Version: 2.45  
+Version: 2.46  
 Doc. ID: UG-CS
 
 ## Version history <!-- omit in toc --> 
@@ -71,6 +71,8 @@ Doc. ID: UG-CS
 | 08.04.2024 | 2.43    | Taking configuration download url from shared parameters                                                                                                                                                                                                                                                                                                                                                                                | Eneli Reimets        |
 | 09.06.2024 | 2.44    | Added ACME information for Approved CAs                                                                                                                                                                                                                                                                                                                                                                                                 | Mikk-Erik Bachmann   |
 | 01.08.2024 | 2.45    | Minor updates                                                                                                                                                                                                                                                                                                                                                                                                                           | Petteri Kivimäki     |
+| 08.01.2025 | 2.46    | Minor updates                                                                                                                                                                                                                                                                                                                                                                                                                           | Raido Kaju           |
+
 ## Table of Contents <!-- omit in toc --> 
 
 <!-- toc -->
@@ -188,19 +190,19 @@ Doc. ID: UG-CS
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# 1. Introduction
+## 1. Introduction
 
-## 1.1 Target Audience
+### 1.1 Target Audience
 
 The intended audience of this User Guide are X-Road Central Server administrators who are responsible for everyday management of the X-Road Central Server.
 
 Instructions for the installation and initial configuration of the Central Server can be found in the Central Server Installation Guide [CSI](#13-references). Instructions for installing the Central Server in a cluster for achieving high availability can be found in the Central Server High Availability Installation Guide [IG-CSHA](#13-references).
 
-## 1.2 Terms and abbreviations
+### 1.2 Terms and abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-## 1.3 References
+### 1.3 References
 
 1. [CSI] X-Road 7. Central Server Installation Guide. Document ID: [IG-CS](ig-cs_x-road_6_central_server_installation_guide.md)
 2. [IG-CSHA] X-Road 7. Central Server High Availability Installation Guide. Document ID: [IG-CSHA](ig-csha_x-road_6_ha_installation_guide.md)
@@ -215,9 +217,9 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 11. <a id="Ref_REST_UI-API" class="anchor"></a>\[REST_UI-API\] X-Road Central Server Admin API OpenAPI Specification: <https://github.com/nordic-institute/X-Road/blob/develop/src/central-server/openapi-model/src/main/resources/openapi-definition.yaml>.
 12. [UG-SS] X-Road 7. Security Server User Guide. Document ID: [UG-SS](ug-ss_x-road_6_security_server_user_guide.md)
 
-# 2. User and Role Management
+## 2. User and Role Management
 
-## 2.1 User Roles
+### 2.1 User Roles
 
 The Central Server supports the following user roles:
 
@@ -233,7 +235,7 @@ The document indicates in sections similar to the following example, which user 
 
 Caution: If the logged-in user does not have a permission to carry out a task, the button that initiates the action is hidden (and neither is it possible to run the task using its corresponding keyboard combinations or mouse actions). Only the permitted information and actions are visible and available to the user.
 
-## 2.2 Managing the Users
+### 2.2 Managing the Users
 
 During the installation, a super user equipped with all the roles is created. You can create additional users that have restricted rights. User management is carried out in root user's permissions using the command line.
 
@@ -255,14 +257,14 @@ To remove a user, enter:
 
 `deluser username`
 
-## 2.3 LDAP user authentication
+### 2.3 LDAP user authentication
 
 X-Road leverages PAM (Pluggable Authentication Modules) for user authentication, which facilitates LDAP integration.
 
 A detailed setup guide can be found under security server user guide [2.3 LDAP user authentication](ug-ss_x-road_6_security_server_user_guide.md#23-ldap-user-authentication).
 Please note that x-road property path will be different in case of Central Server. Refer to [ug-syspar_x-road_v6_system_parameters.md](ug-syspar_x-road_v6_system_parameters.md#413-center-parameters-admin-service) for relevant properties.
 
-## 2.4 Managing API Keys
+### 2.4 Managing API Keys
 
 API keys are used to authenticate API calls to Central Server's management REST API. API keys are associated with roles that define the permissions granted to the API key. If an API key is lost, it can be revoked.
 
@@ -290,7 +292,7 @@ To revoke API key from roles, follow these steps.
 2. Select a API key and click Revoke key. 
 3. Confirm the revoking by clicking Yes.
 
-# 3. Standalone and High-Availability Systems
+## 3. Standalone and High-Availability Systems
 
 The Central Server can be installed and configured in several ways:
 - A standalone server with local database
@@ -303,11 +305,11 @@ In the case of an HA setup, the Central Servers share configuration via an optio
 
 In an HA setup, if the system is configured using different nodes in parallel, the effect will be similar to several people updating the configuration of a standalone server at the same time.
 
-## 3.1 Detecting the Type of Deployment in the User Interface
+### 3.1 Detecting the Type of Deployment in the User Interface
 
 In order to detect the type of deployment and the name of the node in the cluster in the case of HA setup, the logged-in user should check the instance identifier displayed in the left upper corner of the user interface. In the case of an HA setup, the name of the node is displayed in the right upper corner of the user interface.
 
-## 3.2 Checking the Status of the Nodes of the Cluster
+### 3.2 Checking the Status of the Nodes of the Cluster
 
 Access rights: Registration Office, System Administrator, Security Officer
 
@@ -319,7 +321,7 @@ curl --header "Authorization: X-Road-ApiKey token=<api key>" -k https://localhos
 
 **Note:** This endpoint requires authentication which can be provided with a valid API KEY (with at least one of the aforementioned roles) in the `Authorization` header of the request. See [Managing API Keys](#23-managing-api-keys) for instructions regarding setting up an API KEY.
 
-## 3.3 API key considerations in High-Availability setup
+### 3.3 API key considerations in High-Availability setup
 
 API keys are cached in memory, which is typically not a problem in non-clustered Central Server configuration.
 However, in case of High-Availability setup, the caches of different nodes can become out of sync.
@@ -331,8 +333,9 @@ For instance, revoking an API key from `node 1` may not be recognized by `node 2
 - **Option C:** Always restart REST API modules when API key operations are executed.
 - **Option D:** Disable Api key cache. (See [admin-service parameters](ug-syspar_x-road_v6_system_parameters.md#413-center-parameters-admin-service) for more details). This option will degrade API throughput and should only be used when other options do not work.
 
-# 4. System Settings
-## 4.1 Managing the Member Classes
+## 4. System Settings
+
+### 4.1 Managing the Member Classes
 
 Access rights: Security Officer
 
@@ -355,7 +358,7 @@ To delete a member class, follow these steps.
 
 Only the member classes that are used by none of the X-Road members can be deleted.
 
-## 4.2 Configuring the Management Service Provider
+### 4.2 Configuring the Management Service Provider
 
 The Central Server provides management services to the Security Servers that are part of the (local) X-Road infrastructure (see Chapter 6).
 
@@ -363,7 +366,7 @@ A subsystem of an X-Road member acting as a service provider for the management 
 
 The management services’ Security Server must be installed and registered in the Central Server before the management service provider can be registered as a client of the Security Server and the management services can be configured (see [SSI](#13-references)).
 
-### 4.2.1 Appointing the Management Service Provider
+#### 4.2.1 Appointing the Management Service Provider
 
 Access rights: Security Officer
 
@@ -373,7 +376,7 @@ To appoint the management service provider in the Central Server, follow these s
 2. Locate the Management Services section and click Edit on the Service Provider Identifier field.
 3. In the window that opens, find the subsystem of an X-Road member to be appointed as the management service provider and check the subsystem checkbox and then click Select.
 
-### 4.2.2 Registering the Management Service Provider as a Security Server Client
+#### 4.2.2 Registering the Management Service Provider as a Security Server Client
 
 The management service provider can be registered as a Security Server client as described in this section only if the management service provider is not registered as a client of any Security Servers. In case the management service provider is already a client of a Security Server then the Edit button is not shown next to the identifier of the Management Services' Security Server.
 
@@ -386,7 +389,7 @@ To register the appointed management service provider as a Security Server clien
 
 On successful registration the identifier of the management services’ Security Server is displayed and Edit button should hide.
 
-### 4.2.3 Configuring the Management Services in the Management Services’ Security Server
+#### 4.2.3 Configuring the Management Services in the Management Services’ Security Server
 
 Access rights: Security server’s Service Administrator
 
@@ -403,7 +406,7 @@ To configure management services in the management services’ Security Server, 
 7. Click Add subject and search for the global group security-server-owners. Select the group and click Next.
 8. In the window that opens, check management services checkboxes (authCertDeletion, clientDeletion, clientReg, ownerChange) and click Add Selected to add the security-server-owners group’s access rights list.
 
-## 4.3 Configuring the Central Server Address
+### 4.3 Configuring the Central Server Address
 
 Access rights: Security Officer
 
@@ -417,13 +420,13 @@ In the System Settings view (Settings tab --> System Settings), the Central Serv
 
 The services provided by the Central Server must be available from both the new and old address, until all servers using the services have uploaded the configuration anchor containing the new address.
 
-### 4.3.1 Notes on HA Setup
+#### 4.3.1 Notes on HA Setup
 
 In an HA setup, the address of the Central Server is local to the node that is being configured.
 
 In an HA setup, internal and external configuration anchors contain information about each Central Server that is part of the cluster. If the address of one of the servers is changed, configuration anchors will be re-generated automatically on all the nodes.
 
-### 4.3.2 Changing the Central Server Address
+#### 4.3.2 Changing the Central Server Address
 
 To change the Central Server address, follow these steps.
 
@@ -441,11 +444,11 @@ To change the Central Server address, follow these steps.
     > **NOTE**: Starting from version 7.5.0 new Central Server address is automatically distributed to the federation partners within the global configuration. Distribution will take place within two global configuration refresh cycles. However, the new Central Server address is not updated to the configuration anchor stored on the Security Server. If the Security Server's local copy of the global configuration expires, the Security Server returns using the Central Server address from the configuration anchor. Therefore, if the Security Server's local copy of the global configuration is expired, importing a new version of the configuration anchor is required if the current Central Server address doesn't match with the address in the original configuration anchor.
   - Reconfigure the management services addresses in the management service Security Server.
 
-## 4.4 Managing the TLS certificates
+### 4.4 Managing the TLS certificates
 
 Access rights: Security Officer
 
-### 4.4.1 Registration and Management Service TLS certificate
+#### 4.4.1 Registration and Management Service TLS certificate
 
 Registration and Management Service TLS certificate is used to secure the communication between:
 - the management Security Server and the member management web service;
@@ -484,7 +487,7 @@ To upload Management Service certificate, follow these steps.
 3. Find the proper certificate file and click Open, to finish certificate uploading click button Upload.
 4. Complete the activities defined in section [4.4.1.1 Necessary activities after changing certificate](#4411-necessary-activities-after-changing-certificate)
 
-#### 4.4.1.1 Necessary activities after changing certificate
+##### 4.4.1.1 Necessary activities after changing certificate
 
 When the key and certificate are rotated, and mTLS is enabled between the management Security Server and the management services, the new certificate must be updated to the management Security Server. To add new certificate follow Security Server User Guide [UG-SS](#13-references) instruction in section "Managing Information System TLS Certificates".
 
@@ -492,9 +495,9 @@ When the key and certificate are rotated, and mTLS is enabled between the manage
 - The changed TLS certificate is added in the global configuration `private-params.xml` part. The global configuration generation interval on the Central Server and the global configuration fetching interval on the Security Server depend on the system parameters. The system parameters are specified in the [UG-SYSPAR](#13-references) section "Center parameters: [admin-service]" and "Configuration Client parameters: [configuration-client]". With the default values, a new Registration and Management service TLS certificate is usable for the authentication certificate registration request on the Security Server side after ~1.5 min.
 - The changed TLS certificate is automatically detected by Nginx within five minutes after the change.
 
-# 5. Configuration Management
+## 5. Configuration Management
 
-## 5.1 Viewing the Configuration Settings
+### 5.1 Viewing the Configuration Settings
 
 Access rights: Security Officer, System Administrator
 
@@ -503,7 +506,7 @@ The Global Configuration view consists of three sub-tabs.
 - The External Configuration view. The external configuration is distributed by the Central Server to the federation partners (either to the Security Servers directly or through a configuration proxy). The information needed to download and verify the external configuration is included in the external configuration anchor, which must be distributed to the federation partner’s Central Server (or configuration proxy) administrators and uploaded to the Central Server (or configuration proxy). Along with the external configuration anchor, the anchor file hash value must be distributed. The hash value is used by the federation partners to verify the integrity of the anchor file.
 - The Trusted Anchors view. A trusted anchor is the configuration anchor of the configuration source(s) distributing the external configuration of a federation partner. Upon loading the trusted anchor into the Central Server, the anchor is included into the internal configuration, allowing the Security Servers to download the external configuration of a federation partner as well as the internal configuration of the local X-Road infrastructure.
 
-## 5.2 Downloading the Configuration Anchor
+### 5.2 Downloading the Configuration Anchor
 
 Access rights: Security Officer
 
@@ -512,7 +515,7 @@ To download a configuration anchor, follow these steps.
 1. In the Navigation tabs, select Global Configuration and select either the Internal Configuration or External Configuration sub-tab, as appropriate.
 2. In the Anchor section, click Download and save the prompted file.
 
-## 5.3 Re-Creating the Configuration Anchor
+### 5.3 Re-Creating the Configuration Anchor
 
 Access rights: Security Officer
 
@@ -523,7 +526,7 @@ To re-create an anchor, follow these steps.
 1. In the Navigation tabs, select Global Configuration and select either the Internal Configuration or External Configuration sub-tab, as appropriate.
 2. In the Anchor section, click Re-create.
 
-## 5.4 Changing the Configuration Signing Keys
+### 5.4 Changing the Configuration Signing Keys
 
 Access rights: Security Officer
 
@@ -552,7 +555,7 @@ The new signing key(s) should only be activated after all the affected Security 
 
 To perform an emergency key change, the new key must be activated and the old key deleted immediately after the generation of the new key (in the steps described above, step 2 is skipped). The configuration anchor distributed to the Security Server administrators (in case of internal configuration anchor) or to the federation partners (in case of external configuration anchor) must only contain the public key part of the new signing key.
 
-### 5.4.1 Generating a Configuration Signing Key
+#### 5.4.1 Generating a Configuration Signing Key
 
 Access rights: Security Officer
 
@@ -566,7 +569,7 @@ To generate a configuration signing key, follow these steps.
 The system will automatically generate the corresponding configuration anchor containing the public key part of the generated key.
 If the generated key is the only signing key for the configuration source, the key will automatically be set as active.
 
-### 5.4.2 Activating a Configuration Signing Key
+#### 5.4.2 Activating a Configuration Signing Key
 
 Access rights: Security Officer
 
@@ -575,7 +578,7 @@ To activate a configuration signing key, follow these steps.
 1. In the Navigation tabs, select Global Configuration and select either the Internal Configuration or External Configuration sub-tab, as appropriate.
 2. In the Signing Keys section, expand the token's information by clicking the caret next to the token name and select an inactive key (only for an inactive key are the Activate and Delete buttons displayed) and click Activate.
 
-### 5.4.3 Deleting a Configuration Signing Key
+#### 5.4.3 Deleting a Configuration Signing Key
 
 Access rights: Security Officer
 
@@ -585,7 +588,7 @@ To delete a configuration signing key, follow these steps.
 2. In the Signing Keys section,expand the token's information by clicking the caret next to the token name and select an inactive key (only for an inactive key are the Activate and Delete buttons displayed) and click Delete.
 3. Confirm the deletion by clicking Confirm.
 
-## 5.5 Managing the Contents of a Configuration Part
+### 5.5 Managing the Contents of a Configuration Part
 
 Access rights: Security Officer, System Administrator
 
@@ -596,7 +599,7 @@ To download or upload a configuration file, follow these steps.
 1. In the Navigation tabs, select Global Configuration and select either the Internal Configuration or External Configuration sub-tab, as appropriate
 2. In the Configuration Parts section, select a configuration part file and click Download or Upload
 
-## 5.6 Uploading a Trusted Anchor
+### 5.6 Uploading a Trusted Anchor
 
 Access rights: Security Officer
 
@@ -608,7 +611,7 @@ To upload a trusted anchor, follow these steps.
 
 In case a previous anchor from the same federation partner has been uploaded to the system, the new anchor will replace the old one.
 
-## 5.7 Viewing the Contents of a Trusted Anchor
+### 5.7 Viewing the Contents of a Trusted Anchor
 
 Access rights: Security Officer, System Administrator
 
@@ -619,7 +622,7 @@ To download an anchor file, follow these steps.
 2. In an anchor section, click Download.
 3. Save or open the prompted file.
 
-## 5.8 Deleting a Trusted Anchor
+### 5.8 Deleting a Trusted Anchor
 
 Access rights: Security Officer
 
@@ -628,7 +631,7 @@ To delete an anchor file, follow these steps.
 2. In the anchor section, click Delete.
 3. Confirm the deletion by clicking Yes.
 
-## 5.9 Publishing global configuration over HTTPS
+### 5.9 Publishing global configuration over HTTPS
 
 Starting from version 7.4.0, the Central Server supports publishing global configuration over HTTP and HTTPS. Instead, before version 7.4.0, only HTTP was supported.
 
@@ -640,8 +643,8 @@ Applying for a TLS certificate issued by a trusted CA is required, because the S
 
 > **NOTE**: Starting from version 7.5.0, it's not required to re-generate and import the configuration anchor to all the Security Servers to enable downloading global configuration over HTTPS.
 
-# 6. The Management Requests System
-## 6.1 Registration Requests
+## 6. The Management Requests System
+### 6.1 Registration Requests
 
 As the registration of associations in the X-Road governing authority is security-critical, the following measures are applied to increase security by default:
 
@@ -669,7 +672,7 @@ It is possible to streamline the registration process of authentication certific
   - Automatic approval is applied to existing members only.
   - By default, automatic approval of Security Server owner change requests is disabled. It can be enabled by setting the `auto-approve-owner-change-requests` property value to `true` on Central Server.
     
-### 6.1.1 State Model for Registration Requests
+#### 6.1.1 State Model for Registration Requests
 
 A registration request can be in one of the following states. See Figure 1 for the state diagram.
 
@@ -685,7 +688,7 @@ Pending – a registration request has been submitted from a Security Server. Fr
 
 If automatic approval of authentication certificate registration requests, Security Server client registration requests and/or Security Server owner change requests is enabled, the request is approved automatically. Therefore, the request moves directly to Approved state.
 
-## 6.2 Deletion Requests
+### 6.2 Deletion Requests
 
 Deleted requests is submitted through a Security Server or formalized in the Central Server.
 
@@ -693,16 +696,16 @@ Deletion requests are
 - authentication certificate deletion request (see Section 8.4);
 - Security Server client deletion request (see Section 7.6).
 
-## 6.3 Address Change Request
+### 6.3 Address Change Request
 
 Address change request is submitted through a Security Server to change its address. The request does not require any additional approvals on the Central Server.
 
-## 6.4 Temporarily Disabling Client Requests
+### 6.4 Temporarily Disabling Client Requests
 
 Security Server can disable client subsystem temporarily by issuing "Disable client" request. Disabled client can be enabled again to with "Enable client" request.
 These requests do not require any additional approvals on Central Server.
 
-## 6.5 Viewing the Management Request Details
+### 6.5 Viewing the Management Request Details
 
 Access rights: Registration Officer
 
@@ -740,8 +743,8 @@ There are three data sections in the view.
   - Code – the member code of the X-Road member managing the subsystem;
   - Subsystem – the code of the subsystem.
 
-# 7 Managing the X-Road Members
-## 7.1 Adding a Member
+## 7. Managing the X-Road Members
+### 7.1 Adding a Member
 
 Access rights: Registration Officer
 
@@ -749,7 +752,7 @@ To add a new X-Road member, follow these steps.
 1. In the Members tab, click Add member.
 2. In the window that opens, enter the member's information and click Add. The new member appears in the list of members.
 
-## 7.2 Viewing the Member Details
+### 7.2 Viewing the Member Details
 
 Access rights: Registration Officer
 
@@ -765,7 +768,7 @@ The view consists of five sections and a tab Subsystems.
 5. "Global Groups" – displays information about the group membership of the member or its subsystems.
 6. "Subsystems" tab – displays a list of member's subsystems. If a subsystem is not a client of any Security Servers, then subsystem status is UNREGISTERED.
 
-## 7.3 Adding a Subsystem to an X-Road Member
+### 7.3 Adding a Subsystem to an X-Road Member
 
 Access rights: Registration Officer
 
@@ -774,7 +777,7 @@ To add a subsystem to an X-Road member, follow these steps.
 2. In the view that opens, locate the Subsystems tab and click Add new subsystem to database.
 3. Enter the code of the subsystem and click Add.
 
-## 7.4 Registering a Member's Security Server
+### 7.4 Registering a Member's Security Server
 
 Access rights: Registration Officer
 
@@ -798,7 +801,7 @@ To decline a request, it can be done either through in the Management request vi
 On the decline of the request
 - the request moves to the "Rejected" state.
 
-## 7.5 Registering a Client to a Security Server
+### 7.5 Registering a Client to a Security Server
 
 Access rights: Registration Officer
 
@@ -821,7 +824,7 @@ To decline a request, it can be done either through in the Management request vi
 On the decline of the request
 - the request moves to the "Rejected" state.
 
-## 7.6 Removing a Client from a Security Server
+### 7.6 Removing a Client from a Security Server
 
 Access rights: Registration Officer
 
@@ -836,7 +839,7 @@ To submit a Security Server client deletion request through a member's detail vi
 2. In the window that opens, select Subsystems tab and select the client subsystem, and click Unregister.
 3. Review the information displayed on the client deletion request and click Delete to submit the request.
 
-## 7.7 Changing the Owner of Security Server
+### 7.7 Changing the Owner of Security Server
 
 Access rights: Registration Officer
 
@@ -851,7 +854,7 @@ Automatic approval of Security Server owner change requests is disabled by defau
 
 To approve/decline a request, it can be done either through in the Management request view list or in the Management request details view.
 
-## 7.8 Deleting a Subsystem
+### 7.8 Deleting a Subsystem
 
 Access rights: Registration Officer
 
@@ -861,7 +864,7 @@ To delete an X-Road member's subsystem, follow these steps.
 1. In the Members tab, select the member whose subsystem you wish to delete and click members name.
 2. In the window that opens, select Subsystems tab and select the client subsystem, and click Delete. Note: The "Delete" button is displayed only if the subsystem is not a client of any Security Servers.
 
-## 7.9 Deleting an X-Road Member
+### 7.9 Deleting an X-Road Member
 
 Access rights: Registration Officer
 
@@ -871,8 +874,8 @@ To delete an X-Road member, follow these steps.
 1. In the Members tab, select a member that you wish to delete, and click members name.
 2. In the view that opens, click Delete member "\<member name\>". In the confirmation window that opens, enter member code and click Delete.
 
-# 8. Managing the Security Servers
-## 8.1 Viewing the Security Server Details
+## 8. Managing the Security Servers
+### 8.1 Viewing the Security Server Details
 
 Access rights: Registration Officer
 
@@ -887,7 +890,7 @@ Hint: Click a client's member name to open the client's detail view.
 - "Authentication Certificates" – information about the Security Server's registered authentication certificates.
 Hint: Click a certificate's certification authority to open the certificate's detail view.
 
-## 8.2 Changing the Security Server Address
+### 8.2 Changing the Security Server Address
 
 Access rights: Registration Officer
 
@@ -904,7 +907,7 @@ To change the Security Server address from the Central Server, follow these step
 2. In the view that opens, locate the "Address" section and click Edit adjacent to the "Address" field.
 3. Enter the Security Server's address and click Save.
 
-## 8.3 Registering a Security Server's Authentication Certificate
+### 8.3 Registering a Security Server's Authentication Certificate
 
 Access rights: Registration Officer
 
@@ -926,7 +929,7 @@ Upon approving the request
 To decline the request
 - the request moves to the "Rejected" state;
 
-## 8.4 Deleting a Security Server's Authentication Certificate
+### 8.4 Deleting a Security Server's Authentication Certificate
 
 Access rights: Registration Officer
 
@@ -938,7 +941,7 @@ To submit an authentication certificate deletion request in the Central Server, 
 3. Review the information displayed on the deletion request and enter Security Server code and click Delete to submit the request.
 4. The submitted request appears in the management requests view (Management Requests tab).
 
-## 8.5 Deleting a Security Server
+### 8.5 Deleting a Security Server
 
 Access rights: Registration Officer
 
@@ -948,8 +951,8 @@ To delete a Security Server, follow these steps.
 
 If the Security Server being deleted has registered clients or authentication certificates, deletion requests for those associations are automatically generated.
 
-# 9. Managing the Global Groups
-## 9.1 Adding a Global Group
+## 9. Managing the Global Groups
+### 9.1 Adding a Global Group
 
 Access rights: Registration Officer
 
@@ -957,7 +960,7 @@ To add a new global group, follow these steps.
 1. In the Navigation tabs, select Settings --> Global Resources and click Add Global Group.
 2. In the window that opens, enter the new group's code and description, and click Add. The new group is added to the list of global groups.
 
-## 9.2 Viewing the Global Group Details
+### 9.2 Viewing the Global Group Details
 
 Access rights: Registration Officer
 
@@ -967,7 +970,7 @@ To see the details of a global group, follow these steps.
 
 In the global group detail view, a list of the group's members is displayed. The detail view allows you to change the group's description, delete the group, and add or remove its members.
 
-## 9.3 Changing the Description of a Global Group
+### 9.3 Changing the Description of a Global Group
 
 Access rights: Registration Officer
 
@@ -976,7 +979,7 @@ To change the description of a global group, follow these steps.
 2. Select a global group from the table and click its Code.
 3. In the view that opens, click Edit, change the group’s description and click Save.
 
-## 9.4 Changing the Members of a Global Group
+### 9.4 Changing the Members of a Global Group
 
 Access rights: Registration Officer
 
@@ -994,7 +997,7 @@ To remove members from a group, follow these steps.
 3. Click Remove button on the selected subsystem row.
 4. In the confirmation window that opens, enter the member code and then click Delete.
 
-## 9.5 Deleting a Global Group
+### 9.5 Deleting a Global Group
 
 Access rights: Registration Officer
 
@@ -1003,8 +1006,9 @@ To delete a global group, follow these steps.
 2. Select a global group from the table and click its Code.
 3. In the view that opens, click Delete Group and in the confirmation window click Yes.
 
-# 10. Managing the Approved Certification Services
-## 10.1 Adding an Approved Certification Service
+## 10. Managing the Approved Certification Services
+
+### 10.1 Adding an Approved Certification Service
 
 Access rights: System Administrator
 
@@ -1027,7 +1031,7 @@ To add a new intermediate CA
   - in the window that opens, locate the certificate file of the intermediate CA and click Save;
   - to add OCSP service information to the new intermediate CA, click on the added intermediate CA, in the window that opens, locate OCSP Responders tab and click Add.
 
-## 10.2 Changing an Approved Certification Service
+### 10.2 Changing an Approved Certification Service
 
 Access rights: System Administrator
 
@@ -1040,7 +1044,7 @@ To edit a certification service, follow these steps.
 1. In the Trust Services tab, select Certification Services.
 2. Select from the list the certification service you want to edit and click on the approved certification service field.
 
-## 10.3 Deleting an Approved Certification Service
+### 10.3 Deleting an Approved Certification Service
 
 Access rights: System Administrator
 
@@ -1049,8 +1053,9 @@ To delete a certification service from the list of approved services, follow the
 2. Select from the list the approved certification service you wish to remove and click on the approved certification service field.
 3. In the window that opens, click Delete trust service "\<certification service name\>" and in the confirmation window click Yes.
 
-# 11. Managing the Approved Timestamping Services
-## 11.1 Adding an Approved Timestamping Service
+## 11. Managing the Approved Timestamping Services
+
+### 11.1 Adding an Approved Timestamping Service
 
 Access rights: System Administrator
 
@@ -1059,7 +1064,7 @@ To add an approved timestamping service, follow these steps.
 2. In the window that opens, enter the timestamping service URL and locate the certificate file of the timestamping service and click Add.
 3. Information about the new timestamping service appears in the list.
 
-## 11.2 Changing an Approved Timestamping Service
+### 11.2 Changing an Approved Timestamping Service
 
 Access rights: System Administrator
 
@@ -1067,7 +1072,7 @@ To change the timestamping service, follow these steps.
 1. In the Trust Services tab, select Timestamping Services, select a timestamping service from the list and click Edit.
 2. In the window that opens, edit the URL and/or upload new certificate. Click Save.
 
-## 11.3 Deleting an Approved Timestamping Service
+### 11.3 Deleting an Approved Timestamping Service
 
 Access rights: System Administrator
 
@@ -1075,7 +1080,7 @@ To remove a timestamping service, follow these steps.
 1. In the Trust Services tab, select Timestamping Services, select a timestamping service from the list and click Delete.
 2. In the window that opens, click Yes.
 
-# 12. Configuration Backup and Restore
+## 12. Configuration Backup and Restore
 
 Access rights: System Administrator
 
@@ -1087,14 +1092,14 @@ Backups contain sensitive information that must be kept secret (for example, pri
 
 Central Server backups are signed and optionally encrypted. The GNU Privacy Guard [GnuPG] is used for encryption and signing. Central Server's backup encryption key is generated during Central Server initialisation. In addition to the automatically generated backup encryption key, additional public keys can be used to encrypt backups.
 
-## 12.1 Backing Up the System Configuration
+### 12.1 Backing Up the System Configuration
 
 To back up the configuration, follow these steps.
 1. In the Settings tab, select Back Up and Restore sub-tab.
 2. Click Back up config. to start the backup process.
 3. When done, the configuration backup file appears in the list of configuration backup files.
 
-## 12.2 Restoring the System Configuration in the User Interface
+### 12.2 Restoring the System Configuration in the User Interface
 
 To restore configuration, follow these steps.
 1. In the Settings tab, select Back Up and Restore sub-tab.
@@ -1104,7 +1109,7 @@ To restore configuration, follow these steps.
 
 If something goes wrong while restoring the configuration it is possible to revert back to the old configuration. Central Server stores so called pre-restore configuration automatically to `/var/lib/xroad/conf_prerestore_backup.tar`. Move it to `/var/lib/xroad/backup/` folder and use the command line interface described in the next chapter (some specific switches with the restore command is required).
 
-## 12.3 Restoring the Configuration from the Command Line
+### 12.3 Restoring the Configuration from the Command Line
 
 To restore configuration from the command line, the following data must be available:
 - the instance ID of the Central Server and,
@@ -1156,7 +1161,7 @@ To see all the possible parameters use the -h switch, e.g.
 /usr/share/xroad/scripts/restore_xroad_center_configuration.sh -h
 ```
 
-## 12.4 Downloading, Uploading and Deleting Configuration Backup Files
+### 12.4 Downloading, Uploading and Deleting Configuration Backup Files
 
 The following actions can be performed in the Backup And Restore view.
 
@@ -1169,11 +1174,11 @@ To delete the configuration backup file:
 To upload a configuration file from the local file system to the Central Server:
 - click Upload backup, select a file to be uploaded and click Open. The uploaded configuration file appears in the list of configuration files.
 
-## 12.5 Automatic Backups
+### 12.5 Automatic Backups
 
 By default the Central Server backs up its configuration automatically once every day. Backups older than 30 days are automatically removed from the server. If needed, the automatic backup policies can be adjusted by editing the `/etc/cron.d/xroad-center` file.
 
-## 12.6 Backup Encryption Configuration
+### 12.6 Backup Encryption Configuration
 
 Backups are always signed, but backup encryption is initially turned off. To turn encryption on, please override the
 default configuration in the file `/etc/xroad/conf.d/local.ini`, in the `[center]` section (add or edit this section).
@@ -1233,7 +1238,7 @@ To decrypt the encrypted backups, use the following syntax:
 gpg --homedir /etc/xroad/gpghome --output <output file name> --decrypt <backup name>  
 ```
 
-## 12.7 Verifying Backup Archive Consistency
+### 12.7 Verifying Backup Archive Consistency
 
 During restore Central Server verifies consistency of backup archives automatically, archives are not checked during upload.
 Also, it is possible to verify the consistency of the archives externally. For verifying the consistency externally,
@@ -1256,7 +1261,7 @@ for example, `EE`.
 Resulting file (`server-public-key.gpg`) should then be exported from Central Server and imported to GPG keystore used
 for backup archive consistency verification.
 
-# 13. Audit Log
+## 13. Audit Log
 
 The Central Server keeps an audit log of the events performed by the Central Server administrator. The audit log events are generated by the user interface and the management REST API when the user changes the system’s state or configuration. The user actions are logged regardless of whether the outcome of the action was a success or a failure. The complete list of the audit log events is described in [SPEC-AL](#13-references).
 
@@ -1289,7 +1294,7 @@ By default, audit log is located in the file
 
 `/var/log/xroad/audit.log`
 
-## 13.1 Changing the Configuration of the Audit Log
+### 13.1 Changing the Configuration of the Audit Log
 
 The X-Road software writes the audit log to the syslog (rsyslog) using UDP interface (default port is 514). Corresponding configuration is located in the file
 
@@ -1311,13 +1316,13 @@ The audit log is rotated monthly by logrotate. To configure the audit log rotati
 
 `/etc/logrotate.d/xroad-center`
 
-## 13.2 Archiving the Audit Log
+### 13.2 Archiving the Audit Log
 
 In order to save hard disk space and avoid loss of the audit log records during Central Server crash, it is recommended to archive the audit log files periodically to an external storage or a log server.
 
 The X-Road software does not offer special tools for archiving the audit log. The rsyslog can be configured to redirect the audit log to an external location.
 
-# 14. Monitoring
+## 14. Monitoring
 
 Monitoring is taken to use by installing the monitoring support (see [IG-CS](#13-references) and appointing the central monitoring client as specified below.
 
@@ -1347,8 +1352,9 @@ To disable central monitoring client altogether, update configuration to one whi
 </tns:conf>
 ```
 
-# 15. Additional configuration options
-## 15.1 Verify next update
+## 15. Additional configuration options
+
+### 15.1 Verify next update
 
 For additional robustness the OCSP [RFC-OCSP](#13-references) response verifier can be configured to skip checking of nextUpdate parameter. By default the checking is turned on and to turn it off the user has to take action.
 
@@ -1362,7 +1368,7 @@ Configuration is done by updating a specific optional configuration file (see [
 
 With verifyNextUpdate element value “false” the nextUpdate parameter checking is switched off.
 
-## 15.2 OCSP fetch interval
+### 15.2 OCSP fetch interval
 
 The xroad-signer component has a specific interval how often it downloads new OCSP [RFC-OCSP](#13-references) responses. By default the fetch interval is configured to 1200 seconds. To use something else than the default value a global configuration extension part (see [UC-GCONF](#13-references)) of specific format can be uploaded to Central Server.
 
@@ -1374,7 +1380,7 @@ The xroad-signer component has a specific interval how often it downloads new OC
 
 The value is the fetch interval in seconds for new OCSP responses.
 
-# 16. Logs and System Services
+## 16. Logs and System Services
 
 Most significant Central Server services are the following:
 
@@ -1405,7 +1411,7 @@ Default settings for logging are the following:
 - logging level: INFO;
 - rolling policy: whenever file size reaches 100 MB.
 
-# 17 Management REST API
+## 17 Management REST API
 
 Central Server has a REST API that can be used to do all the same server configuration operations that can be done
 using the web UI.
@@ -1439,7 +1445,7 @@ If the default limits are too restricting (or too loose), they can be overridden
 Size limit parameters support formats from Formats from [DataSize](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/util/unit/DataSize.html),
 for example `5MB`.
 
-## 17.1 API key management operations
+### 17.1 API key management operations
 
 **Access rights:** [System Administrator](#xroad-system-administrator)
 
@@ -1450,7 +1456,7 @@ or with session authentication (for admin web application).
 Basic authentication access is limited to localhost by default, but this can
 be changed using System Parameters \[[UG-SYSPAR](#Ref_UG-SYSPAR)\].
 
-### 17.1.1 Creating new API keys
+#### 17.1.1 Creating new API keys
 
 A new API key is created with a `POST` request to `/api/v1/api-keys`. Message body must contain the roles to be
 associated with the key. Server responds with data that contains the actual API key. After this point the key
@@ -1470,7 +1476,7 @@ curl -X POST -u <user>:<password> https://localhost:4000/api/v1/api-keys --data 
 
 In this example the created key was `68117d38-8613-40b4-a9ff-5afe5ea4d27b`.
 
-### 17.1.2 Listing API keys
+#### 17.1.2 Listing API keys
 
 Existing API keys can be listed with a `GET` request to `/api/v1/api-keys`. This lists all keys, regardless of who has created them.
 
@@ -1504,7 +1510,7 @@ curl -X GET -u <user>:<password> https://localhost:4000/api/v1/api-keys/59 -k
 
 ```
 
-### 17.1.3 Updating API keys
+#### 17.1.3 Updating API keys
 
 An existing API key is updated with a `PUT` request to `/api/v1/api-keys/{id}`. Message body must contain the roles to be
 associated with the key. Server responds with data that contains the key id and roles associated with the key.
@@ -1521,7 +1527,7 @@ curl -X PUT -u <user>:<password> https://localhost:4000/api/v1/api-keys/5 --data
 
 ```
 
-### 17.1.4 Revoking API keys
+#### 17.1.4 Revoking API keys
 
 An API key can be revoked with a `DELETE` request to `/api/v1/api-keys/{id}`. Server responds with `HTTP 200` if
 revocation was successful and `HTTP 404` if key did not exist.
@@ -1531,7 +1537,7 @@ curl -X DELETE -u <user>:<password> https://localhost:4000/api/v1/api-keys/5  -k
 
 ```
 
-## 17.2 Executing REST calls
+### 17.2 Executing REST calls
 
 **Access rights:** Depends on the API.
 
@@ -1560,7 +1566,7 @@ as the corresponding UI operations.
 Access to regular APIs is allowed from all IP addresses by default, but this can
 be changed using System Parameters \[[UG-SYSPAR](#Ref_UG-SYSPAR)\].
 
-## 17.3 Correlation ID HTTP header
+### 17.3 Correlation ID HTTP header
 
 The REST API endpoints return an **x-road-ui-correlation-id** HTTP header. This header is also logged in `centralserver-admin-service.log`, so it
 can be used to find the log messages related to a specific API call.
@@ -1574,7 +1580,7 @@ For example, these log messages are related to an API call with correlation ID `
 2019-08-26 13:16:23,611 [https-jsse-nio-4000-exec-10] correlation-id:[3d5f193102435242] DEBUG o.s.s.w.a.ExceptionTranslationFilter - Chain processed normally
 ```
 
-## 17.4 Data Integrity errors
+### 17.4 Data Integrity errors
 
 An error response from the REST API can include data integrity errors if incorrect data was provided with the request.
 When
@@ -1606,7 +1612,7 @@ Response body:
 
 Possible data integrity error codes and messages declared in [Central Server ErrorMessage](https://github.com/nordic-institute/X-Road/blob/develop/src/central-server/admin-service/core-api/src/main/java/org/niis/xroad/cs/admin/api/exception/ErrorMessage.java)
 
-## 17.5 Warning responses
+### 17.5 Warning responses
 
 Error response from the Management API can include additional warnings that you can ignore if seen necessary. The warnings can be ignored by your decision, by executing the same operation with `ignore_warnings` boolean parameter set to `true`. *Always consider the warning before making the decision to ignore it.*
 
@@ -1644,7 +1650,7 @@ Response:
 
 Note that when you are using the admin UI and you encounter warnings, you will always be provided with a popup window with a `CONTINUE` button in it. When you click the `CONTINUE` button in the popup, the request is sent again but this time warnings will be ignored.
 
-# 18 Migrating to Remote Database Host
+## 18. Migrating to Remote Database Host
 
 Since version 6.23.0 Central Server supports using remote databases. In case you have an already running standalone Central Server with local database, it is possible to migrate it to use remote database host instead. The instructions for this process are listed below.
 
@@ -1735,11 +1741,11 @@ pg_restore -h <remote-db-url> -p <remote-db-port> -U centerui_admin -O -n center
 systemctl start "xroad*"
 ```
 
-# 19 Additional Security Hardening
+## 19. Additional Security Hardening
 
 For the guidelines on security hardening, please refer to [UG-SEC](ug-sec_x_road_security_hardening.md).
 
-# 20 Passing additional parameters to psql
+## 20. Passing additional parameters to psql
 
 By default any scripts(for example backup/restore) that uses `psql` utility tries to parse `/etc/xroad/db.properties` file for database related configurations like: database name, user, password, host, port. If the file is not found, the script may use default values which will point to local database. When such behaviour doesn't cover the requirements, it is possible to pass additional configurations to `psql` utility using environment variables from file.
 
@@ -1761,9 +1767,9 @@ Some of the variables like `PGOPTIONS`, `PGDATABASE`, `PGUSER`, `PGPASSWORD` are
 
 In case it is needed to pass additional flags to internally initialized `PGOPTIONS` variable, then `PGOPTIONS_EXTRA` variable can be used. It will be appended to `PGOPTIONS` variable.
 
-# 21 Migrating to EC Based Configuration Signing Keys
+## 21. Migrating to EC Based Configuration Signing Keys
 
-## 21.1 Steps to Enable EC Based Signing Keys
+### 21.1 Steps to Enable EC Based Signing Keys
 
 Since version 7.6.0 Central Server supports ECDSA based configuration signing keys. By default, both internal and external configuration signing keys use the RSA algorithm as in previous versions. The EC algorithm can be enabled separately for internal and external keys so migration can be done in steps, e.g., first internal and then external keys or vice versa. The instructions on how to start using internal and external signing EC keys are listed below.
 
@@ -1778,7 +1784,7 @@ external-key-algorithm = EC
 2. Restart the `xroad-center` service to apply the changes made to the configuration file.
 3. Follow the instructions in the [Generating a Configuration Signing Key](#541-generating-a-configuration-signing-key) to generate new keys, which will be using EC algorithm now.
 
-## 21.2 Backwards Compatibility
+### 21.2 Backwards Compatibility
 
 When Central Server is configured to use EC based signing keys, then Security Servers prior to version 7.6.0 are not be able to use the global configuration. In other words, EC based internal signing keys can be used only when all the Security Servers in the local ecosystem use X-Road version 7.6.0 or later. Instead, in a federated setup, EC based external signing keys can be used only when all the Security Servers in all the federated ecosystems use X-Road version 7.6.0 or later.
 Before migrating to EC based configuration signing keys, always remember to make sure that all the Security Servers in all the affected ecosystems use X-Road version 7.6.0 or later.

--- a/doc/Manuals/ug-sec_x_road_security_hardening.md
+++ b/doc/Manuals/ug-sec_x_road_security_hardening.md
@@ -1,6 +1,6 @@
 # X-Road: Security hardening guidelines <!-- omit in toc -->
 
-Version: 0.5  
+Version: 0.6  
 Doc. ID: UG-SEC
 
 ## Version history <!-- omit in toc -->
@@ -12,6 +12,7 @@ Doc. ID: UG-SEC
 | 14.11.2023 | 0.3     | Publish global configuration over HTTPS          | Eneli Reimets     |
 | 15.12.2023 | 0.4     | Minor updates                                    | Eneli Reimets     |
 | 07.01.2025 | 0.5     | Update references                                | Petteri Kivimäki  |
+| 09.01.2025 | 0.6     | Restructure heading levels                       | Raido Kaju        |
 
 ## Table of Contents <!-- omit in toc -->
 <!-- toc -->
@@ -43,20 +44,20 @@ Doc. ID: UG-SEC
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# 1. Introduction
+## 1. Introduction
 
 You may want to harden the security of your X-Road instance by configuring additional security policies within your X-Road infrastructure.
 The security measures that are introduced in this guide are common security policies that can be configured on operating system level.
 
-## 1.1 Target Audience
+### 1.1 Target Audience
 
 The intended audience of this User Guide are X-Road administrators (Central or Security server) who are responsible for X-Road instance set-up and/or everyday management of the X-Road infrastructure.
 
-## 1.2 Terms and abbreviations
+### 1.2 Terms and abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-## 1.3 References
+### 1.3 References
 
 1. <a id="Ref_IG-CS" class="anchor"></a>\[IG-CS\] X-Road: Central Server Installation Guide. Document ID: [IG-CS](ig-cs_x-road_6_central_server_installation_guide.md).
 2. <a id="Ref_UG-CS" class="anchor"></a>\[UG-CS\] X-Road: Central Server User Guide. Document ID: [UG-CS](ug-cs_x-road_6_central_server_user_guide.md).
@@ -66,7 +67,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 6. <a id="Ref_TERMS" class="anchor"></a>\[TA-TERMS\] X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../terms_x-road_docs.md).
 7. <a id="Ref_UG-CP" class="anchor"></a>\[UG-CP\] X-Road: Configuration Proxy Manual. Document ID: [UG-CP](ug-cp_x-road_v6_configuration_proxy_manual.md).
 
-## 2 User management
+## 2. User management
 
 X-Road uses the Linux Pluggable Authentication Modules (PAM) to authenticate users. This makes it easy to configure the account management to your liking. 
 The example PAM configurations provided in this guide may or may not work on your system depending on your system and existing PAM configurations. 

--- a/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
+++ b/doc/OperationalMonitoring/Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md
@@ -156,7 +156,7 @@ The interface is described in more detail in [[ARC-G]](#ARC-G) and [[PR-GCONF]]
 
 Figure 2 shows the deployment diagram.
 
-<img src="x-road_operational_monitoring_daemon_deployment.png" width="40%" />
+![Operational monitoring daemon deployment diagram](x-road_operational_monitoring_daemon_deployment.png)
 
 **Figure 2. Operational monitoring daemon deployment**
 

--- a/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmon_x-road_operational_monitoring_protocol_Y-1096-2.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.4  
+Version: 1.5  
 Doc. ID: PR-OPMON
 
 | Date       | Version | Description                                                          | Author           |
@@ -18,6 +18,7 @@ Doc. ID: PR-OPMON
 | 01.06.2023 | 1.2     | Update references                                                    | Petteri Kivimäki |
 | 02.10.2024 | 1.3     | Update schema file locations                                         | Justas Samuolis  | 
 | 05.12.2024 | 1.4     | Add endpoint level statistics gathering support                      | Eneli Reimets    |
+| 09.01.2025 | 1.5     | Restructure heading levels for the documentation platform            | Raido Kaju       |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -40,11 +41,11 @@ Doc. ID: PR-OPMON
 
 <!-- tocstop -->
 
-# License
+## License
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# 1 Introduction
+## 1 Introduction
 
 This specification describes services that can be used by X-Road participants to gather operational monitoring information of the security servers. The operational monitoring information contains data about request exchange (such as which services or endpoints have been called, how many times, what was the size of the response, etc.) of the security servers. The X-Road operational monitoring protocol is intended to support external monitoring systems and other software that can monitor service level agreements, make service statistics, etc.
 
@@ -77,7 +78,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="RFC2119"></a>**RFC2119** -- Key words for use in RFCs to Indicate Requirement Levels. Request for Comments 2119, Internet Engineering Task Force, March 1997, https://www.ietf.org/rfc/rfc2119.txt  
 <a name="Ref_TERMS" class="anchor"></a>**TA-TERMS** -- X-Road Terms and Abbreviations. Document ID: [TA-TERMS](../../terms_x-road_docs.md).
 
-# 2 Retrieving Operational Data of Security Server
+## 2 Retrieving Operational Data of Security Server
 
 Security server clients can retrieve operational data of the specified time period of the security server. Method is invoked as regular X-Road service.
 
@@ -183,7 +184,7 @@ The XML schema fragment of the operational data response body is shown below. Fo
 
 The example response message is presented in \[[Annex C.2](#AnnexC.2)\].
 
-# 3 Retrieving Health Data of Security Server
+## 3 Retrieving Health Data of Security Server
 
 Security server clients can retrieve health data of the specified security server. Method is invoked as regular X-Road service.
 
@@ -950,7 +951,7 @@ The WSDL is located in the file *src/op-monitor-daemon/core/src/main/resources/o
 ```
 
 <a name="AnnexB"/></a>
-# Annex B JSON-Schema for Payload of getSecurityServerOperationalData Response
+## Annex B JSON-Schema for Payload of getSecurityServerOperationalData Response
 
 The schema is located in the file *src/op-monitor-daemon/core/src/main/resources/query_operational_data_response_payload_schema.yaml* of the X-Road source code.
 
@@ -1123,10 +1124,10 @@ required:
 ```
 
 <a name="AnnexC"/></a>
-# Annex C Example Messages
+## Annex C Example Messages
 
 <a name="AnnexC.1"/></a>
-## C.1 getSecurityServerOperationalData Request
+### C.1 getSecurityServerOperationalData Request
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -1169,7 +1170,7 @@ required:
 ```
 
 <a name="AnnexC.2"/></a>
-## C.2 getSecurityServerOperationalData Response
+### C.2 getSecurityServerOperationalData Response
 
 ```xml
 Content-Type: multipart/related; type="text/xml"; charset=UTF-8;
@@ -1226,7 +1227,7 @@ content-id: <operational-monitoring-data.json.gz>
 --xroadfngEfgBlxyLszDaqXiFfDxVzvvlbhU--
 ```
 
-### C.2.1 Example JSON-Payload of getSecurityServerOperationalData Response
+#### C.2.1 Example JSON-Payload of getSecurityServerOperationalData Response
 
 ```json
 {
@@ -1269,7 +1270,7 @@ content-id: <operational-monitoring-data.json.gz>
 }
 ```
 <a name="AnnexC.3"/></a>
-## C.3 getSecurityServerHealthData Request
+### C.3 getSecurityServerHealthData Request
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -1316,7 +1317,7 @@ content-id: <operational-monitoring-data.json.gz>
 ```
 
 <a name="AnnexC.3"/></a>
-## C.4 getSecurityServerHealthData Response
+### C.4 getSecurityServerHealthData Response
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
+++ b/doc/OperationalMonitoring/Protocols/pr-opmonjmx_x-road_operational_monitoring_jmx_protocol_Y-1096-3.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.2  
+Version: 1.3  
 Doc. ID: PR-OPMONJMX
 
 | Date       | Version | Description                                                         | Author           |
@@ -13,6 +13,7 @@ Doc. ID: PR-OPMONJMX
 | 12.12.2019 | 1.0     | Add description of serviceType gauges                               | Ilkka Seppälä    |
 | 25.06.2020 | 1.1     | Add note about JMX being disabled by default                        | Petteri Kivimäki |
 | 01.06.2023 | 1.2     | Update references                                                   | Petteri Kivimäki |
+| 09.01.2025 | 1.3     | Restructure heading levels for the documentation platform           | Raido Kaju       |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -30,11 +31,11 @@ Doc. ID: PR-OPMONJMX
 
 <!-- tocstop -->
 
-# License
+## License
 
 This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.
 
-# 1 Introduction
+## 1 Introduction
 
 This document specifies the format and protocol for exchanging health data of X-Road security servers that the X-Road operational monitoring daemon makes available for applications implementing the Java Management Extensions (JMX) using the JMX Messaging Protocol (JMXMP).
 
@@ -50,11 +51,11 @@ This specification does not include option for partially implementing the protoc
 
 **By default, operational monitoring JMX interface is disabled. Enabling the JMX interface is explained in \[[ARC-OPMOND](#Ref_ARC-OPMOND)\].**
 
-## 1.1 Terms and Abbreviations
+### 1.1 Terms and Abbreviations
 
 See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 
-## 1.2 References
+### 1.2 References
 
 <a name="Ref_PR-MESS"></a>**PR-MESS** -- X-Road: Message Protocol v4.0. Document ID: [PR-MESS](../../Protocols/pr-mess_x-road_message_protocol.md).  
 <a name="Ref_JMX"></a>**JMX** -- Java Management Extensions (JMX) Specification, version 1.4, http://download.oracle.com/otn-pub/jcp/jmx_remote-1_4-mrel2-eval-spec/jsr160-jmx-1_4-mrel4-spec-FINAL-v1_0.pdf  
@@ -65,7 +66,7 @@ See X-Road terms and abbreviations documentation \[[TA-TERMS](#Ref_TERMS)\].
 <a name="Ref_ARC-OPMOND"></a>**ARC-OPMOND** -- X-Road: Operational Monitoring Daemon Architecture. Document ID: [ARC-OPMOND](../Architecture/arc-opmond_x-road_operational_monitoring_daemon_architecture_Y-1096-1.md).
 
 <a name="section_2"></a>
-# 2 Encoding X-Road Service Identifiers in Object Names
+## 2 Encoding X-Road Service Identifiers in Object Names
 
 In the object names of exposed MBeans, X-Road service identifiers are encoded according to the following rules:
 
@@ -75,7 +76,7 @@ In the object names of exposed MBeans, X-Road service identifiers are encoded ac
 * Because the JMXMP protocol imposes the XML character set on the names of objects, the following characters are escaped using XML escape sequences: `"` (`&quot;`), `'` (`&apos;`), `<` (`&lt;`), `>` (`&gt;`), `&` (`&amp;`).
 * In order to provide compatibility with the Zabbix monitoring system \[[ZABBIX](#Ref_ZABBIX)\], the following characters are escaped in addition: `.` (`&#46;`), `\` (`&#92;`), the space (`&#32;`), `,` (`&#44;`), `[` (`&#91;`), `]` (`&#93;`).
 
-# 3 Objects, Attributes and Operations Exposed over JMXMP
+## 3 Objects, Attributes and Operations Exposed over JMXMP
 
 The `MBean` objects exposed by the operational monitoring daemon over JMXMP have been implemented using the types of metrics available in the `com.codahale.metrics` library \[[METRICS](#Ref_METRICS)\], version 3.0. All the metric classes implement the `com.codahale.metrics.Metric` interface. More precisely, the following classes are used for making health data available:
 
@@ -85,7 +86,7 @@ The `MBean` objects exposed by the operational monitoring daemon over JMXMP have
 
 For each `MBean` object there is an associated `MBeanInfo` object available that describes the management interface exposed by the object: the name of the class, the name of the object and its description for consumers of the data over JMXMP.
 
-## 3.1 Gauge Metrics
+### 3.1 Gauge Metrics
 
 The value of the `ClassName` attribute of the `MBeanInfo` object for gauges is `com.codahale.metrics.JmxReporter$JmxGauge`.
 
@@ -102,7 +103,7 @@ For each service mediated during the configured statistics period, the following
 
 where `<service ID>` will be replaced by the full ID of the service encoded as described in \[[Section 2](#section_2)\].
 
-## 3.2 Counter Metrics
+### 3.2 Counter Metrics
 
 The value of the `ClassName` attribute of the `MBeanInfo` object for counters is `com.codahale.metrics.JmxReporter$JmxCounter`.
 
@@ -114,7 +115,7 @@ For each service mediated during the configured statistics period, the following
 
 where `<service ID>` will be replaced by the full ID of the service encoded as described in \[[Section 2](#section_2)\.
 
-## 3.3 Histogram Metrics
+### 3.3 Histogram Metrics
 
 The value of the `ClassName` attribute of the `MBeanInfo` object for histograms is `com.codahale.metrics.JmxReporter$JmxHistogram`.
 


### PR DESCRIPTION
Resolves the issue with heading levels being incorrect in various documents.

Also changed how the image is included in OpMon daemons architecture document so that it is properly included.