### PR TITLE
fix: xroad-opmonitor runs into Out-Of-Memory exceptions

### DIFF
--- a/src/packages/src/xroad/common/op-monitor/etc/xroad/services/opmonitor.conf
+++ b/src/packages/src/xroad/common/op-monitor/etc/xroad/services/opmonitor.conf
@@ -9,7 +9,7 @@ CUSTOM_OPMON_PARAMS="$XROAD_OPMON_PARAMS"
 
 CP="/usr/share/xroad/jlib/op-monitor-daemon.jar"
 
-XROAD_OPMON_PARAMS=" -Xms50m -Xmx256m -XX:MaxMetaspaceSize=80m \
+XROAD_OPMON_PARAMS=" -Xms50m -Xmx350m -XX:MaxMetaspaceSize=80m \
 -Dlogback.configurationFile=/etc/xroad/conf.d/op-monitor-logback.xml $XROAD_OPMON_PARAMS"
 
 apply_local_conf XROAD_OPMON_PARAMS


### PR DESCRIPTION
refs: XRDDEV-2848