### PR TITLE
fix: global conf extension loader gets a reflection error because of package access

### DIFF
--- a/src/lib/globalconf-core/src/main/java/org/niis/xroad/globalconf/extension/OcspFetchInterval.java
+++ b/src/lib/globalconf-core/src/main/java/org/niis/xroad/globalconf/extension/OcspFetchInterval.java
@@ -56,7 +56,7 @@ public class OcspFetchInterval extends AbstractXmlConf<OcspFetchIntervalType> {
      */
     public static final int OCSP_FETCH_INTERVAL_MIN = 60;
 
-    OcspFetchInterval() {
+    public OcspFetchInterval() {
         super(OcspFetchIntervalSchemaValidator.class);
     }
 

--- a/src/lib/globalconf-core/src/main/java/org/niis/xroad/globalconf/extension/OcspNextUpdate.java
+++ b/src/lib/globalconf-core/src/main/java/org/niis/xroad/globalconf/extension/OcspNextUpdate.java
@@ -50,7 +50,7 @@ public class OcspNextUpdate extends AbstractXmlConf<OcspNextUpdateType> {
      */
     public static final boolean OCSP_NEXT_UPDATE_DEFAULT = true;
 
-    OcspNextUpdate() {
+    public OcspNextUpdate() {
         super(OcspNextUpdateSchemaValidator.class);
     }
 


### PR DESCRIPTION
Found `java.lang.IllegalAccessException: class org.niis.xroad.globalconf.impl.extension.GlobalConfExtensionLoaderImpl cannot access a member of class org.niis.xroad.globalconf.extension.OcspFetchInterval with package access` error from ec2 dev env signer logs while doing janitor things.