### PR TITLE
feat(i18n): add pt-BR language support in X-Road admin interfaces

### DIFF
--- a/src/central-server/admin-service/ui/src/locales/pt.json
+++ b/src/central-server/admin-service/ui/src/locales/pt.json
@@ -1,0 +1,766 @@
+{
+  "403": {
+    "goBack": "Voltar",
+    "mainTitle": "Permissão negada",
+    "text": "Parece que você não tem permissão para visualizar esta página. Se você acha que isso é um erro, verifique se está logado na conta correta ou entre em contato com o administrador para verificar suas permissões.",
+    "topTitle": "Proibido"
+  },
+  "action": {
+    "approve": "Aprovar",
+    "decline": "Recusar",
+    "select": "Selecionar",
+    "generateCsr": "Gerar CSR"
+  },
+  "apiKey": {
+    "role": {
+      "XROAD_MANAGEMENT_SERVICE": "Serviços de Gestão"
+    }
+  },
+  "customValidation": {
+    "invalidUrl": "URL inválida. Exemplos de formatos válidos: 'http://www.exemplo.com', 'https://www.exemplo.com'",
+    "invalidIpAddress": "O campo deve conter um endereço IP ou múltiplos endereços separados por vírgula"
+  },
+  "error_code": {
+    "certificate_profile_info_class_not_found": "Classe de informações do perfil do certificado não encontrada",
+    "certification_service_not_found": "Serviço de certificação não encontrado.",
+    "configuration_not_found": "Fonte de configuração não encontrada",
+    "configuration_part_file_not_found": "Arquivo da parte de configuração não encontrado",
+    "configuration_part_validation_failed": "Falha na validação da parte de configuração",
+    "configuration_part_validator_not_found": "Validador da parte de configuração não encontrado",
+    "error_activating_signing_key": "Erro ao ativar a chave de assinatura",
+    "error_deleting_signing_key": "Erro ao excluir a chave de assinatura",
+    "error_recreating_anchor": "Erro ao recriar o arquivo âncora",
+    "global_group_exists": "Um grupo global com o mesmo código já existe.",
+    "global_group_not_found": "Grupo global com o código fornecido não existe",
+    "init_already_initialized": "Falha na inicialização do servidor central, já completamente inicializado",
+    "init_invalid_params": "Parâmetros vazios, ausentes ou redundantes fornecidos para inicialização",
+    "init_signer_pin_policy_failed": "Falha na política de PIN do token no Signer",
+    "init_software_token_failed": "Falha na inicialização do token de software",
+    "instance_identifier_not_set": "Parâmetro de sistema para identificador de instância não definido",
+    "intermediate_ca_not_found": "CA intermediária não encontrada",
+    "internal_error": "Erro interno. Consulte os logs do servidor para mais detalhes",
+    "invalid_certificate": "Certificado X.509 inválido",
+    "invalid_member_id": "ID de membro inválido",
+    "invalid_pagination_properties": "Paginação possui propriedades inválidas",
+    "invalid_service_provider_id": "ID de provedor de serviço inválido",
+    "invalid_sort_properties": "Parâmetro de ordenação inválido",
+    "invalid_subsystem_id": "ID de subsistema inválido",
+    "invalid_url": "URL inválida",
+    "invalid_ip_address": "Endereço IP inválido",
+    "key_generation_failed": "Falha ao gerar chave de assinatura",
+    "management_request_cannot_register_owner": "Não é possível registrar o proprietário como cliente",
+    "management_request_client_already_owner": "O cliente já é proprietário do servidor seguro",
+    "management_request_client_already_registered": "O cliente já está registrado em um servidor",
+    "management_request_client_registration_not_found": "Registro de cliente não encontrado",
+    "management_request_exists": "Já existe uma solicitação de gerenciamento pendente.",
+    "management_request_invalid_auth_certificate": "Certificado de autenticação inválido",
+    "management_request_invalid_state": "A operação solicitada não pode ser aplicada neste estado",
+    "management_request_invalid_state_for_approval": "A solicitação de gerenciamento não pode ser aprovada",
+    "management_request_member_not_found": "Membro não encontrado",
+    "management_request_not_found": "Nenhuma solicitação de gerenciamento com o ID especificado encontrada.",
+    "management_request_not_supported": "Tipo de solicitação de gerenciamento desconhecido",
+    "management_request_owner_must_be_client": "O proprietário não está registrado como cliente no servidor seguro",
+    "management_request_owner_must_be_member": "O proprietário deve ser um membro",
+    "management_request_security_server_exists": "O certificado já está registrado.",
+    "management_request_server_code_exists": "O membro já possui um servidor seguro com este código",
+    "management_request_server_not_found": "servidor seguro não encontrado",
+    "management_request_server_owner_not_found": "Proprietário do servidor seguro não encontrado",
+    "management_request_unknown_type": "Tipo de solicitação desconhecido",
+    "management_service_provider_not_set": "Provedor de serviço de gerenciamento não configurado",
+    "member_class_exists": "Classe de membro com o mesmo código já existe.",
+    "member_class_is_in_use": "Não é possível excluir a classe de membro: existem membros registrados pertencentes à classe. Apenas classes sem membros registrados podem ser excluídas.",
+    "member_class_not_found": "Nenhuma classe de membro com o código especificado encontrada.",
+    "member_exists": "Membro com o mesmo código já existe.",
+    "member_not_found": "Nenhum membro com o código/ID especificado encontrado.",
+    "no_configuration_signing_keys_configured": "Nenhuma chave de assinatura de configuração configurada",
+    "ocsp_responder_not_found": "Validador OCSP não encontrado",
+    "owners_global_group_cannot_be_deleted": "Não é possível excluir o grupo global dos proprietários do servidor",
+    "owners_global_group_member_cannot_be_deleted": "Não é possível excluir membro do grupo global de proprietários",
+    "signer_proxy_error": "Exceção no proxy do assinador",
+    "signing_key_action_not_possible": "Ação da chave de assinatura não é possível",
+    "signing_key_not_found": "Chave de assinatura não encontrada",
+    "ss_auth_certificate_not_found": "Certificado de autenticação não encontrado",
+    "subsystem_already_registered_to_security_server": "Subsistema já registrado no servidor seguro",
+    "subsystem_exists": "Subsistema com o mesmo código já existe.",
+    "subsystem_not_found": "Subsistema com o código especificado não encontrado.",
+    "subsystem_not_registered_to_security_server": "Subsistema não está registrado no servidor seguro especificado.",
+    "subsystem_registered_and_cannot_be_deleted": "Não é possível excluir subsistema já registrado.",
+    "timestamping_authority_not_found": "Autoridade de carimbo de tempo não encontrada",
+    "token_action_not_possible": "Ação do token não é possível",
+    "token_activation_failed": "Falha na ativação do token",
+    "token_deactivation_failed": "Falha na desativação do token",
+    "token_incorrect_pin_format": "Formato de PIN incorreto",
+    "token_invalid_characters": "O PIN fornecido contém caracteres inválidos",
+    "token_pin_final_try": "Tentativas restantes: 1",
+    "token_pin_locked": "PIN do token bloqueado",
+    "token_weak_pin": "O PIN fornecido é muito fraco",
+    "unknown_configuration_part": "Parte de configuração desconhecida",
+    "malformed_anchor": "Arquivo âncora malformado",
+    "trusted_anchor_verification_failed": "Falha na verificação do âncora confiável",
+    "trusted_anchor_not_found": "Âncora confiável não encontrada",
+    "invalid_parameters": "Falha de validação",
+    "security_server_not_found": "Servidor seguro não encontrado",
+    "invalid_encoded_id": "ID codificado inválido",
+    "id_not_a_number": "ID não é um número",
+    "invalid_role": "Papel inválido",
+    "invalid_file_content_type": "Tipo de conteúdo do arquivo enviado é inválido",
+    "invalid_file_extension": "Extensão de arquivo inválida",
+    "double_file_extension": "Extensão de arquivo dupla não é permitida",
+    "backup_deletion_failed": "Falha ao excluir o backup",
+    "conf_verification.anchor_not_for_external_source": "Falha na verificação da configuração: âncora não é para fonte externa",
+    "conf_verification.missing_private_params": "Falha na verificação da configuração: parâmetros privados ausentes",
+    "conf_verification.other": "Falha na verificação da configuração: outro",
+    "conf_verification.outdated": "Falha na verificação da configuração: desatualizado",
+    "conf_verification.signature_invalid": "Falha na verificação da configuração: assinatura inválida",
+    "conf_verification.unreachable": "Falha na verificação da configuração: inacessível",
+    "cannot_add_member_to_owners_group": "Não é possível adicionar membros ao grupo de proprietários do servidor",
+    "generate_key_cert_interrupted": "A geração de chave e certificado foi interrompida",
+    "key_and_cert_generation_failed": "Falha ao gerar chave e certificado TLS",
+    "csr_generation_failed": "Falha na geração do CSR",
+    "cannot_convert_bytes_to_certificate": "Não é possível converter bytes em certificado",
+    "certificate_writing_failed": "Falha ao gravar certificado no arquivo",
+    "cannot_read_certificate": "Não é possível ler o certificado TLS",
+    "key_not_found": "O certificado importado não corresponde à chave TLS",
+    "certificate_already_exists": "O certificado importado já existe",
+    "certificate_import_failed": "Não é possível importar o certificado TLS",
+    "invalid_address_char": "O campo de endereço contém caracteres inválidos"
+  },
+  "fields": {
+    "init": {
+      "address": "Endereço do Servidor Central",
+      "confirmPin": "Repetir PIN",
+      "identifier": "Identificador da Instância",
+      "pin": "PIN",
+      "repeatPin": "Repetir PIN"
+    },
+    "initialServerConf": {
+      "centralServerAddress": "Endereço do Servidor Central",
+      "instanceIdentifier": "Identificador da Instância"
+    },
+    "username": "Nome de Usuário",
+    "url": "URL",
+    "tokenPin": "PIN do Token",
+    "keyLabel": "Nome amigável da chave",
+    "subsystemCode": "Código do Subsistema",
+    "memberCode": "Código do Membro",
+    "memberName": "Nome do Membro",
+    "securityServerAddress": "Endereço do servidor seguro",
+    "serverCode": "Código do Servidor",
+    "serviceAddress": "Endereço do Servidor Central",
+    "certProfile": "Informações do Perfil do Certificado",
+    "certFile": "Arquivo de Certificado",
+    "distinguishedName": "Nome Diferenciado",
+    "acmeServerDirectoryUrl": "URL do Diretório do Servidor ACME",
+    "acmeServerIpAddress": "Endereço(s) IP do Servidor ACME",
+    "authenticationCertificateProfileId": "ID do Perfil do Certificado de Autenticação",
+    "signingCertificateProfileId": "ID do Perfil do Certificado de Assinatura"
+  },
+  "filters": {
+    "apply": "Aplicar",
+    "chooseFilters": "Escolher filtros",
+    "clearFields": "Limpar campos",
+    "groupMembers": {
+      "byClass": "Por classe",
+      "byCode": "Por código",
+      "byInstance": "Por instância",
+      "bySubsystem": "Por subsistema",
+      "byType": "Por tipo",
+      "class": "Classe",
+      "instance": "Instância",
+      "member": "Membro",
+      "subsystem": "Subsistema"
+    },
+    "managementRequests": {
+      "byCreationDate": "Por data de criação",
+      "byRequestType": "Por tipo de solicitação",
+      "byServerCode": "Por código do servidor",
+      "byServerOwnerClass": "Por classe do proprietário do servidor",
+      "byServerOwnerCode": "Por código do proprietário do servidor",
+      "byServerOwnerName": "Por nome do proprietário do servidor",
+      "bySource": "Por origem",
+      "byStatus": "Por status"
+    }
+  },
+  "global": {
+    "appTitle": "X-Road Servidor Central ",
+    "pageNotFound": "Ops, página não encontrada",
+    "approve": "Aprovar",
+    "class": "Classe",
+    "code": "Código",
+    "created": "Criado",
+    "delete": "Excluir",
+    "id": "ID",
+    "instance": "Instância",
+    "memberClass": "Classe do Membro",
+    "memberCode": "Código do Membro",
+    "memberName": "Nome do Membro",
+    "navigation": {
+      "back": "Voltar"
+    },
+    "register": "Registrar",
+    "search": "Pesquisar",
+    "server": "Servidor",
+    "status": "Status",
+    "subsystem": "Subsistema",
+    "type": "Tipo"
+  },
+  "globalConf": {
+    "globalConf": "Configuração Global",
+    "internalConf": "Configuração Interna",
+    "trustedAnchors": "Âncora Confiável",
+    "cfgParts": {
+      "title": "Partes da Configuração",
+      "file": "Arquivo",
+      "contentIdentifier": "Identificador de Conteúdo",
+      "version": "Versão",
+      "allVersions": "Todas as versões",
+      "updated": "Atualizado",
+      "dialog": {
+        "upload": {
+          "title": "Carregar Parte da Configuração",
+          "uploadConfigurationPart": "Carregar o arquivo de configuração do seu computador",
+          "success": "Parte da Configuração carregada com sucesso."
+        }
+      }
+    },
+    "anchor": {
+      "title": "Âncora",
+      "certificateHash": "Hash do Certificado (SHA-224)",
+      "created": "Criado",
+      "download": "Baixar",
+      "recreate": "Recriar",
+      "recreateSuccess": "Âncora de configuração {configurationType} gerada com sucesso"
+    },
+    "downloadUrl": {
+      "title": "Baixar URL",
+      "urlAddress": "Endereço URL"
+    },
+    "trustedAnchor": {
+      "dialog": {
+        "upload": {
+          "confirmation": "Continuar com o envio?",
+          "field": {
+            "generated": "Gerado",
+            "hash": "Hash (SHA-224)"
+          },
+          "info": "Detalhes da âncora confiável:",
+          "success": "Âncora confiável enviada com sucesso",
+          "title": "Confirmar detalhes da âncora confiável"
+        },
+        "delete": {
+          "confirmation": "Excluir a âncora {identifier} com Hash (SHA-224) {hash}?",
+          "success": "Âncora confiável excluída com sucesso",
+          "title": "Excluir Âncora"
+        }
+      }
+    }
+  },
+  "globalGroup": {
+    "added": "Adicionado",
+    "addMembers": "Adicionar Membros",
+    "areYouSure": "Tem certeza de que deseja remover o grupo global {group}?",
+    "code": "Código",
+    "class": "Classe",
+    "deleteGroup": "Excluir Grupo",
+    "description": "Descrição",
+    "descriptionSaved": "Descrição salva com sucesso.",
+    "editDescription": "Editar Descrição",
+    "groupDeletedSuccessfully": "Grupo global excluído com sucesso.",
+    "groupMembers": "Membros do grupo ({memberCount})",
+    "instance": "Instância",
+    "memberName": "Nome do Membro",
+    "subsystem": "Subsistema",
+    "type": "Tipo",
+    "dialog": {
+      "addMembers": {
+        "title": "Adicionar Membros",
+        "success": "Membros com identificadores: {identifiers} foram adicionados a este grupo global"
+      },
+      "deleteMember": {
+        "title": "Excluir Membro",
+        "confirmation": "Tem certeza de que deseja excluir o membro do grupo com o identificador \"{identifier}\" deste grupo global? Insira o código do membro para confirmar.",
+        "placeholder": "Insira o Código do Membro",
+        "success": "Membro com o identificador \"{identifier}\" foi excluído deste grupo global"
+      }
+    }
+  },
+  "globalResources": {
+    "addGlobalGroup": "Adicionar Grupo Global",
+    "globalGroupSuccessfullyAdded": "Grupo global adicionado com sucesso.",
+    "code": "Código",
+    "description": "Descrição",
+    "globalGroups": "Grupos Globais",
+    "memberCount": "Contagem de Membros",
+    "updated": "Atualizado"
+  },
+  "init": {
+    "address": {
+      "info": "Nome DNS público ou endereço IP externo do servidor central. Usado para conexões de entrada da rede externa para o servidor central."
+    },
+    "csIdentification": "Identificação do Servidor Central",
+    "initialConfiguration": "Configuração Inicial",
+    "instanceIdentifier": {
+      "info": "Código da instância X-Road, identifica exclusivamente esta instância X-Road."
+    },
+    "notification": "O Servidor Central foi inicializado! Agora continue com a configuração completa.",
+    "pin": {
+      "info": "PIN para acessar o token de software.",
+      "pinMatchError": "A confirmação da senha não corresponde",
+      "repeat": "Repetir PIN"
+    },
+    "softwareToken": "Token de Software"
+  },
+  "keys": {
+    "title": "Chaves de Assinatura",
+    "addKey": "Adicionar chave",
+    "created": "Criado",
+    "logIn": "Entrar",
+    "logOut": "Sair",
+    "signKey": "Assinar chave",
+    "algorithm": "Algoritmo da chave",
+    "token": "Token:",
+    "dialog": {
+      "delete": {
+        "title": "Excluir chave",
+        "text": "Excluir chave '{label}'?",
+        "confirmButton": "Excluir",
+        "success": "Chave de assinatura excluída com sucesso"
+      },
+      "add": {
+        "title": "Adicionar chave",
+        "labelField": "Nome amigável da chave",
+        "confirmButton": "Adicionar",
+        "success": "Chave de assinatura '{label}' adicionada com sucesso. Por favor, não ative a chave imediatamente. Consulte o guia do usuário do Servidor Central antes de ativar a chave."
+      },
+      "activate": {
+        "title": "Ativar chave",
+        "text": "Ativar chave '{label}'?",
+        "confirmButton": "Ativar",
+        "success": "Chave de assinatura '{label}' ativada com sucesso"
+      }
+    }
+  },
+  "tokens": {
+    "keysInfoMessage": "É permitido no máximo duas chaves de assinatura de fonte de configuração em um token de segurança",
+    "logIn": "Entrar",
+    "pin": "PIN do Token",
+    "loginDialog": {
+      "title": "Entrar",
+      "success": "Token autenticado com sucesso"
+    },
+    "logout": {
+      "title": "Sair",
+      "confirmButton": "Sair",
+      "text": "Tem certeza de que deseja sair do token?",
+      "success": "Desconectado do token"
+    },
+    "errors": {
+      "Signer": {
+        "PinIncorrect": "PIN inválido"
+      }
+    }
+  },
+  "managementRequests": {
+    "addCertificate": "Adicionar Certificado",
+    "addClient": "Adicionar Cliente",
+    "approved": "Aprovado",
+    "submitted": "Enviado para aprovação",
+    "changeOwner": "Alterar Proprietário",
+    "changeAddress": "Alterar endereço",
+    "clientEnable": "Habilitar cliente",
+    "clientDisable": "Desabilitar cliente",
+    "pending": "Pendente",
+    "rejected": "Rejeitado",
+    "revoked": "Revogado",
+    "unknown": "Desconhecido",
+    "removeCertificate": "Remover Certificado",
+    "removeClient": "Remover Cliente",
+    "securityServerId": "Identificador do Servidor",
+    "securityServerOwnerName": "Nome do Proprietário do Servidor",
+    "showOnlyPending": "Mostrar apenas solicitações pendentes",
+    "dialog": {
+      "approve": {
+        "title": "Aprovar solicitação de gerenciamento",
+        "bodyMessage": "Tem certeza de que deseja aprovar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
+        "successMessage": "Solicitação de gerenciamento ID {id} do servidor {serverId} aprovada",
+        "newMemberWarning": "O membro especificado atualmente não existe. Ele será criado automaticamente quando esta solicitação for aprovada."
+      },
+      "decline": {
+        "title": "Rejeitar solicitação de gerenciamento",
+        "bodyMessage": "Tem certeza de que deseja rejeitar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
+        "successMessage": "Solicitação de gerenciamento ID {id} do servidor {serverId} rejeitada"
+      }
+    }
+  },
+  "managementRequestDetails": {
+    "requestInformation": "Informações da Solicitação",
+    "requestId": "ID da Solicitação",
+    "received": "Recebido",
+    "source": "Fonte",
+    "status": "Status",
+    "comments": "Comentários",
+    "securityServerInformation": "Informações do servidor seguro Afetado",
+    "ownerName": "Nome do Proprietário",
+    "ownerClass": "Classe do Proprietário",
+    "ownerCode": "Código do Proprietário",
+    "serverCode": "Código do Servidor",
+    "address": "Endereço",
+    "clientInformation": "Cliente Enviado para Registro",
+    "ownerChangeInformation": "Novo Proprietário Enviado para Registro",
+    "clientDisableInformation": "Cliente desabilitado",
+    "clientEnableInformation": "Cliente habilitado",
+    "subsystemCode": "Código do Subsistema",
+    "certificateformation": "Certificado de Autenticação Enviado para Registro",
+    "ca": "CA",
+    "serialNumber": "Número de Série",
+    "subject": "Titular do Certificado (DN)",
+    "expires": "Expira"
+  },
+  "members": {
+    "addMember": "Adicionar membro",
+    "header": "Membros",
+    "member": {
+      "details": {
+        "addedToGroup": "Adicionado ao grupo",
+        "globalGroups": "Grupos Globais",
+        "group": "Grupo",
+        "ownedServers": "Servidores Possuídos",
+        "usedServers": "Servidores Utilizados",
+        "server": "Servidor",
+        "enterCode": "Insira o Código do Membro",
+        "deleteMember": "Excluir membro",
+        "confirmDelete": "Tem certeza de que deseja excluir o Membro {member} da configuração do sistema? Insira o código do membro para confirmar.",
+        "editMemberName": "Editar nome do Membro",
+        "memberNameSaved": "Nome do membro salvo com sucesso",
+        "memberDeleted": "Membro excluído com sucesso",
+        "areYouSureUnregister": "Tem certeza de que deseja desregistrar o Membro {memberCode} do servidor {serverCode} da configuração do sistema?",
+        "unregisterMember": "Desregistrar membro",
+        "memberSuccessfullyUnregistered": "Membro {memberCode} do servidor {serverCode} foi desregistrado com sucesso"
+      },
+      "managementRequests": {
+        "created": "Criado",
+        "id": "ID da Solicitação",
+        "showOnlyWaiting": "Mostrar apenas solicitações pendentes",
+        "status": "Status",
+        "type": "Tipo de solicitação"
+      },
+      "pagenavigation": {
+        "details": "Detalhes",
+        "managementRequests": "Solicitações de Gerenciamento",
+        "subsystems": "Subsistemas"
+      },
+      "subsystems": {
+        "addClient": "Adicionar subsistema",
+        "deleteSubsystem": "Excluir Subsistema",
+        "serverOwner": "Proprietário do servidor",
+        "servercode": "Código do servidor",
+        "status": "Status",
+        "subsystemcode": "Código do subsistema",
+        "subsystemSuccessfullyAdded": "Subsistema {subsystemCode} foi adicionado à configuração do sistema",
+        "areYouSureDelete": "Tem certeza de que deseja excluir o Subsistema {subsystemCode} do membro X-Road {memberId} da configuração do sistema?",
+        "subsystemSuccessfullyDeleted": "Subsistema {subsystemCode} foi excluído da configuração do sistema",
+        "areYouSureUnregister": "Tem certeza de que deseja excluir o Subsistema {subsystemCode} do servidor {serverCode} da configuração do sistema?",
+        "subsystemSuccessfullyUnregistered": "Subsistema {subsystemCode} do servidor {serverCode} foi excluído"
+      }
+    },
+    "memberSuccessfullyAdded": "Membro {memberName} foi adicionado à configuração do sistema."
+  },
+    "noData": {
+      "noMemberClasses": "Nenhuma classe de membros",
+      "noSecurityServers": "Nenhum servidor seguro"
+    },
+    "securityServers": {
+      "address": "Endereço",
+      "ownerClass": "Classe do Proprietário",
+      "ownerCode": "Código do Proprietário",
+      "ownerName": "Nome do Proprietário",
+      "registered": "Registrado",
+      "unregistered": "Não registrado",
+      "pending": "Aguardando aprovação",
+      "disabled": "Temporariamente desativado",
+      "securityServer": {
+        "certificationAuthority": "Autoridade de Certificação",
+        "deleteServer": "Excluir servidor",
+        "expires": "Expira",
+        "serialNumber": "Número de Série",
+        "subject": "Titular do Certificado (DN)",
+        "deleteSecurityServer": "Excluir servidor seguro",
+        "tabs": {
+          "authCertificates": "Certificados de Autenticação",
+          "clients": "Clientes",
+          "details": "Detalhes",
+          "managementRequests": "Solicitações de Gerenciamento"
+        },
+        "dialog": {
+          "deleteAuthCertificate": {
+            "title": "Excluir Certificado de Autenticação",
+            "content": "Tem certeza de que deseja excluir o Certificado de Autenticação Test CA da configuração do sistema? Insira o código do servidor para confirmar.",
+            "securityServerCode": "Insira o Código do servidor seguro",
+            "success": "Certificado de autenticação do servidor seguro excluído com sucesso"
+          }
+        }
+      },
+      "dialogs": {
+        "editAddress": {
+          "title": "Editar endereço do servidor seguro",
+          "addressField": "Endereço do servidor seguro",
+          "success": "Endereço do servidor seguro atualizado com sucesso"
+        },
+        "deleteAddress": {
+          "title": "Excluir servidor seguro",
+          "enterCode": "Insira o Código do servidor seguro",
+          "areYouSure": "Tem certeza de que deseja excluir o servidor seguro {securityServer} da configuração do sistema? Insira o código do servidor para confirmar.",
+          "success": "Servidor seguro excluído."
+        }
+      },
+      "serverCode": "Código do Servidor"
+    },
+      "systemSettings": {
+        "centralServerAddress": "Endereço do Servidor Central",
+        "code": "Código",
+        "description": "Descrição",
+        "editCentralServerAddressSuccess": "Endereço do Servidor Central atualizado com sucesso",
+        "editCentralServerAddressTitle": "Editar endereço do Servidor Central",
+        "instanceIdentifier": "Identificador da Instância",
+        "managementServices": {
+          "title": "Serviços de Gerenciamento",
+          "securityServer": "Servidor seguro dos Serviços de Gerenciamento"
+        },
+        "selectSubsystem": {
+          "title": "Selecionar Subsistema",
+          "search": "Pesquisar",
+          "name": "Nome",
+          "memberClass": "Classe",
+          "memberCode": "Código",
+          "subsystemCode": "Subsistema",
+          "xroadInstance": "Instância",
+          "type": "Tipo"
+        },
+        "selectSecurityServer": {
+          "title": "Selecionar servidor seguro",
+          "search": "Pesquisar",
+          "name": "Nome",
+          "memberClass": "Classe",
+          "memberCode": "Código",
+          "subsystemCode": "Subsistema",
+          "xroadInstance": "Instância",
+          "type": "Tipo"
+        },
+        "serviceProvider": {
+          "changedSuccess": "Provedor de Serviço alterado com sucesso",
+          "registeredSuccess": "Provedor de serviço de gerenciamento '{subsystemId}' registrado como cliente do servidor seguro '{securityServerId}'"
+        },
+        "memberClasses": "Classes de Membros",
+        "securityServerOwnerGroupCode": "Código do Grupo de Proprietários do servidor seguro",
+        "serviceProviderIdentifier": "Identificador do Provedor de Serviço",
+        "serviceProviderName": "Nome do Provedor de Serviço",
+        "systemParameters": "Parâmetros do Sistema",
+        "wsdlAddress": "Endereço WSDL",
+        "managementServicesAddress": "Endereço dos Serviços de Gerenciamento",
+        "editMemberClassTitle": "Editar classe de membro",
+        "addMemberClassTitle": "Adicionar classe de membro",
+        "deleteMemberClass": "Excluir classe de membro?",
+        "memberClassSaved": "Classe de membro salva.",
+        "memberClassDeleted": "Classe de membro excluída."
+      },
+      "tlsCertificates": {
+        "managementService": {
+          "title": "Certificado TLS do Serviço de Gerenciamento",
+          "key": "Chave TLS do Serviço de Gerenciamento",
+          "downloadCertificate": "Baixar certificado",
+          "downloadSuccess": "Certificado TLS do serviço de gerenciamento baixado com sucesso",
+          "generateKey": {
+            "button": "Recriar chave",
+            "title": "Chave TLS do Serviço de Gerenciamento",
+            "confirmation": "Gerar uma nova chave e certificado TLS do serviço de gerenciamento?",
+            "explanation": "O sistema irá gerar uma nova chave TLS do serviço de gerenciamento e um certificado autoassinado, substituindo a chave e o certificado existentes.",
+            "success": "Nova chave e certificado TLS do serviço de gerenciamento gerados com sucesso"
+          },
+          "generateCsr": {
+            "button": "Gerar CSR",
+            "title": "Gerar Solicitação de Assinatura de Certificado TLS",
+            "content": "Primeiro, forneça um Titular do Certificado (DN). Em seguida, gere um novo CSR e salve-o em um local seguro",
+            "distinguishedName": "Insira o Titular do Certificado (DN)",
+            "example": "CN=meuservercentral.exemplo.com, O=Minha Organização, C=BR"
+          },
+          "uploadCertificate": {
+            "button": "Enviar certificado",
+            "title": "Enviar certificado TLS do Serviço de Gerenciamento",
+            "label": "Envie o arquivo de certificado do seu computador",
+            "success": "Certificado TLS do serviço de gerenciamento enviado com sucesso"
+      }
+    }
+  },
+  "tab": {
+    "globalConf": {
+      "externalConf": "Configuração Externa",
+      "internalConf": "Configuração Interna",
+      "trustedAnchors": "Âncoras Confiáveis"
+    },
+    "main": {
+      "globalConfiguration": "Configuração Global",
+      "managementRequests": "Solicitações de Gerenciamento",
+      "members": "Membros",
+      "securityServers": "Servidores de Segurança",
+      "settings": "Configurações",
+      "trustServices": "Serviços de Confiança"
+    },
+    "settings": {
+      "apiKeys": "Chaves de API",
+      "backupAndRestore": "Backup e Restauração",
+      "globalResources": "Recursos Globais",
+      "systemSettings": "Configurações do Sistema",
+      "tlsCertificates": "Certificados TLS"
+    }
+  },
+  "trustServices": {
+    "addCertificationService": "Adicionar serviço de certificação",
+    "addCASettingsCheckbox": "Esta CA pode ser usada apenas para autenticação TLS (marque se for verdade)",
+    "approvedCertificationService": "Serviço de certificação aprovado",
+    "caSettings": "Configurações da CA",
+    "certificationServices": "Serviços de Certificação",
+    "certImportedSuccessfully": "Certificado importado com sucesso",
+    "certProfileInput": "Informações do perfil do certificado",
+    "certProfileInputExplanation": "Nome completo da classe que implementa a interface ee.ria.xroad.common.certificateprofile.CertificateProfileInfoProvider",
+    "acmeServerDirectoryUrlExplanation": "Usado pelos Servidores de Segurança para operações relacionadas a certificados via a API do Servidor ACME.",
+    "acmeServerIpAddressExplanation": "Uma lista de IPs de origem do Servidor ACME usados para completar o desafio HTTP do ACME com o servidor seguro. Vários endereços são separados por vírgula. Esta informação é exibida na interface do servidor seguro.",
+    "acmeServerAuthProfileIdExplanation": "ID do perfil usado por alguns servidores ACME para informar o tipo de uso do certificado ao solicitar um certificado de autenticação.",
+    "acmeServerSignProfileIdExplanation": "ID do perfil usado por alguns servidores ACME para informar o tipo de uso do certificado ao solicitar um certificado de assinatura.",
+    "timestampingServices": "Serviços de Carimbo de Tempo",
+    "validFrom": "Válido de",
+    "validTo": "Válido até",
+    "viewCertificate": "Visualizar Certificado",
+    "uploadCertificate": "Enviar o arquivo de certificado do seu computador",
+    "timestampingService": {
+      "url": "URL",
+      "dialog": {
+        "add": {
+          "title": "Adicionar serviço de carimbo de tempo",
+          "success": "Serviço de carimbo de tempo adicionado com sucesso"
+        },
+        "edit": {
+          "title": "Editar serviço de carimbo de tempo",
+          "uploadCertificate": "Enviar novo certificado",
+          "success": "Serviço de carimbo de tempo editado com sucesso"
+        }
+      },
+      "addedSuccessfully": "Serviço de carimbo de tempo adicionado com sucesso"
+    },
+    "trustService": {
+      "details": {
+        "subjectDistinguishedName": "Titular do Certificado (DN)",
+        "issuerDistinguishedName": "Autoridade Certificadora"
+      },
+      "delete": {
+        "action": "Excluir serviço de confiança",
+        "confirmationDialog": {
+          "title": "Você tem certeza?",
+          "message": "Tem certeza de que deseja excluir o serviço de confiança \"{name}\"?"
+        },
+        "success": "Serviço de confiança excluído com sucesso"
+      },
+      "settings": {
+        "tlsAuth": "Esta CA pode ser usada apenas para autenticação TLS",
+        "certProfile": "Informações do perfil do certificado (nome completo da classe que implementa a interface ee.ria.xroad.common.CertificateProfileInfoProvider)",
+        "saveSuccess": "Configurações da CA salvas com sucesso",
+        "acmeCapable": "Esta CA pode ser usada para ACME",
+        "acmeNotCapable": "Esta CA não pode ser usada para ACME"
+      },
+      "ocspResponders": {
+        "url": "URL",
+        "add": {
+          "dialog": {
+            "title": "Adicionar Validador OCSP"
+          },
+          "success": "Validador OCSP adicionado com sucesso"
+        },
+        "edit": {
+          "dialog": {
+            "title": "Editar Validador OCSP",
+            "uploadCertificate": "Enviar novo certificado"
+          },
+          "success": "Validador OCSP editado com sucesso"
+        },
+        "delete": {
+          "confirmationDialog": {
+            "message": "Tem certeza de que deseja excluir o Validador OCSP com o URL {url}?",
+            "title": "Você tem certeza?"
+          },
+          "success": "Validador OCSP excluído com sucesso"
+        }
+      },
+      "intermediateCas": {
+        "intermediateCa": "CA Intermediária",
+        "add": {
+          "dialog": {
+            "title": "Adicionar CAs Intermediárias"
+          },
+          "success": "CA Intermediária adicionada com sucesso"
+        },
+        "delete": {
+          "confirmationDialog": {
+            "message": "Tem certeza de que deseja excluir a CA Intermediária {name}?",
+            "title": "Você tem certeza?"
+          },
+          "success": "CA Intermediária excluída com sucesso"
+        }
+      },
+      "timestampingService": {
+        "url": "URL",
+        "timestampingInterval": "Intervalo de carimbo de tempo",
+        "timestampingIntervalMinutes": "{min} minuto(s)",
+        "cost": "Custo",
+        "costValues": {
+          "FREE": "Gratuito",
+          "PAID": "Pago",
+          "UNDEFINED": "Indefinido"
+        },
+        "delete": {
+          "dialog": {
+            "title": "Você tem certeza?",
+            "message": "Tem certeza de que deseja excluir o serviço de carimbo de tempo com o URL {url}?"
+          },
+          "success": "Serviço de carimbo de tempo excluído com sucesso"
+        }
+      },
+      "pagenavigation": {
+        "details": "Detalhes",
+        "settings": "Configurações da CA",
+        "ocspResponders": "Validadores OCSP",
+        "intermediateCas": "CAs Intermediárias"
+      }
+    }
+  },
+  "validationError": {
+    "IdentifierChars": "O identificador da instância não deve conter dois pontos (:), ponto e vírgula (;), barras (/) ou sinais de porcentagem (%).",
+    "IdentifierCharsField": "Use apenas caracteres válidos para identificadores",
+    "SizeField": "O valor não atende aos requisitos de comprimento"
+  },
+  "validation": {
+    "messages": {
+      "is": "O campo {field} deve ter o valor \"{other}\""
+    }
+  },
+  "status": {
+    "signer_error": "Falha na invocação do cliente do assinador",
+    "global_conf_generation": {
+      "status_not_found": "O status da geração da configuração global é desconhecido",
+      "failing": "A geração da configuração global está falhando desde {0}",
+      "global_conf_expired": "Configuração global expirada"
+    },
+    "signing_key": {
+      "internal": {
+        "missing": "Assinatura da configuração interna falhou - chave ativa ausente",
+        "token_not_found": "Assinatura da configuração interna falhou - chave ativa não encontrada",
+        "token_not_active": "Assinatura da configuração interna falhou - PIN da chave ativa não foi inserido",
+        "key_not_available": "Assinatura da configuração interna falhou - chave ativa não disponível"
+      },
+      "external": {
+        "missing": "Assinatura da configuração externa falhou - chave ativa ausente",
+        "token_not_found": "Assinatura da configuração externa falhou - chave ativa não encontrada",
+        "token_not_active": "Assinatura da configuração externa falhou - PIN da chave ativa não foi inserido",
+        "key_not_available": "Assinatura da configuração externa falhou - chave ativa não disponível"
+      }
+    }
+  }
+}

--- a/src/central-server/admin-service/ui/src/locales/pt.json
+++ b/src/central-server/admin-service/ui/src/locales/pt.json
@@ -1,766 +1,766 @@
 {
-  "403": {
-    "goBack": "Voltar",
-    "mainTitle": "Permissão negada",
-    "text": "Parece que você não tem permissão para visualizar esta página. Se você acha que isso é um erro, verifique se está logado na conta correta ou entre em contato com o administrador para verificar suas permissões.",
-    "topTitle": "Proibido"
+  "403":{
+     "goBack":"Voltar",
+     "mainTitle":"Permissão negada",
+     "text":"Parece que você não tem permissão para visualizar esta página. Se acredita que isso seja um erro, verifique se está conectado com a conta correta ou entre em contato com o administrador para revisar suas permissões.",
+     "topTitle":"Acesso proibido"
   },
-  "action": {
-    "approve": "Aprovar",
-    "decline": "Recusar",
-    "select": "Selecionar",
-    "generateCsr": "Gerar CSR"
+  "action":{
+     "addName":"Adicionar nome do subsistema",
+     "approve":"Aprovar",
+     "decline":"Recusar",
+     "generateCsr":"Gerar CSR",
+     "rename":"Renomear",
+     "select":"Selecionar"
   },
-  "apiKey": {
-    "role": {
-      "XROAD_MANAGEMENT_SERVICE": "Serviços de Gestão"
-    }
+  "apiKey":{
+     "role":{
+        "XROAD_MANAGEMENT_SERVICE":"Serviços de Gerenciamento"
+     }
   },
-  "customValidation": {
-    "invalidUrl": "URL inválida. Exemplos de formatos válidos: 'http://www.exemplo.com', 'https://www.exemplo.com'",
-    "invalidIpAddress": "O campo deve conter um endereço IP ou múltiplos endereços separados por vírgula"
+  "customValidation":{
+     "invalidIpAddress":"O campo deve conter um endereço IP ou vários endereços separados por vírgula",
+     "invalidUrl":"URL inválida. Exemplos de formatos válidos: 'http://www.exemplo.com', 'https://www.exemplo.com'"
   },
-  "error_code": {
-    "certificate_profile_info_class_not_found": "Classe de informações do perfil do certificado não encontrada",
-    "certification_service_not_found": "Serviço de certificação não encontrado.",
-    "configuration_not_found": "Fonte de configuração não encontrada",
-    "configuration_part_file_not_found": "Arquivo da parte de configuração não encontrado",
-    "configuration_part_validation_failed": "Falha na validação da parte de configuração",
-    "configuration_part_validator_not_found": "Validador da parte de configuração não encontrado",
-    "error_activating_signing_key": "Erro ao ativar a chave de assinatura",
-    "error_deleting_signing_key": "Erro ao excluir a chave de assinatura",
-    "error_recreating_anchor": "Erro ao recriar o arquivo âncora",
-    "global_group_exists": "Um grupo global com o mesmo código já existe.",
-    "global_group_not_found": "Grupo global com o código fornecido não existe",
-    "init_already_initialized": "Falha na inicialização do servidor central, já completamente inicializado",
-    "init_invalid_params": "Parâmetros vazios, ausentes ou redundantes fornecidos para inicialização",
-    "init_signer_pin_policy_failed": "Falha na política de PIN do token no Signer",
-    "init_software_token_failed": "Falha na inicialização do token de software",
-    "instance_identifier_not_set": "Parâmetro de sistema para identificador de instância não definido",
-    "intermediate_ca_not_found": "CA intermediária não encontrada",
-    "internal_error": "Erro interno. Consulte os logs do servidor para mais detalhes",
-    "invalid_certificate": "Certificado X.509 inválido",
-    "invalid_member_id": "ID de membro inválido",
-    "invalid_pagination_properties": "Paginação possui propriedades inválidas",
-    "invalid_service_provider_id": "ID de provedor de serviço inválido",
-    "invalid_sort_properties": "Parâmetro de ordenação inválido",
-    "invalid_subsystem_id": "ID de subsistema inválido",
-    "invalid_url": "URL inválida",
-    "invalid_ip_address": "Endereço IP inválido",
-    "key_generation_failed": "Falha ao gerar chave de assinatura",
-    "management_request_cannot_register_owner": "Não é possível registrar o proprietário como cliente",
-    "management_request_client_already_owner": "O cliente já é proprietário do servidor seguro",
-    "management_request_client_already_registered": "O cliente já está registrado em um servidor",
-    "management_request_client_registration_not_found": "Registro de cliente não encontrado",
-    "management_request_exists": "Já existe uma solicitação de gerenciamento pendente.",
-    "management_request_invalid_auth_certificate": "Certificado de autenticação inválido",
-    "management_request_invalid_state": "A operação solicitada não pode ser aplicada neste estado",
-    "management_request_invalid_state_for_approval": "A solicitação de gerenciamento não pode ser aprovada",
-    "management_request_member_not_found": "Membro não encontrado",
-    "management_request_not_found": "Nenhuma solicitação de gerenciamento com o ID especificado encontrada.",
-    "management_request_not_supported": "Tipo de solicitação de gerenciamento desconhecido",
-    "management_request_owner_must_be_client": "O proprietário não está registrado como cliente no servidor seguro",
-    "management_request_owner_must_be_member": "O proprietário deve ser um membro",
-    "management_request_security_server_exists": "O certificado já está registrado.",
-    "management_request_server_code_exists": "O membro já possui um servidor seguro com este código",
-    "management_request_server_not_found": "servidor seguro não encontrado",
-    "management_request_server_owner_not_found": "Proprietário do servidor seguro não encontrado",
-    "management_request_unknown_type": "Tipo de solicitação desconhecido",
-    "management_service_provider_not_set": "Provedor de serviço de gerenciamento não configurado",
-    "member_class_exists": "Classe de membro com o mesmo código já existe.",
-    "member_class_is_in_use": "Não é possível excluir a classe de membro: existem membros registrados pertencentes à classe. Apenas classes sem membros registrados podem ser excluídas.",
-    "member_class_not_found": "Nenhuma classe de membro com o código especificado encontrada.",
-    "member_exists": "Membro com o mesmo código já existe.",
-    "member_not_found": "Nenhum membro com o código/ID especificado encontrado.",
-    "no_configuration_signing_keys_configured": "Nenhuma chave de assinatura de configuração configurada",
-    "ocsp_responder_not_found": "Validador OCSP não encontrado",
-    "owners_global_group_cannot_be_deleted": "Não é possível excluir o grupo global dos proprietários do servidor",
-    "owners_global_group_member_cannot_be_deleted": "Não é possível excluir membro do grupo global de proprietários",
-    "signer_proxy_error": "Exceção no proxy do assinador",
-    "signing_key_action_not_possible": "Ação da chave de assinatura não é possível",
-    "signing_key_not_found": "Chave de assinatura não encontrada",
-    "ss_auth_certificate_not_found": "Certificado de autenticação não encontrado",
-    "subsystem_already_registered_to_security_server": "Subsistema já registrado no servidor seguro",
-    "subsystem_exists": "Subsistema com o mesmo código já existe.",
-    "subsystem_not_found": "Subsistema com o código especificado não encontrado.",
-    "subsystem_not_registered_to_security_server": "Subsistema não está registrado no servidor seguro especificado.",
-    "subsystem_registered_and_cannot_be_deleted": "Não é possível excluir subsistema já registrado.",
-    "timestamping_authority_not_found": "Autoridade de carimbo de tempo não encontrada",
-    "token_action_not_possible": "Ação do token não é possível",
-    "token_activation_failed": "Falha na ativação do token",
-    "token_deactivation_failed": "Falha na desativação do token",
-    "token_incorrect_pin_format": "Formato de PIN incorreto",
-    "token_invalid_characters": "O PIN fornecido contém caracteres inválidos",
-    "token_pin_final_try": "Tentativas restantes: 1",
-    "token_pin_locked": "PIN do token bloqueado",
-    "token_weak_pin": "O PIN fornecido é muito fraco",
-    "unknown_configuration_part": "Parte de configuração desconhecida",
-    "malformed_anchor": "Arquivo âncora malformado",
-    "trusted_anchor_verification_failed": "Falha na verificação do âncora confiável",
-    "trusted_anchor_not_found": "Âncora confiável não encontrada",
-    "invalid_parameters": "Falha de validação",
-    "security_server_not_found": "Servidor seguro não encontrado",
-    "invalid_encoded_id": "ID codificado inválido",
-    "id_not_a_number": "ID não é um número",
-    "invalid_role": "Papel inválido",
-    "invalid_file_content_type": "Tipo de conteúdo do arquivo enviado é inválido",
-    "invalid_file_extension": "Extensão de arquivo inválida",
-    "double_file_extension": "Extensão de arquivo dupla não é permitida",
-    "backup_deletion_failed": "Falha ao excluir o backup",
-    "conf_verification.anchor_not_for_external_source": "Falha na verificação da configuração: âncora não é para fonte externa",
-    "conf_verification.missing_private_params": "Falha na verificação da configuração: parâmetros privados ausentes",
-    "conf_verification.other": "Falha na verificação da configuração: outro",
-    "conf_verification.outdated": "Falha na verificação da configuração: desatualizado",
-    "conf_verification.signature_invalid": "Falha na verificação da configuração: assinatura inválida",
-    "conf_verification.unreachable": "Falha na verificação da configuração: inacessível",
-    "cannot_add_member_to_owners_group": "Não é possível adicionar membros ao grupo de proprietários do servidor",
-    "generate_key_cert_interrupted": "A geração de chave e certificado foi interrompida",
-    "key_and_cert_generation_failed": "Falha ao gerar chave e certificado TLS",
-    "csr_generation_failed": "Falha na geração do CSR",
-    "cannot_convert_bytes_to_certificate": "Não é possível converter bytes em certificado",
-    "certificate_writing_failed": "Falha ao gravar certificado no arquivo",
-    "cannot_read_certificate": "Não é possível ler o certificado TLS",
-    "key_not_found": "O certificado importado não corresponde à chave TLS",
-    "certificate_already_exists": "O certificado importado já existe",
-    "certificate_import_failed": "Não é possível importar o certificado TLS",
-    "invalid_address_char": "O campo de endereço contém caracteres inválidos"
+  "error_code":{
+     "backup_deletion_failed":"Falha ao excluir o backup",
+     "cannot_add_member_to_owners_group":"Não é possível adicionar membros ao grupo de proprietários do servidor",
+     "cannot_convert_bytes_to_certificate":"Não foi possível converter os dados em certificado",
+     "cannot_read_certificate":"Não foi possível ler o certificado TLS",
+     "certificate_already_exists":"O certificado importado já existe",
+     "certificate_import_failed":"Falha ao importar o certificado TLS",
+     "certificate_profile_info_class_not_found":"Classe de perfil de certificado não encontrada",
+     "certificate_writing_failed":"Erro ao gravar o certificado no arquivo",
+     "certification_service_not_found":"Serviço de certificação não encontrado",
+     "conf_verification.anchor_not_for_external_source":"Verificação de configuração falhou: âncora não permitida para fonte externa",
+     "conf_verification.missing_private_params":"Verificação de configuração falhou: parâmetros privados ausentes",
+     "conf_verification.other":"Verificação de configuração falhou: erro desconhecido",
+     "conf_verification.outdated":"Verificação de configuração falhou: configuração desatualizada",
+     "conf_verification.signature_invalid":"Verificação de configuração falhou: assinatura inválida",
+     "conf_verification.unreachable":"Verificação de configuração falhou: fonte inacessível",
+     "configuration_not_found":"Fonte de configuração não encontrada",
+     "configuration_part_file_not_found":"Arquivo de parte da configuração não encontrado",
+     "configuration_part_validation_failed":"Validação da parte da configuração falhou",
+     "configuration_part_validator_not_found":"Validador da parte da configuração não encontrado",
+     "csr_generation_failed":"Falha ao gerar CSR",
+     "double_file_extension":"Extensões duplas de arquivo não são permitidas",
+     "error_activating_signing_key":"Erro ao ativar a chave de assinatura",
+     "error_deleting_signing_key":"Erro ao excluir a chave de assinatura",
+     "error_recreating_anchor":"Erro ao recriar o arquivo de âncora",
+     "generate_key_cert_interrupted":"Geração de chave e certificado foi interrompida",
+     "global_group_exists":"Grupo global com o mesmo código já existe",
+     "global_group_not_found":"Grupo global com o código informado não existe",
+     "id_not_a_number":"O ID não é um número válido",
+     "init_already_initialized":"Falha na inicialização do Servidor Central: já está totalmente inicializado",
+     "init_invalid_params":"Parâmetros vazios, ausentes ou redundantes fornecidos na inicialização",
+     "init_signer_pin_policy_failed":"Falha na política de PIN do assinador",
+     "init_software_token_failed":"Falha ao inicializar o token de software",
+     "instance_identifier_not_set":"O identificador da instância não foi definido",
+     "intermediate_ca_not_found":"AC intermediária não encontrada",
+     "invalid_address_char":"O campo de endereço contém caracteres inválidos",
+     "invalid_encoded_id":"ID codificado inválido",
+     "invalid_file_content_type":"Tipo de conteúdo do arquivo inválido",
+     "invalid_file_extension":"Extensão de arquivo inválida",
+     "invalid_ip_address":"Endereço IP inválido",
+     "invalid_member_id":"ID de membro inválido",
+     "invalid_pagination_properties":"Parâmetros de paginação inválidos",
+     "invalid_parameters":"Falha de validação dos parâmetros",
+     "invalid_role":"Função inválida",
+     "invalid_service_provider_id":"ID do provedor de serviço inválido",
+     "invalid_sort_properties":"Parâmetro de ordenação inválido",
+     "invalid_subsystem_id":"ID do subsistema inválido",
+     "invalid_url":"URL inválida",
+     "key_and_cert_generation_failed":"Falha ao gerar chave e certificado TLS",
+     "key_generation_failed":"Falha na geração da chave de assinatura",
+     "key_not_found":"O certificado importado não corresponde à chave TLS",
+     "malformed_anchor":"Arquivo de âncora com formato inválido",
+     "management_request_cannot_register_owner":"Não é possível registrar o proprietário como cliente",
+     "management_request_client_already_owner":"O cliente já é proprietário do servidor seguro",
+     "management_request_client_already_registered":"Cliente já está registrado em um servidor",
+     "management_request_client_registration_not_found":"Registro de cliente não existe",
+     "management_request_exists":"Já existe uma solicitação de gerenciamento pendente",
+     "management_request_invalid_auth_certificate":"Certificado de autenticação inválido",
+     "management_request_invalid_state":"A operação solicitada não pode ser aplicada neste estado",
+     "management_request_invalid_state_for_approval":"A solicitação de gerenciamento não pode ser aprovada",
+     "management_request_member_not_found":"Membro não encontrado",
+     "management_request_not_found":"Solicitação de gerenciamento com o ID especificado não encontrada",
+     "management_request_not_supported":"Tipo de solicitação de gerenciamento desconhecido",
+     "management_request_owner_must_be_client":"O proprietário não está registrado como cliente do servidor seguro",
+     "management_request_owner_must_be_member":"O proprietário precisa ser um membro",
+     "management_request_security_server_exists":"O certificado já está registrado",
+     "management_request_server_code_exists":"O membro já possui um servidor seguro com esse código",
+     "management_request_server_not_found":"Servidor seguro não encontrado",
+     "management_request_server_owner_not_found":"Proprietário do servidor seguro não encontrado",
+     "management_request_unknown_type":"Tipo de solicitação desconhecido",
+     "management_service_provider_not_set":"Provedor do serviço de gerenciamento não configurado",
+     "member_class_exists":"Classe de membro com o mesmo código já existe",
+     "member_class_is_in_use":"Não é possível excluir a classe de membro: há membros registrados vinculados",
+     "member_class_not_found":"Classe de membro com o código especificado não encontrada",
+     "member_exists":"Membro com o mesmo código já existe",
+     "member_not_found":"Membro com o código ou ID especificado não encontrado",
+     "no_configuration_signing_keys_configured":"Nenhuma chave de assinatura de configuração configurada",
+     "ocsp_responder_not_found":"Responder OCSP não encontrado",
+     "owners_global_group_cannot_be_deleted":"Não é possível excluir o grupo de proprietários do servidor",
+     "owners_global_group_member_cannot_be_deleted":"Não é possível excluir um membro do grupo de proprietários do servidor",
+     "security_server_not_found":"Servidor seguro não encontrado",
+     "signer_proxy_error":"Erro de proxy do assinador",
+     "signing_key_action_not_possible":"Ação com a chave de assinatura não permitida",
+     "signing_key_not_found":"Chave de assinatura não encontrada",
+     "ss_auth_certificate_not_found":"Certificado de autenticação não encontrado",
+     "subsystem_already_registered_to_security_server":"Subsistema já registrado no servidor seguro",
+     "subsystem_exists":"Subsistema com o mesmo código já existe",
+     "subsystem_not_found":"Subsistema com o código especificado não encontrado",
+     "subsystem_not_registered_to_security_server":"Subsistema não está registrado neste servidor seguro",
+     "subsystem_registered_and_cannot_be_deleted":"Não é possível excluir subsistema já registrado",
+     "timestamping_authority_not_found":"Autoridade de Carimbo de Tempo (TSA) não encontrada",
+     "token_action_not_possible":"Ação com o token não permitida",
+     "token_activation_failed":"Falha na ativação do token",
+     "token_deactivation_failed":"Falha na desativação do token",
+     "token_incorrect_pin_format":"Formato do PIN incorreto",
+     "token_invalid_characters":"O PIN fornecido contém caracteres inválidos",
+     "token_pin_final_try":"Tentativas restantes: 1",
+     "token_pin_locked":"PIN do token bloqueado",
+     "trusted_anchor_not_found":"Âncora confiável não encontrada",
+     "trusted_anchor_verification_failed":"Falha na verificação da âncora confiável",
+     "unknown_configuration_part":"Parte da configuração desconhecida"
   },
-  "fields": {
-    "init": {
-      "address": "Endereço do Servidor Central",
-      "confirmPin": "Repetir PIN",
-      "identifier": "Identificador da Instância",
-      "pin": "PIN",
-      "repeatPin": "Repetir PIN"
-    },
-    "initialServerConf": {
-      "centralServerAddress": "Endereço do Servidor Central",
-      "instanceIdentifier": "Identificador da Instância"
-    },
-    "username": "Nome de Usuário",
-    "url": "URL",
-    "tokenPin": "PIN do Token",
-    "keyLabel": "Nome amigável da chave",
-    "subsystemCode": "Código do Subsistema",
-    "memberCode": "Código do Membro",
-    "memberName": "Nome do Membro",
-    "securityServerAddress": "Endereço do servidor seguro",
-    "serverCode": "Código do Servidor",
-    "serviceAddress": "Endereço do Servidor Central",
-    "certProfile": "Informações do Perfil do Certificado",
-    "certFile": "Arquivo de Certificado",
-    "distinguishedName": "Nome Diferenciado",
-    "acmeServerDirectoryUrl": "URL do Diretório do Servidor ACME",
-    "acmeServerIpAddress": "Endereço(s) IP do Servidor ACME",
-    "authenticationCertificateProfileId": "ID do Perfil do Certificado de Autenticação",
-    "signingCertificateProfileId": "ID do Perfil do Certificado de Assinatura"
+  "fields":{
+     "acmeServerDirectoryUrl":"URL do diretório do servidor ACME",
+     "acmeServerIpAddress":"Endereço(s) IP do servidor ACME",
+     "authenticationCertificateProfileId":"ID do perfil de certificado de autenticação",
+     "certFile":"Arquivo do certificado",
+     "certProfile":"Informações do perfil de certificado",
+     "distinguishedName":"Nome distinto (DN)",
+     "init":{
+        "address":"Endereço do Servidor Central",
+        "confirmPin":"Confirmar PIN",
+        "identifier":"Identificador da Instância",
+        "pin":"PIN",
+        "repeatPin":"Repetir PIN"
+     },
+     "initialServerConf":{
+        "centralServerAddress":"Endereço do Servidor Central",
+        "instanceIdentifier":"Identificador da Instância"
+     },
+     "keyLabel":"Nome amigável da chave",
+     "memberCode":"Código do Membro",
+     "memberName":"Nome do Membro",
+     "securityServerAddress":"Endereço do Servidor Seguro",
+     "serverCode":"Código do Servidor",
+     "serviceAddress":"Endereço do Servidor Central",
+     "signingCertificateProfileId":"ID do perfil de certificado de assinatura",
+     "subsystemCode":"Código do Subsistema",
+     "tokenPin":"PIN do Token",
+     "url":"URL",
+     "username":"Nome de usuário"
   },
-  "filters": {
-    "apply": "Aplicar",
-    "chooseFilters": "Escolher filtros",
-    "clearFields": "Limpar campos",
-    "groupMembers": {
-      "byClass": "Por classe",
-      "byCode": "Por código",
-      "byInstance": "Por instância",
-      "bySubsystem": "Por subsistema",
-      "byType": "Por tipo",
-      "class": "Classe",
-      "instance": "Instância",
-      "member": "Membro",
-      "subsystem": "Subsistema"
-    },
-    "managementRequests": {
-      "byCreationDate": "Por data de criação",
-      "byRequestType": "Por tipo de solicitação",
-      "byServerCode": "Por código do servidor",
-      "byServerOwnerClass": "Por classe do proprietário do servidor",
-      "byServerOwnerCode": "Por código do proprietário do servidor",
-      "byServerOwnerName": "Por nome do proprietário do servidor",
-      "bySource": "Por origem",
-      "byStatus": "Por status"
-    }
+  "filters":{
+     "apply":"Aplicar",
+     "chooseFilters":"Escolher filtros",
+     "clearFields":"Limpar campos",
+     "groupMembers":{
+        "byClass":"Por classe",
+        "byCode":"Por código",
+        "byInstance":"Por instância",
+        "bySubsystem":"Por subsistema",
+        "byType":"Por tipo",
+        "class":"Classe",
+        "instance":"Instância",
+        "member":"Membro",
+        "subsystem":"Subsistema"
+     },
+     "managementRequests":{
+        "byCreationDate":"Por data de criação",
+        "byRequestType":"Por tipo de solicitação",
+        "byServerCode":"Por código do servidor",
+        "byServerOwnerClass":"Por classe do proprietário do servidor",
+        "byServerOwnerCode":"Por código do proprietário do servidor",
+        "byServerOwnerName":"Por nome do proprietário do servidor",
+        "bySource":"Por origem",
+        "byStatus":"Por status"
+     }
   },
-  "global": {
-    "appTitle": "X-Road Servidor Central ",
-    "pageNotFound": "Ops, página não encontrada",
-    "approve": "Aprovar",
-    "class": "Classe",
-    "code": "Código",
-    "created": "Criado",
-    "delete": "Excluir",
-    "id": "ID",
-    "instance": "Instância",
-    "memberClass": "Classe do Membro",
-    "memberCode": "Código do Membro",
-    "memberName": "Nome do Membro",
-    "navigation": {
-      "back": "Voltar"
-    },
-    "register": "Registrar",
-    "search": "Pesquisar",
-    "server": "Servidor",
-    "status": "Status",
-    "subsystem": "Subsistema",
-    "type": "Tipo"
+  "global":{
+     "appTitle":"Servidor Central X-Road",
+     "approve":"Aprovar",
+     "class":"Classe",
+     "code":"Código",
+     "created":"Criado",
+     "delete":"Excluir",
+     "id":"ID",
+     "instance":"Instância",
+     "memberClass":"Classe do Membro",
+     "memberCode":"Código do Membro",
+     "memberName":"Nome do Membro",
+     "navigation":{
+        "back":"Voltar"
+     },
+     "pageNotFound":"Ops, página não encontrada",
+     "register":"Registrar",
+     "search":"Buscar",
+     "server":"Servidor",
+     "status":"Status",
+     "subsystem":"Subsistema",
+     "type":"Tipo"
   },
-  "globalConf": {
-    "globalConf": "Configuração Global",
-    "internalConf": "Configuração Interna",
-    "trustedAnchors": "Âncora Confiável",
-    "cfgParts": {
-      "title": "Partes da Configuração",
-      "file": "Arquivo",
-      "contentIdentifier": "Identificador de Conteúdo",
-      "version": "Versão",
-      "allVersions": "Todas as versões",
-      "updated": "Atualizado",
-      "dialog": {
-        "upload": {
-          "title": "Carregar Parte da Configuração",
-          "uploadConfigurationPart": "Carregar o arquivo de configuração do seu computador",
-          "success": "Parte da Configuração carregada com sucesso."
+  "globalConf":{
+     "anchor":{
+        "certificateHash":"Hash do Certificado (SHA-224)",
+        "created":"Criado",
+        "download":"Download",
+        "recreate":"Recriar",
+        "recreateSuccess":"Âncora de configuração {configurationType} gerada com sucesso",
+        "title":"Âncora"
+     },
+     "cfgParts":{
+        "allVersions":"Todas as versões",
+        "contentIdentifier":"Identificador de conteúdo",
+        "dialog":{
+           "upload":{
+              "success":"Parte da configuração enviada com sucesso.",
+              "title":"Enviar Parte da Configuração",
+              "uploadConfigurationPart":"Envie o arquivo de configuração do seu computador"
+           }
+        },
+        "file":"Arquivo",
+        "title":"Partes da Configuração",
+        "updated":"Atualizado",
+        "version":"Versão"
+     },
+     "downloadUrl":{
+        "title":"URL para Download",
+        "urlAddress":"Endereço da URL"
+     },
+     "globalConf":"Configuração Global",
+     "internalConf":"Configuração Interna",
+     "trustedAnchor":{
+        "dialog":{
+           "delete":{
+              "confirmation":"Excluir âncora {identifier} com hash (SHA-224) {hash}?",
+              "success":"Âncora confiável excluída com sucesso",
+              "title":"Excluir Âncora"
+           },
+           "upload":{
+              "confirmation":"Deseja continuar com o envio?",
+              "field":{
+                 "generated":"Gerado",
+                 "hash":"Hash (SHA-224)"
+              },
+              "info":"Detalhes da âncora confiável:",
+              "success":"Âncora confiável enviada com sucesso",
+              "title":"Confirmar detalhes da âncora confiável"
+           }
         }
-      }
-    },
-    "anchor": {
-      "title": "Âncora",
-      "certificateHash": "Hash do Certificado (SHA-224)",
-      "created": "Criado",
-      "download": "Baixar",
-      "recreate": "Recriar",
-      "recreateSuccess": "Âncora de configuração {configurationType} gerada com sucesso"
-    },
-    "downloadUrl": {
-      "title": "Baixar URL",
-      "urlAddress": "Endereço URL"
-    },
-    "trustedAnchor": {
-      "dialog": {
-        "upload": {
-          "confirmation": "Continuar com o envio?",
-          "field": {
-            "generated": "Gerado",
-            "hash": "Hash (SHA-224)"
-          },
-          "info": "Detalhes da âncora confiável:",
-          "success": "Âncora confiável enviada com sucesso",
-          "title": "Confirmar detalhes da âncora confiável"
+     },
+     "trustedAnchors":"Âncoras Confiáveis"
+  },
+  "globalGroup":{
+     "addMembers":"Adicionar membros",
+     "added":"Adicionado",
+     "areYouSure":"Tem certeza de que deseja remover o grupo global {group}?",
+     "class":"Classe",
+     "code":"Código",
+     "deleteGroup":"Excluir grupo",
+     "description":"Descrição",
+     "descriptionSaved":"Descrição salva com sucesso.",
+     "dialog":{
+        "addMembers":{
+           "success":"Membros com os identificadores: {identifiers} adicionados a este grupo global",
+           "title":"Adicionar membros"
         },
-        "delete": {
-          "confirmation": "Excluir a âncora {identifier} com Hash (SHA-224) {hash}?",
-          "success": "Âncora confiável excluída com sucesso",
-          "title": "Excluir Âncora"
+        "deleteMember":{
+           "confirmation":"Deseja excluir o membro com identificador \"{identifier}\" deste grupo global? Digite o código do membro para confirmar.",
+           "placeholder":"Digite o código do membro",
+           "success":"Membro \"{identifier}\" excluído com sucesso deste grupo global",
+           "title":"Excluir membro"
         }
-      }
-    }
+     },
+     "editDescription":"Editar descrição",
+     "groupDeletedSuccessfully":"Grupo global excluído com sucesso.",
+     "groupMembers":"Membros do grupo ({memberCount})",
+     "instance":"Instância",
+     "memberName":"Nome do Membro",
+     "subsystem":"Subsistema",
+     "type":"Tipo"
   },
-  "globalGroup": {
-    "added": "Adicionado",
-    "addMembers": "Adicionar Membros",
-    "areYouSure": "Tem certeza de que deseja remover o grupo global {group}?",
-    "code": "Código",
-    "class": "Classe",
-    "deleteGroup": "Excluir Grupo",
-    "description": "Descrição",
-    "descriptionSaved": "Descrição salva com sucesso.",
-    "editDescription": "Editar Descrição",
-    "groupDeletedSuccessfully": "Grupo global excluído com sucesso.",
-    "groupMembers": "Membros do grupo ({memberCount})",
-    "instance": "Instância",
-    "memberName": "Nome do Membro",
-    "subsystem": "Subsistema",
-    "type": "Tipo",
-    "dialog": {
-      "addMembers": {
-        "title": "Adicionar Membros",
-        "success": "Membros com identificadores: {identifiers} foram adicionados a este grupo global"
-      },
-      "deleteMember": {
-        "title": "Excluir Membro",
-        "confirmation": "Tem certeza de que deseja excluir o membro do grupo com o identificador \"{identifier}\" deste grupo global? Insira o código do membro para confirmar.",
-        "placeholder": "Insira o Código do Membro",
-        "success": "Membro com o identificador \"{identifier}\" foi excluído deste grupo global"
-      }
-    }
+  "globalResources":{
+     "addGlobalGroup":"Adicionar grupo global",
+     "code":"Código",
+     "description":"Descrição",
+     "globalGroupSuccessfullyAdded":"Grupo global adicionado com sucesso.",
+     "globalGroups":"Grupos Globais",
+     "memberCount":"Quantidade de membros",
+     "updated":"Atualizado"
   },
-  "globalResources": {
-    "addGlobalGroup": "Adicionar Grupo Global",
-    "globalGroupSuccessfullyAdded": "Grupo global adicionado com sucesso.",
-    "code": "Código",
-    "description": "Descrição",
-    "globalGroups": "Grupos Globais",
-    "memberCount": "Contagem de Membros",
-    "updated": "Atualizado"
+  "init":{
+     "address":{
+        "info":"Nome DNS público ou endereço IP externo do Servidor Central. Utilizado para conexões recebidas da rede externa."
+     },
+     "csIdentification":"Identificação do Servidor Central",
+     "initialConfiguration":"Configuração Inicial",
+     "instanceIdentifier":{
+        "info":"Código da instância X-Road, identifica unicamente esta instância."
+     },
+     "notification":"Servidor Central inicializado! Agora continue com a configuração completa.",
+     "pin":{
+        "info":"PIN de acesso ao token de software.",
+        "pinMatchError":"A confirmação do PIN não corresponde",
+        "repeat":"Repetir PIN"
+     },
+     "softwareToken":"Token de Software"
   },
-  "init": {
-    "address": {
-      "info": "Nome DNS público ou endereço IP externo do servidor central. Usado para conexões de entrada da rede externa para o servidor central."
-    },
-    "csIdentification": "Identificação do Servidor Central",
-    "initialConfiguration": "Configuração Inicial",
-    "instanceIdentifier": {
-      "info": "Código da instância X-Road, identifica exclusivamente esta instância X-Road."
-    },
-    "notification": "O Servidor Central foi inicializado! Agora continue com a configuração completa.",
-    "pin": {
-      "info": "PIN para acessar o token de software.",
-      "pinMatchError": "A confirmação da senha não corresponde",
-      "repeat": "Repetir PIN"
-    },
-    "softwareToken": "Token de Software"
-  },
-  "keys": {
-    "title": "Chaves de Assinatura",
-    "addKey": "Adicionar chave",
-    "created": "Criado",
-    "logIn": "Entrar",
-    "logOut": "Sair",
-    "signKey": "Assinar chave",
-    "algorithm": "Algoritmo da chave",
-    "token": "Token:",
-    "dialog": {
-      "delete": {
-        "title": "Excluir chave",
-        "text": "Excluir chave '{label}'?",
-        "confirmButton": "Excluir",
-        "success": "Chave de assinatura excluída com sucesso"
-      },
-      "add": {
-        "title": "Adicionar chave",
-        "labelField": "Nome amigável da chave",
-        "confirmButton": "Adicionar",
-        "success": "Chave de assinatura '{label}' adicionada com sucesso. Por favor, não ative a chave imediatamente. Consulte o guia do usuário do Servidor Central antes de ativar a chave."
-      },
-      "activate": {
-        "title": "Ativar chave",
-        "text": "Ativar chave '{label}'?",
-        "confirmButton": "Ativar",
-        "success": "Chave de assinatura '{label}' ativada com sucesso"
-      }
-    }
-  },
-  "tokens": {
-    "keysInfoMessage": "É permitido no máximo duas chaves de assinatura de fonte de configuração em um token de segurança",
-    "logIn": "Entrar",
-    "pin": "PIN do Token",
-    "loginDialog": {
-      "title": "Entrar",
-      "success": "Token autenticado com sucesso"
-    },
-    "logout": {
-      "title": "Sair",
-      "confirmButton": "Sair",
-      "text": "Tem certeza de que deseja sair do token?",
-      "success": "Desconectado do token"
-    },
-    "errors": {
-      "Signer": {
-        "PinIncorrect": "PIN inválido"
-      }
-    }
-  },
-  "managementRequests": {
-    "addCertificate": "Adicionar Certificado",
-    "addClient": "Adicionar Cliente",
-    "approved": "Aprovado",
-    "submitted": "Enviado para aprovação",
-    "changeOwner": "Alterar Proprietário",
-    "changeAddress": "Alterar endereço",
-    "clientEnable": "Habilitar cliente",
-    "clientDisable": "Desabilitar cliente",
-    "pending": "Pendente",
-    "rejected": "Rejeitado",
-    "revoked": "Revogado",
-    "unknown": "Desconhecido",
-    "removeCertificate": "Remover Certificado",
-    "removeClient": "Remover Cliente",
-    "securityServerId": "Identificador do Servidor",
-    "securityServerOwnerName": "Nome do Proprietário do Servidor",
-    "showOnlyPending": "Mostrar apenas solicitações pendentes",
-    "dialog": {
-      "approve": {
-        "title": "Aprovar solicitação de gerenciamento",
-        "bodyMessage": "Tem certeza de que deseja aprovar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
-        "successMessage": "Solicitação de gerenciamento ID {id} do servidor {serverId} aprovada",
-        "newMemberWarning": "O membro especificado atualmente não existe. Ele será criado automaticamente quando esta solicitação for aprovada."
-      },
-      "decline": {
-        "title": "Rejeitar solicitação de gerenciamento",
-        "bodyMessage": "Tem certeza de que deseja rejeitar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
-        "successMessage": "Solicitação de gerenciamento ID {id} do servidor {serverId} rejeitada"
-      }
-    }
-  },
-  "managementRequestDetails": {
-    "requestInformation": "Informações da Solicitação",
-    "requestId": "ID da Solicitação",
-    "received": "Recebido",
-    "source": "Fonte",
-    "status": "Status",
-    "comments": "Comentários",
-    "securityServerInformation": "Informações do servidor seguro Afetado",
-    "ownerName": "Nome do Proprietário",
-    "ownerClass": "Classe do Proprietário",
-    "ownerCode": "Código do Proprietário",
-    "serverCode": "Código do Servidor",
-    "address": "Endereço",
-    "clientInformation": "Cliente Enviado para Registro",
-    "ownerChangeInformation": "Novo Proprietário Enviado para Registro",
-    "clientDisableInformation": "Cliente desabilitado",
-    "clientEnableInformation": "Cliente habilitado",
-    "subsystemCode": "Código do Subsistema",
-    "certificateformation": "Certificado de Autenticação Enviado para Registro",
-    "ca": "CA",
-    "serialNumber": "Número de Série",
-    "subject": "Titular do Certificado (DN)",
-    "expires": "Expira"
-  },
-  "members": {
-    "addMember": "Adicionar membro",
-    "header": "Membros",
-    "member": {
-      "details": {
-        "addedToGroup": "Adicionado ao grupo",
-        "globalGroups": "Grupos Globais",
-        "group": "Grupo",
-        "ownedServers": "Servidores Possuídos",
-        "usedServers": "Servidores Utilizados",
-        "server": "Servidor",
-        "enterCode": "Insira o Código do Membro",
-        "deleteMember": "Excluir membro",
-        "confirmDelete": "Tem certeza de que deseja excluir o Membro {member} da configuração do sistema? Insira o código do membro para confirmar.",
-        "editMemberName": "Editar nome do Membro",
-        "memberNameSaved": "Nome do membro salvo com sucesso",
-        "memberDeleted": "Membro excluído com sucesso",
-        "areYouSureUnregister": "Tem certeza de que deseja desregistrar o Membro {memberCode} do servidor {serverCode} da configuração do sistema?",
-        "unregisterMember": "Desregistrar membro",
-        "memberSuccessfullyUnregistered": "Membro {memberCode} do servidor {serverCode} foi desregistrado com sucesso"
-      },
-      "managementRequests": {
-        "created": "Criado",
-        "id": "ID da Solicitação",
-        "showOnlyWaiting": "Mostrar apenas solicitações pendentes",
-        "status": "Status",
-        "type": "Tipo de solicitação"
-      },
-      "pagenavigation": {
-        "details": "Detalhes",
-        "managementRequests": "Solicitações de Gerenciamento",
-        "subsystems": "Subsistemas"
-      },
-      "subsystems": {
-        "addClient": "Adicionar subsistema",
-        "deleteSubsystem": "Excluir Subsistema",
-        "serverOwner": "Proprietário do servidor",
-        "servercode": "Código do servidor",
-        "status": "Status",
-        "subsystemcode": "Código do subsistema",
-        "subsystemSuccessfullyAdded": "Subsistema {subsystemCode} foi adicionado à configuração do sistema",
-        "areYouSureDelete": "Tem certeza de que deseja excluir o Subsistema {subsystemCode} do membro X-Road {memberId} da configuração do sistema?",
-        "subsystemSuccessfullyDeleted": "Subsistema {subsystemCode} foi excluído da configuração do sistema",
-        "areYouSureUnregister": "Tem certeza de que deseja excluir o Subsistema {subsystemCode} do servidor {serverCode} da configuração do sistema?",
-        "subsystemSuccessfullyUnregistered": "Subsistema {subsystemCode} do servidor {serverCode} foi excluído"
-      }
-    },
-    "memberSuccessfullyAdded": "Membro {memberName} foi adicionado à configuração do sistema."
-  },
-    "noData": {
-      "noMemberClasses": "Nenhuma classe de membros",
-      "noSecurityServers": "Nenhum servidor seguro"
-    },
-    "securityServers": {
-      "address": "Endereço",
-      "ownerClass": "Classe do Proprietário",
-      "ownerCode": "Código do Proprietário",
-      "ownerName": "Nome do Proprietário",
-      "registered": "Registrado",
-      "unregistered": "Não registrado",
-      "pending": "Aguardando aprovação",
-      "disabled": "Temporariamente desativado",
-      "securityServer": {
-        "certificationAuthority": "Autoridade de Certificação",
-        "deleteServer": "Excluir servidor",
-        "expires": "Expira",
-        "serialNumber": "Número de Série",
-        "subject": "Titular do Certificado (DN)",
-        "deleteSecurityServer": "Excluir servidor seguro",
-        "tabs": {
-          "authCertificates": "Certificados de Autenticação",
-          "clients": "Clientes",
-          "details": "Detalhes",
-          "managementRequests": "Solicitações de Gerenciamento"
+  "keys":{
+     "addKey":"Adicionar chave",
+     "algorithm":"Algoritmo da chave",
+     "created":"Criada",
+     "dialog":{
+        "activate":{
+           "confirmButton":"Ativar",
+           "success":"Chave de assinatura '{label}' ativada com sucesso",
+           "text":"Ativar chave '{label}'?",
+           "title":"Ativar chave"
         },
-        "dialog": {
-          "deleteAuthCertificate": {
-            "title": "Excluir Certificado de Autenticação",
-            "content": "Tem certeza de que deseja excluir o Certificado de Autenticação Test CA da configuração do sistema? Insira o código do servidor para confirmar.",
-            "securityServerCode": "Insira o Código do servidor seguro",
-            "success": "Certificado de autenticação do servidor seguro excluído com sucesso"
-          }
+        "add":{
+           "confirmButton":"Adicionar",
+           "labelField":"Nome amigável da chave",
+           "success":"Chave de assinatura '{label}' adicionada com sucesso. Não ative a chave imediatamente. Consulte o guia do usuário do Servidor Central antes de ativar.",
+           "title":"Adicionar chave"
+        },
+        "delete":{
+           "confirmButton":"Excluir",
+           "success":"Chave de assinatura excluída com sucesso",
+           "text":"Excluir chave '{label}'?",
+           "title":"Excluir chave"
         }
-      },
-      "dialogs": {
-        "editAddress": {
-          "title": "Editar endereço do servidor seguro",
-          "addressField": "Endereço do servidor seguro",
-          "success": "Endereço do servidor seguro atualizado com sucesso"
-        },
-        "deleteAddress": {
-          "title": "Excluir servidor seguro",
-          "enterCode": "Insira o Código do servidor seguro",
-          "areYouSure": "Tem certeza de que deseja excluir o servidor seguro {securityServer} da configuração do sistema? Insira o código do servidor para confirmar.",
-          "success": "Servidor seguro excluído."
-        }
-      },
-      "serverCode": "Código do Servidor"
-    },
-      "systemSettings": {
-        "centralServerAddress": "Endereço do Servidor Central",
-        "code": "Código",
-        "description": "Descrição",
-        "editCentralServerAddressSuccess": "Endereço do Servidor Central atualizado com sucesso",
-        "editCentralServerAddressTitle": "Editar endereço do Servidor Central",
-        "instanceIdentifier": "Identificador da Instância",
-        "managementServices": {
-          "title": "Serviços de Gerenciamento",
-          "securityServer": "Servidor seguro dos Serviços de Gerenciamento"
-        },
-        "selectSubsystem": {
-          "title": "Selecionar Subsistema",
-          "search": "Pesquisar",
-          "name": "Nome",
-          "memberClass": "Classe",
-          "memberCode": "Código",
-          "subsystemCode": "Subsistema",
-          "xroadInstance": "Instância",
-          "type": "Tipo"
-        },
-        "selectSecurityServer": {
-          "title": "Selecionar servidor seguro",
-          "search": "Pesquisar",
-          "name": "Nome",
-          "memberClass": "Classe",
-          "memberCode": "Código",
-          "subsystemCode": "Subsistema",
-          "xroadInstance": "Instância",
-          "type": "Tipo"
-        },
-        "serviceProvider": {
-          "changedSuccess": "Provedor de Serviço alterado com sucesso",
-          "registeredSuccess": "Provedor de serviço de gerenciamento '{subsystemId}' registrado como cliente do servidor seguro '{securityServerId}'"
-        },
-        "memberClasses": "Classes de Membros",
-        "securityServerOwnerGroupCode": "Código do Grupo de Proprietários do servidor seguro",
-        "serviceProviderIdentifier": "Identificador do Provedor de Serviço",
-        "serviceProviderName": "Nome do Provedor de Serviço",
-        "systemParameters": "Parâmetros do Sistema",
-        "wsdlAddress": "Endereço WSDL",
-        "managementServicesAddress": "Endereço dos Serviços de Gerenciamento",
-        "editMemberClassTitle": "Editar classe de membro",
-        "addMemberClassTitle": "Adicionar classe de membro",
-        "deleteMemberClass": "Excluir classe de membro?",
-        "memberClassSaved": "Classe de membro salva.",
-        "memberClassDeleted": "Classe de membro excluída."
-      },
-      "tlsCertificates": {
-        "managementService": {
-          "title": "Certificado TLS do Serviço de Gerenciamento",
-          "key": "Chave TLS do Serviço de Gerenciamento",
-          "downloadCertificate": "Baixar certificado",
-          "downloadSuccess": "Certificado TLS do serviço de gerenciamento baixado com sucesso",
-          "generateKey": {
-            "button": "Recriar chave",
-            "title": "Chave TLS do Serviço de Gerenciamento",
-            "confirmation": "Gerar uma nova chave e certificado TLS do serviço de gerenciamento?",
-            "explanation": "O sistema irá gerar uma nova chave TLS do serviço de gerenciamento e um certificado autoassinado, substituindo a chave e o certificado existentes.",
-            "success": "Nova chave e certificado TLS do serviço de gerenciamento gerados com sucesso"
-          },
-          "generateCsr": {
-            "button": "Gerar CSR",
-            "title": "Gerar Solicitação de Assinatura de Certificado TLS",
-            "content": "Primeiro, forneça um Titular do Certificado (DN). Em seguida, gere um novo CSR e salve-o em um local seguro",
-            "distinguishedName": "Insira o Titular do Certificado (DN)",
-            "example": "CN=meuservercentral.exemplo.com, O=Minha Organização, C=BR"
-          },
-          "uploadCertificate": {
-            "button": "Enviar certificado",
-            "title": "Enviar certificado TLS do Serviço de Gerenciamento",
-            "label": "Envie o arquivo de certificado do seu computador",
-            "success": "Certificado TLS do serviço de gerenciamento enviado com sucesso"
-      }
-    }
+     },
+     "logIn":"Entrar",
+     "logOut":"Sair",
+     "signKey":"Chave de Assinatura",
+     "title":"Chaves de Assinatura"
   },
-  "tab": {
-    "globalConf": {
-      "externalConf": "Configuração Externa",
-      "internalConf": "Configuração Interna",
-      "trustedAnchors": "Âncoras Confiáveis"
-    },
-    "main": {
-      "globalConfiguration": "Configuração Global",
-      "managementRequests": "Solicitações de Gerenciamento",
-      "members": "Membros",
-      "securityServers": "Servidores de Segurança",
-      "settings": "Configurações",
-      "trustServices": "Serviços de Confiança"
-    },
-    "settings": {
-      "apiKeys": "Chaves de API",
-      "backupAndRestore": "Backup e Restauração",
-      "globalResources": "Recursos Globais",
-      "systemSettings": "Configurações do Sistema",
-      "tlsCertificates": "Certificados TLS"
-    }
+  "managementRequestDetails":{
+     "address":"Endereço",
+     "ca":"AC (Autoridade Certificadora)",
+     "certificateformation":"Certificado de Autenticação enviado para registro",
+     "clientDisableInformation":"Cliente desativado",
+     "clientEnableInformation":"Cliente ativado",
+     "clientInformation":"Cliente enviado para registro",
+     "clientRenameInformation":"Cliente renomeado",
+     "comments":"Comentários",
+     "expires":"Expira em",
+     "ownerChangeInformation":"Novo proprietário enviado para registro",
+     "ownerClass":"Classe do proprietário",
+     "ownerCode":"Código do proprietário",
+     "ownerName":"Nome do proprietário",
+     "received":"Recebido",
+     "requestId":"ID da solicitação",
+     "requestInformation":"Informações da solicitação",
+     "securityServerInformation":"Informações do servidor seguro afetado",
+     "serialNumber":"Número de série",
+     "serverCode":"Código do servidor",
+     "source":"Origem",
+     "status":"Status",
+     "subject":"Titular",
+     "subsystemCode":"Código do subsistema",
+     "subsystemName":"Nome do subsistema"
   },
-  "trustServices": {
-    "addCertificationService": "Adicionar serviço de certificação",
-    "addCASettingsCheckbox": "Esta CA pode ser usada apenas para autenticação TLS (marque se for verdade)",
-    "approvedCertificationService": "Serviço de certificação aprovado",
-    "caSettings": "Configurações da CA",
-    "certificationServices": "Serviços de Certificação",
-    "certImportedSuccessfully": "Certificado importado com sucesso",
-    "certProfileInput": "Informações do perfil do certificado",
-    "certProfileInputExplanation": "Nome completo da classe que implementa a interface ee.ria.xroad.common.certificateprofile.CertificateProfileInfoProvider",
-    "acmeServerDirectoryUrlExplanation": "Usado pelos Servidores de Segurança para operações relacionadas a certificados via a API do Servidor ACME.",
-    "acmeServerIpAddressExplanation": "Uma lista de IPs de origem do Servidor ACME usados para completar o desafio HTTP do ACME com o servidor seguro. Vários endereços são separados por vírgula. Esta informação é exibida na interface do servidor seguro.",
-    "acmeServerAuthProfileIdExplanation": "ID do perfil usado por alguns servidores ACME para informar o tipo de uso do certificado ao solicitar um certificado de autenticação.",
-    "acmeServerSignProfileIdExplanation": "ID do perfil usado por alguns servidores ACME para informar o tipo de uso do certificado ao solicitar um certificado de assinatura.",
-    "timestampingServices": "Serviços de Carimbo de Tempo",
-    "validFrom": "Válido de",
-    "validTo": "Válido até",
-    "viewCertificate": "Visualizar Certificado",
-    "uploadCertificate": "Enviar o arquivo de certificado do seu computador",
-    "timestampingService": {
-      "url": "URL",
-      "dialog": {
-        "add": {
-          "title": "Adicionar serviço de carimbo de tempo",
-          "success": "Serviço de carimbo de tempo adicionado com sucesso"
+  "managementRequests":{
+     "addCertificate":"Adicionar certificado",
+     "addClient":"Adicionar cliente",
+     "approved":"Aprovada",
+     "changeAddress":"Alterar endereço",
+     "changeOwner":"Alterar proprietário",
+     "clientDisable":"Desativar cliente",
+     "clientEnable":"Ativar cliente",
+     "dialog":{
+        "approve":{
+           "bodyMessage":"Deseja realmente aprovar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
+           "newMemberWarning":"O membro especificado ainda não existe. Ele será criado automaticamente ao aprovar esta solicitação.",
+           "successMessage":"Solicitação de gerenciamento ID {id} do servidor {serverId} aprovada",
+           "title":"Aprovar solicitação de gerenciamento"
         },
-        "edit": {
-          "title": "Editar serviço de carimbo de tempo",
-          "uploadCertificate": "Enviar novo certificado",
-          "success": "Serviço de carimbo de tempo editado com sucesso"
+        "decline":{
+           "bodyMessage":"Deseja realmente recusar a solicitação de gerenciamento ID {id} do servidor {serverId}?",
+           "successMessage":"Solicitação de gerenciamento ID {id} do servidor {serverId} recusada",
+           "title":"Recusar solicitação de gerenciamento"
         }
-      },
-      "addedSuccessfully": "Serviço de carimbo de tempo adicionado com sucesso"
-    },
-    "trustService": {
-      "details": {
-        "subjectDistinguishedName": "Titular do Certificado (DN)",
-        "issuerDistinguishedName": "Autoridade Certificadora"
-      },
-      "delete": {
-        "action": "Excluir serviço de confiança",
-        "confirmationDialog": {
-          "title": "Você tem certeza?",
-          "message": "Tem certeza de que deseja excluir o serviço de confiança \"{name}\"?"
-        },
-        "success": "Serviço de confiança excluído com sucesso"
-      },
-      "settings": {
-        "tlsAuth": "Esta CA pode ser usada apenas para autenticação TLS",
-        "certProfile": "Informações do perfil do certificado (nome completo da classe que implementa a interface ee.ria.xroad.common.CertificateProfileInfoProvider)",
-        "saveSuccess": "Configurações da CA salvas com sucesso",
-        "acmeCapable": "Esta CA pode ser usada para ACME",
-        "acmeNotCapable": "Esta CA não pode ser usada para ACME"
-      },
-      "ocspResponders": {
-        "url": "URL",
-        "add": {
-          "dialog": {
-            "title": "Adicionar Validador OCSP"
-          },
-          "success": "Validador OCSP adicionado com sucesso"
-        },
-        "edit": {
-          "dialog": {
-            "title": "Editar Validador OCSP",
-            "uploadCertificate": "Enviar novo certificado"
-          },
-          "success": "Validador OCSP editado com sucesso"
-        },
-        "delete": {
-          "confirmationDialog": {
-            "message": "Tem certeza de que deseja excluir o Validador OCSP com o URL {url}?",
-            "title": "Você tem certeza?"
-          },
-          "success": "Validador OCSP excluído com sucesso"
-        }
-      },
-      "intermediateCas": {
-        "intermediateCa": "CA Intermediária",
-        "add": {
-          "dialog": {
-            "title": "Adicionar CAs Intermediárias"
-          },
-          "success": "CA Intermediária adicionada com sucesso"
-        },
-        "delete": {
-          "confirmationDialog": {
-            "message": "Tem certeza de que deseja excluir a CA Intermediária {name}?",
-            "title": "Você tem certeza?"
-          },
-          "success": "CA Intermediária excluída com sucesso"
-        }
-      },
-      "timestampingService": {
-        "url": "URL",
-        "timestampingInterval": "Intervalo de carimbo de tempo",
-        "timestampingIntervalMinutes": "{min} minuto(s)",
-        "cost": "Custo",
-        "costValues": {
-          "FREE": "Gratuito",
-          "PAID": "Pago",
-          "UNDEFINED": "Indefinido"
-        },
-        "delete": {
-          "dialog": {
-            "title": "Você tem certeza?",
-            "message": "Tem certeza de que deseja excluir o serviço de carimbo de tempo com o URL {url}?"
-          },
-          "success": "Serviço de carimbo de tempo excluído com sucesso"
-        }
-      },
-      "pagenavigation": {
-        "details": "Detalhes",
-        "settings": "Configurações da CA",
-        "ocspResponders": "Validadores OCSP",
-        "intermediateCas": "CAs Intermediárias"
-      }
-    }
+     },
+     "pending":"Pendente",
+     "rejected":"Recusada",
+     "removeCertificate":"Remover certificado",
+     "removeClient":"Remover cliente",
+     "renameClient":"Renomear cliente",
+     "revoked":"Revogada",
+     "securityServerId":"Identificador do Servidor",
+     "securityServerOwnerName":"Nome do proprietário do servidor",
+     "showOnlyPending":"Exibir apenas solicitações pendentes",
+     "submitted":"Enviada para aprovação",
+     "unknown":"Desconhecida"
   },
-  "validationError": {
-    "IdentifierChars": "O identificador da instância não deve conter dois pontos (:), ponto e vírgula (;), barras (/) ou sinais de porcentagem (%).",
-    "IdentifierCharsField": "Use apenas caracteres válidos para identificadores",
-    "SizeField": "O valor não atende aos requisitos de comprimento"
+  "members":{
+     "addMember":"Adicionar membro",
+     "header":"Membros",
+     "member":{
+        "details":{
+           "addedToGroup":"Adicionado ao grupo",
+           "areYouSureUnregister":"Deseja realmente remover o Membro {memberCode} do servidor {serverCode} da configuração do sistema?",
+           "confirmDelete":"Tem certeza de que deseja excluir o Membro {member} da configuração do sistema? Digite o código do membro para confirmar.",
+           "deleteMember":"Excluir membro",
+           "editMemberName":"Editar nome do Membro",
+           "enterCode":"Digite o Código do Membro",
+           "globalGroups":"Grupos Globais",
+           "group":"Grupo",
+           "memberDeleted":"Membro excluído com sucesso",
+           "memberNameSaved":"Nome do membro salvo com sucesso",
+           "memberSuccessfullyUnregistered":"Membro {memberCode} do servidor {serverCode} removido com sucesso",
+           "ownedServers":"Servidores próprios",
+           "server":"Servidor",
+           "unregisterMember":"Remover membro",
+           "usedServers":"Servidores utilizados"
+        },
+        "managementRequests":{
+           "created":"Criado",
+           "id":"ID da solicitação",
+           "showOnlyWaiting":"Exibir apenas solicitações pendentes",
+           "status":"Status",
+           "type":"Tipo da solicitação"
+        },
+        "pagenavigation":{
+           "details":"Detalhes",
+           "managementRequests":"Solicitações de Gerenciamento",
+           "subsystems":"Subsistemas"
+        },
+        "subsystems":{
+           "addClient":"Adicionar subsistema",
+           "areYouSureDelete":"Tem certeza de que deseja excluir o Subsistema {subsystemCode} do Membro X-Road {memberId} da configuração do sistema?",
+           "areYouSureUnregister":"Tem certeza de que deseja remover o Subsistema {subsystemCode} do servidor {serverCode} da configuração do sistema?",
+           "deleteSubsystem":"Excluir Subsistema",
+           "renameSubsystem":"Renomear Subsistema",
+           "serverOwner":"Proprietário do servidor",
+           "servercode":"Código do servidor",
+           "status":"Status",
+           "subsystemSuccessfullyAdded":"Subsistema {subsystemCode} adicionado à configuração do sistema",
+           "subsystemSuccessfullyDeleted":"Subsistema {subsystemCode} excluído da configuração do sistema",
+           "subsystemSuccessfullyRenamed":"Nome do subsistema salvo com sucesso",
+           "subsystemSuccessfullyUnregistered":"Subsistema {subsystemCode} do servidor {serverCode} removido",
+           "subsystemcode":"Código do Subsistema",
+           "subsystemname":"Nome do Subsistema"
+        }
+     },
+     "memberSuccessfullyAdded":"Membro {memberName} adicionado à configuração do sistema."
   },
-  "validation": {
-    "messages": {
-      "is": "O campo {field} deve ter o valor \"{other}\""
-    }
+  "noData":{
+     "noMemberClasses":"Nenhuma classe de membro encontrada",
+     "noSecurityServers":"Nenhum servidor seguro encontrado"
   },
-  "status": {
-    "signer_error": "Falha na invocação do cliente do assinador",
-    "global_conf_generation": {
-      "status_not_found": "O status da geração da configuração global é desconhecido",
-      "failing": "A geração da configuração global está falhando desde {0}",
-      "global_conf_expired": "Configuração global expirada"
-    },
-    "signing_key": {
-      "internal": {
-        "missing": "Assinatura da configuração interna falhou - chave ativa ausente",
-        "token_not_found": "Assinatura da configuração interna falhou - chave ativa não encontrada",
-        "token_not_active": "Assinatura da configuração interna falhou - PIN da chave ativa não foi inserido",
-        "key_not_available": "Assinatura da configuração interna falhou - chave ativa não disponível"
-      },
-      "external": {
-        "missing": "Assinatura da configuração externa falhou - chave ativa ausente",
-        "token_not_found": "Assinatura da configuração externa falhou - chave ativa não encontrada",
-        "token_not_active": "Assinatura da configuração externa falhou - PIN da chave ativa não foi inserido",
-        "key_not_available": "Assinatura da configuração externa falhou - chave ativa não disponível"
-      }
-    }
+  "securityServers":{
+     "address":"Endereço",
+     "dialogs":{
+        "deleteAddress":{
+           "areYouSure":"Tem certeza de que deseja excluir o Servidor Seguro {securityServer} da configuração do sistema? Digite o código do servidor para confirmar.",
+           "enterCode":"Digite o Código do Servidor Seguro",
+           "success":"Servidor seguro excluído.",
+           "title":"Excluir Servidor Seguro"
+        },
+        "editAddress":{
+           "addressField":"Endereço do servidor seguro",
+           "success":"Endereço do servidor seguro atualizado com sucesso",
+           "title":"Editar endereço do servidor seguro"
+        }
+     },
+     "disabled":"Temporariamente desativado",
+     "ownerClass":"Classe do Proprietário",
+     "ownerCode":"Código do Proprietário",
+     "ownerName":"Nome do Proprietário",
+     "pending":"Aguardando aprovação",
+     "registered":"Registrado",
+     "securityServer":{
+        "certificationAuthority":"Autoridade Certificadora",
+        "deleteSecurityServer":"Excluir Servidor Seguro",
+        "deleteServer":"Excluir servidor",
+        "dialog":{
+           "deleteAuthCertificate":{
+              "content":"Tem certeza de que deseja excluir o Certificado de Autenticação Test CA da configuração do sistema? Digite o código do servidor para confirmar.",
+              "securityServerCode":"Digite o Código do Servidor Seguro",
+              "success":"Certificado de autenticação do servidor seguro excluído com sucesso",
+              "title":"Excluir Certificado de Autenticação"
+           }
+        },
+        "expires":"Expira em",
+        "serialNumber":"Número de Série",
+        "subject":"Titular",
+        "tabs":{
+           "authCertificates":"Certificados de Autenticação",
+           "clients":"Clientes",
+           "details":"Detalhes",
+           "managementRequests":"Solicitações de Gerenciamento"
+        }
+     },
+     "serverCode":"Código do Servidor",
+     "unregistered":"Não registrado"
+  },
+  "status":{
+     "global_conf_generation":{
+        "failing":"Geração da configuração global falhando desde {0}",
+        "global_conf_expired":"Configuração global expirada",
+        "status_not_found":"Status da geração da configuração global desconhecido"
+     },
+     "signer_error":"Falha ao invocar cliente do assinador",
+     "signing_key":{
+        "external":{
+           "key_not_available":"Assinatura da configuração externa falhou - chave ativa indisponível",
+           "missing":"Assinatura da configuração externa falhou - chave ativa ausente",
+           "token_not_active":"Assinatura da configuração externa falhou - PIN da chave ativa não foi inserido",
+           "token_not_found":"Assinatura da configuração externa falhou - chave ativa não encontrada"
+        },
+        "internal":{
+           "key_not_available":"Assinatura da configuração interna falhou - chave ativa indisponível",
+           "missing":"Assinatura da configuração interna falhou - chave ativa ausente",
+           "token_not_active":"Assinatura da configuração interna falhou - PIN da chave ativa não foi inserido",
+           "token_not_found":"Assinatura da configuração interna falhou - chave ativa não encontrada"
+        }
+     }
+  },
+  "systemSettings":{
+     "addMemberClassTitle":"Adicionar classe de membro",
+     "centralServerAddress":"Endereço do Servidor Central",
+     "code":"Código",
+     "deleteMemberClass":"Excluir classe de membro?",
+     "description":"Descrição",
+     "editCentralServerAddressSuccess":"Endereço do Servidor Central atualizado com sucesso",
+     "editCentralServerAddressTitle":"Editar endereço do Servidor Central",
+     "editMemberClassTitle":"Editar classe de membro",
+     "instanceIdentifier":"Identificador da Instância",
+     "managementServices":{
+        "securityServer":"Servidor Seguro dos Serviços de Gerenciamento",
+        "title":"Serviços de Gerenciamento"
+     },
+     "managementServicesAddress":"Endereço dos Serviços de Gerenciamento",
+     "memberClassDeleted":"Classe de membro excluída.",
+     "memberClassSaved":"Classe de membro salva.",
+     "memberClasses":"Classes de Membro",
+     "securityServerOwnerGroupCode":"Código do grupo de proprietários do Servidor Seguro",
+     "selectSecurityServer":{
+        "memberClass":"Classe",
+        "memberCode":"Código",
+        "name":"Nome",
+        "search":"Buscar",
+        "subsystemCode":"Subsistema",
+        "title":"Selecionar Servidor Seguro",
+        "type":"Tipo",
+        "xroadInstance":"Instância"
+     },
+     "selectSubsystem":{
+        "memberClass":"Classe",
+        "memberCode":"Código",
+        "name":"Nome",
+        "search":"Buscar",
+        "subsystemCode":"Subsistema",
+        "title":"Selecionar Subsistema",
+        "type":"Tipo",
+        "xroadInstance":"Instância"
+     },
+     "serviceProvider":{
+        "changedSuccess":"Provedor de serviço alterado com sucesso",
+        "registeredSuccess":"Provedor de serviço '{subsystemId}' registrado como cliente do servidor seguro '{securityServerId}'"
+     },
+     "serviceProviderIdentifier":"Identificador do Provedor de Serviço",
+     "serviceProviderName":"Nome do Provedor de Serviço",
+     "systemParameters":"Parâmetros do Sistema",
+     "wsdlAddress":"Endereço WSDL"
+  },
+  "tab":{
+     "globalConf":{
+        "externalConf":"Configuração Externa",
+        "internalConf":"Configuração Interna",
+        "trustedAnchors":"Âncoras Confiáveis"
+     },
+     "main":{
+        "globalConfiguration":"Configuração Global",
+        "managementRequests":"Solicitações de Gerenciamento",
+        "members":"Membros",
+        "securityServers":"Servidores Seguros",
+        "settings":"Configurações",
+        "trustServices":"Serviços de Confiança"
+     },
+     "settings":{
+        "apiKeys":"Chaves de API",
+        "backupAndRestore":"Backup e Restauração",
+        "globalResources":"Recursos Globais",
+        "systemSettings":"Configurações do Sistema",
+        "tlsCertificates":"Certificados TLS"
+     }
+  },
+  "tlsCertificates":{
+     "managementService":{
+        "downloadCertificate":"Baixar certificado",
+        "downloadSuccess":"Certificado TLS dos Serviços de Gerenciamento baixado com sucesso",
+        "generateCsr":{
+           "button":"Gerar CSR",
+           "content":"Primeiro, informe um nome distinto. Em seguida, gere uma nova CSR e salve em local seguro",
+           "distinguishedName":"Insira o Titular do Certificado (DN)",
+           "example":"CN=meuservercentral.exemplo.com, O=Minha Organização, C=BR",
+           "title":"Gerar Requisição de Assinatura de Certificado TLS"
+        },
+        "generateKey":{
+           "button":"Recriar chave",
+           "confirmation":"Gerar nova chave e certificado TLS autossinado para os Serviços de Gerenciamento?",
+           "explanation":"O sistema irá gerar uma nova chave TLS e um certificado autossinado, substituindo os existentes.",
+           "success":"Nova chave e certificado TLS gerados com sucesso",
+           "title":"Chave TLS dos Serviços de Gerenciamento"
+        },
+        "key":"Chave TLS dos Serviços de Gerenciamento",
+        "title":"Certificado TLS dos Serviços de Gerenciamento",
+        "uploadCertificate":{
+           "button":"Enviar certificado",
+           "label":"Envie o arquivo do certificado do seu computador",
+           "success":"Certificado TLS dos Serviços de Gerenciamento enviado com sucesso",
+           "title":"Enviar Certificado dos Serviços de Gerenciamento"
+        }
+     }
+  },
+  "tokens":{
+     "keysInfoMessage":"O token pode conter no máximo duas chaves de assinatura da fonte de configuração",
+     "logIn":"Entrar",
+     "loginDialog":{
+        "success":"Token autenticado com sucesso",
+        "title":"Autenticar token"
+     },
+     "logout":{
+        "confirmButton":"Sair",
+        "success":"Token desconectado com sucesso",
+        "text":"Deseja realmente sair do token?",
+        "title":"Desconectar token"
+     },
+     "pin":"PIN do Token"
+  },
+  "trustServices":{
+     "acmeServerAuthProfileIdExplanation":"ID do perfil usado por alguns servidores ACME para indicar o uso do certificado ao solicitar certificados de autenticação.",
+     "acmeServerDirectoryUrlExplanation":"Usado pelos Servidores Seguros para executar operações de certificado via API do Servidor ACME.",
+     "acmeServerIpAddressExplanation":"Lista de IPs de origem do servidor ACME usados para completar o desafio HTTP com o Servidor Seguro. Endereços múltiplos devem ser separados por vírgula. Essa informação aparece na interface do Servidor Seguro.",
+     "acmeServerSignProfileIdExplanation":"ID do perfil usado por alguns servidores ACME ao solicitar certificados de assinatura.",
+     "addCASettingsCheckbox":"Esta AC pode ser usada apenas para autenticação TLS (marcar se verdadeiro)",
+     "addCertificationService":"Adicionar serviço de certificação",
+     "approvedCertificationService":"Serviço de certificação aprovado",
+     "caSettings":"Configurações da AC",
+     "certImportedSuccessfully":"Certificado importado com sucesso",
+     "certProfileInput":"Informações do perfil do certificado",
+     "certProfileInputExplanation":"Nome completo da classe que implementa a interface ee.ria.xroad.common.certificateprofile.CertificateProfileInfoProvider",
+     "certificationServices":"Serviços de Certificação",
+     "timestampingService":{
+        "addedSuccessfully":"Serviço de carimbo do tempo adicionado com sucesso",
+        "dialog":{
+           "add":{
+              "success":"Serviço de carimbo do tempo adicionado com sucesso",
+              "title":"Adicionar serviço de carimbo do tempo"
+           },
+           "edit":{
+              "success":"Serviço de carimbo do tempo editado com sucesso",
+              "title":"Editar Serviço de Carimbo do Tempo",
+              "uploadCertificate":"Enviar novo certificado"
+           }
+        },
+        "url":"URL"
+     },
+     "timestampingServices":"Serviços de Carimbo do Tempo",
+     "trustService":{
+        "delete":{
+           "action":"Excluir serviço de confiança",
+           "confirmationDialog":{
+              "message":"Tem certeza de que deseja excluir o serviço de confiança \"{name}\"?",
+              "title":"Tem certeza?"
+           },
+           "success":"Serviço de confiança excluído com sucesso"
+        },
+        "details":{
+           "issuerDistinguishedName":"Autoridade Certificadora",
+           "subjectDistinguishedName":"Titular do Certificado (DN)"
+        },
+        "intermediateCas":{
+           "add":{
+              "dialog":{
+                 "title":"Adicionar ACs Intermediárias"
+              },
+              "success":"AC Intermediária adicionada com sucesso"
+           },
+           "delete":{
+              "confirmationDialog":{
+                 "message":"Tem certeza de que deseja excluir a AC Intermediária {name}?",
+                 "title":"Tem certeza?"
+              },
+              "success":"AC Intermediária excluída com sucesso"
+           },
+           "intermediateCa":"AC Intermediária"
+        },
+        "ocspResponders":{
+           "add":{
+              "dialog":{
+                 "title":"Adicionar Validador OCSP"
+              },
+              "success":"Validador OCSP adicionado com sucesso"
+           },
+           "delete":{
+              "confirmationDialog":{
+                 "message":"Tem certeza de que deseja excluir o Validador OCSP com a URL {url}?",
+                 "title":"Tem certeza?"
+              },
+              "success":"Validador OCSP excluído com sucesso"
+           },
+           "edit":{
+              "dialog":{
+                 "title":"Editar Validador OCSP",
+                 "uploadCertificate":"Enviar novo certificado"
+              },
+              "success":"Validador OCSP editado com sucesso"
+           },
+           "url":"URL"
+        },
+        "pagenavigation":{
+           "details":"Detalhes",
+           "intermediateCas":"ACs Intermediárias",
+           "ocspResponders":"Validador OCSP",
+           "settings":"Configurações da AC"
+        },
+        "settings":{
+           "acmeCapable":"Esta AC pode ser usada com ACME",
+           "acmeNotCapable":"Esta AC não pode ser usada com ACME",
+           "certProfile":"Informações do perfil do certificado (nome completo da classe que implementa a interface ee.ria.xroad.common.CertificateProfileInfoProvider)",
+           "saveSuccess":"Configurações da AC salvas com sucesso",
+           "tlsAuth":"Esta AC pode ser usada apenas para autenticação TLS"
+        },
+        "timestampingService":{
+           "cost":"Custo",
+           "costValues":{
+              "FREE":"Gratuito",
+              "PAID":"Pago",
+              "UNDEFINED":"Indefinido"
+           },
+           "delete":{
+              "dialog":{
+                 "message":"Tem certeza de que deseja excluir o serviço de carimbo do tempo com a URL {url}?",
+                 "title":"Tem certeza?"
+              },
+              "success":"Serviço de carimbo do tempo excluído com sucesso"
+           },
+           "timestampingInterval":"Intervalo de carimbo do tempo",
+           "timestampingIntervalMinutes":"{min} minuto(s)",
+           "url":"URL"
+        }
+     },
+     "uploadCertificate":"Enviar o arquivo do certificado a partir do seu computador",
+     "validFrom":"Válido de",
+     "validTo":"Válido até",
+     "viewCertificate":"Visualizar Certificado",
+   },
+     "validation":{
+        "messages":{
+           "is":"O campo {field} deve ter o valor \"{other}\""
+        }
+     },
+     "validationError":{
+        "IdentifierChars":"O identificador da instância não deve conter dois-pontos (:), ponto e vírgula (;), barras (/ ou \\) ou sinais de porcentagem (%)",
+        "IdentifierCharsField":"Utilize apenas caracteres válidos no identificador",
+        "SizeField":"O valor não atende aos requisitos de comprimento"
+     }
   }
-}
+  

--- a/src/central-server/admin-service/ui/src/plugins/i18n.ts
+++ b/src/central-server/admin-service/ui/src/plugins/i18n.ts
@@ -25,18 +25,17 @@
  * THE SOFTWARE.
  */
 import { prepareI18n } from '@niis/shared-ui';
+import enMessages from '@/locales/en.json';
 
-export const availableLanguages = ['en', 'es', 'ru', 'tk'];
+export const availableLanguages = ['en', 'es', 'ru', 'tk', 'pt']; // adicionado suporte para pt (Português do Brasil)
+export const { i18n, languageHelper } = prepareI18n(enMessages, loadMessages);
 
-export const { i18n, languageHelper } = prepareI18n(loadMessages);
-
-// Fetches all language-specific messages for the given language
 async function loadMessages(language: string) {
   try {
     const module = await import(`@/locales/${language}.json`);
     return module.default;
   } catch {
-    console.warn("Failed to load translations for: " + language);
+    console.error("Failed to load translations for: " + language);
     return {};
   }
 }

--- a/src/security-server/admin-service/ui/src/locales/pt.json
+++ b/src/security-server/admin-service/ui/src/locales/pt.json
@@ -1,0 +1,1003 @@
+{
+  "403": {
+    "goBack": "Voltar",
+    "mainTitle": "Acesso negado",
+    "text": "Parece que você não tem permissão para acessar esta página. Verifique se está na conta correta ou entre em contato com o administrador.",
+    "topTitle": "Acesso negado"
+  },
+  "404": {
+    "pageNotFound": "404 - página não encontrada",
+    "text": "Ops! Essa página não existe.",
+    "textUnicorn": "Verifique o endereço ou volte a página inicial."
+  },
+  "accessRights": {
+    "addServiceClients": "Adicionar clientes",
+    "addServiceClientsSuccess": "Direitos de acesso adicionados com sucesso",
+    "addServiceClientsTitle": "Adicionar clientes",
+    "addSubjectsSuccess": "Direitos de acesso adicionados com sucesso",
+    "id": "ID",
+    "memberName": "Nome do Membro / Descrição do Grupo",
+    "removeAllText": "Você tem certeza de que deseja remover os direitos de acesso de todos os clientes?",
+    "removeAllTitle": "Remover todos os direitos de acesso?",
+    "removeSuccess": "Direitos de acesso removidos com sucesso",
+    "removeText": "Você tem certeza de que deseja remover os direitos de acesso deste cliente?",
+    "removeTitle": "Remover direitos de acesso?",
+    "rightsGiven": "Direitos de Acesso concedidos",
+    "title": "Direitos de Acesso"
+  },
+  "action": {
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "disable": "Desativar",
+    "enable": "Ativar",
+    "order": "Ordenar"
+  },
+  "alert": {
+    "warningCount": "Quantidade de avisos iguais"
+  },
+  "apiKey": {
+    "role": {
+      "XROAD_SECURITYSERVER_OBSERVER": "Observador do Servidor",
+      "XROAD_SERVICE_ADMINISTRATOR": "Administrador de Serviços"
+    }
+  },
+  "backup": {
+    "createBackup": {
+      "messages": {
+        "localConfWarning": "Aviso! O arquivo “/etc/xroad/services/local.conf” usado para sobrescrever configurações está obsoleto e não é mais incluído nos backups. Use o arquivo “/etc/xroad/services/local.properties” em vez disso."
+      }
+    }
+  },
+  "cert": {
+    "activateSuccess": "Certificado ativado",
+    "certDeleted": "Certificado excluído",
+    "deleteCertConfirm": "Tem certeza de que deseja excluir este certificado?",
+    "deleteCertTitle": "Excluir certificado?",
+    "disableSuccess": "Certificado desativado",
+    "disabled": "Desativado",
+    "expires": "Expira em",
+    "inUse": "Em uso",
+    "serialNumber": "Número de Série",
+    "signCertificate": "Assinar Certificado",
+    "state": "Estado"
+  },
+  "certificateProfile": {
+    "COMMON_NAME": "Nome Comum (CN)",
+    "COUNTRY_CODE": "Código do País (C)",
+    "INSTANCE_IDENTIFIER": "Identificador da Instância (C)",
+    "INSTANCE_IDENTIFIER_O": "Identificador da Instância (O)",
+    "MEMBER_CLASS": "Classe do Membro (O)",
+    "MEMBER_CLASS_BC": "Classe do Membro (BC)",
+    "MEMBER_CLASS_OU": "Classe do Membro (OU)",
+    "MEMBER_CODE": "Código do Membro (CN)",
+    "MEMBER_CODE_SN": "Código do Membro (SN)",
+    "ORGANIZATION_NAME": "Nome da Organização (O)",
+    "ORGANIZATION_NAME_CN": "Nome da Organização (CN)",
+    "SERIAL_NUMBER": "Número de Série",
+    "SERIAL_NUMBER_SN": "Número de Série (SN)",
+    "SERVER_CODE": "Código do Servidor (CN)",
+    "SERVER_DNS_NAME": "Nome DNS do Servidor (CN)",
+    "SUBJECT_ALTERNATIVE_NAME": "Nome Alternativo do  (SAN)"
+  },
+  "client": {
+    "action": {
+      "delete": {
+        "confirmText": "Você deseja excluir este cliente?",
+        "confirmTitle": "Excluir cliente",
+        "success": "Cliente excluído"
+      },
+      "makeOwner": {
+        "button": "Tornar Proprietário",
+        "confirmText1": "Você deseja tornar o membro abaixo o novo Membro Proprietário deste Servidor Seguro?",
+        "confirmText2": "Ao pressionar o botão \"Tornar proprietário\" abaixo, uma solicitação de alteração de proprietário será enviada à autoridade gestora do X-Road.",
+        "confirmTitle": "Tornar Membro Proprietário",
+        "success": "Proprietário alterado"
+      },
+      "removeOrphans": {
+        "cancelButtonText": "Não",
+        "confirmText": "A chave de assinatura e o certificado associados ao cliente excluído não possuem usuários. Deseja excluir a chave e o certificado?",
+        "confirmTitle": "Exclusão de chave e certificado",
+        "success": "Certificado excluído"
+      },
+      "unregister": {
+        "confirmText": "Você deseja desregistrar este cliente?",
+        "confirmTitle": "Desregistrar cliente",
+        "success": "Cliente desregistrado"
+      },
+      "disable": {
+        "confirmText": "Você deseja desativar este cliente?",
+        "confirmTitle": "Desativar cliente",
+        "success": "Desativação do cliente em andamento"
+      },
+      "enable": {
+        "confirmText": "Você deseja ativar este cliente?",
+        "confirmTitle": "Ativar cliente",
+        "success": "Ativação do cliente em andamento"
+      }
+    },
+    "id": "ID",
+    "member": "Membro",
+    "memberClass": "Classe do Membro",
+    "memberCode": "Código do Membro",
+    "memberName": "Nome do Membro",
+    "name": "Nome",
+    "owner": "Proprietário",
+    "status": "Status",
+    "statusText": {
+      "deletionInProgress": "EXCLUSÃO EM ANDAMENTO",
+      "globalError": "ERRO GLOBAL",
+      "registered": "REGISTRADO",
+      "registrationInProgress": "REGISTRO EM ANDAMENTO",
+      "saved": "SALVO",
+      "disabled": "DESATIVADO",
+      "disablingInProgress": "DESATIVAÇÃO EM ANDAMENTO",
+      "enablingInProgress": "ATIVAÇÃO EM ANDAMENTO"
+    },
+    "subsystemCode": "Código do Subsistema",
+    "unknownMember": "membro desconhecido"
+  },
+  "clients": {
+    "action": {
+      "register": {
+        "confirm": {
+          "text": "Tem certeza de que deseja enviar uma solicitação de registro de cliente?",
+          "title": "Registrar cliente"
+        },
+        "success": "Solicitação de registro de cliente enviada com sucesso"
+      }
+    }
+  },
+  "csr": {
+    "addKey": "Adicionar chave",
+    "certificationService": "Serviço de Certificação",
+    "client": "Cliente",
+    "csrDetails": "Detalhes do CSR",
+    "csrFormat": "Formato do CSR",
+    "eabCredRequired": "A Autoridade Certificadora selecionada exige vinculação de conta externa para ACME, mas as credenciais estão ausentes na configuração.",
+    "failedFetchAcmeMetadata": "Falha ao buscar os metadados ACME para a Autoridade Certificadora selecionada, o que pode causar erros nas próximas etapas.",
+    "generateCsr": "Gerar CSR",
+    "helpCertificationService": "Autoridade Certificadora (CA) que emitirá o certificado.",
+    "helpClient": "Membro X-Road para o qual o certificado será emitido.",
+    "helpCsrFormat": "Formato do pedido de assinatura de certificado conforme os requisitos da CA.",
+    "helpUsage": "Política de uso do certificado: assinar mensagens ou autenticar o Servidor Seguro.",
+    "saveInfo": "Gere um novo CSR e salve-o em um local seguro.",
+    "usage": "Uso",
+    "orderAcmeCertificate": "Solicite um certificado do Servidor ACME com o CSR gerado e importe o certificado retornado para o token."
+  },
+  "customValidation": {
+    "invalidEndpoint": "O endpoint contém caracteres inválidos",
+    "invalidUrl": "A URL não é válida",
+    "invalidXrdIdentifier": "O identificador contém caracteres inválidos",
+    "requiredIf": "O campo {fieldName} é obrigatório"
+  },
+  "diagnostics": {
+    "addOnStatus": {
+      "messageLogDisabled": "Desativado pela configuração"
+    },
+    "globalConfiguration": {
+      "configurationStatus": {
+        "ERROR_CODE_CANNOT_DOWNLOAD_CONF": "Não foi possível baixar a configuração global. Verifique a conexão de rede.",
+        "ERROR_CODE_EXPIRED_CONF": "A configuração global baixada expirou.",
+        "ERROR_CODE_INTERNAL": "Ocorreu um erro interno.",
+        "ERROR_CODE_INVALID_SIGNATURE_VALUE": "Valor de assinatura inválido.",
+        "ERROR_CODE_MISSING_PRIVATE_PARAMS": "A configuração global baixada não contém parâmetros privados.",
+        "ERROR_CODE_UNINITIALIZED": "O cliente de configuração está inicializando.",
+        "SUCCESS": "Tudo certo",
+        "UNKNOWN": "Desconhecido"
+      },
+      "title": "Configuração global"
+    },
+    "javaVersion": {
+      "earliest": "Versão mínima suportada",
+      "latest": "Última versão suportada",
+      "notSupported": "A versão atual do Java não é suportada",
+      "ok": "Tudo certo",
+      "title": "Versão do Java",
+      "vendor": "Nome do fornecedor"
+    },
+    "mailNotificationConfiguration": {
+      "title": "Status das notificações por e-mail",
+      "help": {
+        "title": "Status de notificações por e-mail disponíveis",
+        "description": "Notificações por e-mail são enviadas automaticamente para os destinatários configurados nos seguintes eventos, dependendo da configuração: renovação do certificado de autenticação via ACME (sucesso/falha), renovação do certificado de assinatura via ACME (sucesso/falha) e registro do certificado de autenticação (sucesso). Ativar notificações por e-mail exige alterações na configuração do Servidor Seguro. Consulte o Guia do Usuário do Servidor Seguro para mais detalhes."
+      },
+      "failureEnabled": "Notificações de falha",
+      "successEnabled": "Notificações de sucesso",
+      "configuration": "Configuração do servidor de e-mail",
+      "recipientsEmails": "E-mails dos destinatários",
+      "enabled": {
+        "true": "Ativado",
+        "false": "Desativado"
+      },
+      "confStatus": {
+        "true": "Configurado",
+        "false": "Configuração incompleta"
+      }
+    },
+    "message": "Mensagem",
+    "nextUpdate": "Próxima atualização",
+    "ocspResponders": {
+      "certificationService": "Serviço de Certificação:",
+      "ocspStatus": {
+        "ERROR_CODE_OCSP_CONNECTION_ERROR": "Não foi possível conectar ao validador OCSP",
+        "ERROR_CODE_OCSP_FAILED": "Não foi possível obter a resposta do validador OCSP",
+        "ERROR_CODE_OCSP_RESPONSE_INVALID": "Não foi possível interpretar a resposta do OCSP",
+        "ERROR_CODE_OCSP_RESPONSE_UNVERIFIED": "Não foi possível verificar a resposta do OCSP",
+        "ERROR_CODE_OCSP_UNINITIALIZED": "Solicitação de status ainda não enviada",
+        "SUCCESS": "Tudo certo",
+        "UNKNOWN": "Desconhecido"
+      },
+      "title": "Validadores OCSP"
+    },
+    "previousUpdate": "Atualização anterior",
+    "serviceUrl": "URL do Serviço",
+    "status": "Status",
+    "timestamping": {
+      "timestampingStatus": {
+        "ERROR_CODE_INTERNAL": "Ocorreu um erro interno",
+        "ERROR_CODE_MALFORMED_TIMESTAMP_SERVER_URL": "URL do servidor de carimbo de tempo malformada. Verifique a URL.",
+        "ERROR_CODE_TIMESTAMP_REQUEST_TIMED_OUT": "Conexão expirou. Verifique a rede com o provedor da configuração global.",
+        "ERROR_CODE_TIMESTAMP_UNINITIALIZED": "Conexão ok, nenhuma solicitação de carimbo de tempo feita ainda",
+        "SUCCESS": "Tudo certo",
+        "UNKNOWN": "Desconhecido"
+      },
+      "title": "Carimbo de Tempo"
+    },
+    "encryption": {
+      "status": {
+        "false": "Desativada",
+        "true": "Ativada"
+      },
+      "statusTitle": "Status da criptografia:",
+      "backup": {
+        "title": "Criptografia de backup",
+        "configuredKeyId": "ID da Chave Configurada"
+      },
+      "messageLog": {
+        "archive": {
+          "title": "Criptografia do arquivo de logs de mensagens",
+          "groupingTitle": "Regra de agrupamento:",
+          "memberIdentifier": "Identificador do membro",
+          "keyId": "ID da chave",
+          "defaultKeyNote": "Este membro está configurado para usar a chave padrão de criptografia do servidor. Para maior segurança, considere definir uma chave específica."
+        },
+        "database": {
+          "title": "Criptografia do banco de dados de logs de mensagens"
+        }
+      }
+    }
+  },
+  "endpoints": {
+    "addEndpoint": "Adicionar Endpoint",
+    "all": "TODOS",
+    "deleteEndpointText": "Tem certeza de que deseja excluir este endpoint?",
+    "deleteSuccess": "Endpoint removido com sucesso",
+    "deleteTitle": "Excluir endpoint",
+    "details": "Detalhes do Endpoint",
+    "editSuccess": "Alterações no endpoint salvas com sucesso",
+    "endpointHelp1": "Os caminhos são relativos ao caminho base da API, por exemplo, '/pets'. O asterisco (*) pode ser usado como um caractere curinga.",
+    "endpointHelp2": "* = corresponde a um segmento de caminho.",
+    "endpointHelp3": "** = corresponde a zero ou mais segmentos, por exemplo, '/pets/**'.",
+    "endpointHelp4": "Parâmetros de caminho devem ser substituídos por um asterisco, por exemplo, '/pets/{id}/images' => '/pets/*/images'.",
+    "httpRequestMethod": "Método HTTP",
+    "path": "Caminho",
+    "saveNewEndpointSuccess": "Novo endpoint criado com sucesso"
+  },
+  "error_code": {
+    "accessright_not_found": "Direito de acesso não encontrado",
+    "acme": {
+      "eab_credentials_missing": "Credenciais de vinculação de conta externa ausentes, mas necessárias",
+      "eab_secret_length": "Comprimento do segredo base64 da vinculação de conta externa inválido",
+      "account_key_pair_error": "Erro ao obter o par de chaves para a conta do servidor ACME",
+      "account_keystore_password_missing": "Senha do keystore da conta ACME ausente no arquivo de configuração acme.yml",
+      "fetching_metadata_error": "Falha ao buscar metadados do servidor ACME. O servidor ACME pode estar inacessível",
+      "account_creation_failure": "Falha ao criar conta no servidor ACME. Se a vinculação de conta externa for necessária, verifique se as credenciais corretas estão configuradas no acme.yml",
+      "order_creation_failure": "Falha ao criar nova Ordem no servidor ACME",
+      "order_finalization_failure": "Falha ao finalizar a Ordem no servidor ACME",
+      "http_challenge_file_creation": "Falha ao criar o arquivo de desafio HTTP do ACME",
+      "http_challenge_file_deletion": "Falha ao excluir o arquivo de desafio HTTP do ACME",
+      "http_challenge_missing": "Atualmente o X-Road suporta apenas o desafio HTTP, mas ele está ausente das opções disponíveis no servidor ACME",
+      "challenge_trigger_failure": "Falha ao solicitar ao servidor ACME a validação do desafio",
+      "authorization_failure": "Falha na autorização. Geralmente está relacionada à falha na validação do desafio necessária para provar a propriedade do domínio",
+      "authorization_wait_failure": "Falha ao aguardar a conclusão da autorização",
+      "certificate_failure": "Falha ao obter o Certificado do servidor ACME",
+      "certificate_wait_failure": "Falha ao aguardar a criação do novo Certificado"
+    },
+    "action_not_possible": "Ação não é possível",
+    "additional_member_already_exists": "Membro adicional já existe",
+    "anchor_already_exists": "Âncora já existe",
+    "anchor_file_not_found": "Arquivo de âncora não encontrado",
+    "anchor_not_found": "Âncora não encontrada",
+    "anchor_upload_failed": "Falha ao enviar a âncora",
+    "auth_cert_not_supported": "Certificado de autenticação não suportado",
+    "base_endpoint_not_found": "Endpoint base não encontrado",
+    "ca_cert_status_processing_failure": "Falha ao processar o status do certificado da CA",
+    "cannot_delete_owner": "Não é possível excluir o proprietário",
+    "cannot_register_owner": "Não é possível registrar o proprietário",
+    "cannot_unregister_owner": "Não é possível desregistrar o proprietário",
+    "cert_wrong_usage": "Uso incorreto do certificado",
+    "certificate_already_exists": "Certificado já existe",
+    "certificate_authority_not_found": "Autoridade Certificadora não encontrada",
+    "certificate_id_not_found": "ID do Certificado não encontrado",
+    "certificate_not_found": "Certificado não encontrado",
+    "certificate_profile_instantiation_failure": "Falha ao instanciar o perfil do certificado",
+    "client_already_exists": "Cliente já existe",
+    "client_not_deleted": "Não foi possível excluir chaves, certificados e CSRs porque pertencem a um cliente existente",
+    "client_not_found": "Cliente não encontrado",
+    "conf_download_failed": "Falha no download da configuração",
+    "conf_verification": {
+      "anchor_not_for_external_source": "Âncora aponta para uma fonte de configuração interna. Apenas âncoras de fontes externas são suportadas como âncoras confiáveis.",
+      "missing_private_params": "Falha na importação da âncora de configuração: arquivo de âncora inválido",
+      "other": "Configuração da fonte falhou na verificação",
+      "outdated": "Configuração da fonte está desatualizada",
+      "signature_invalid": "A assinatura da configuração não pode ser verificada",
+      "unreachable": "A fonte de configuração não pode ser acessada, verifique a URL da fonte no arquivo de âncora enviado"
+    },
+    "core": {
+      "Server": {
+        "InternalError": "Erro interno",
+        "ServerProxy": {
+          "ServiceFailed": {
+            "HttpError": "Erro HTTP",
+            "SslAuthenticationFailed": "Falha na autenticação SSL"
+          },
+          "UnknownService": "Serviço desconhecido"
+        }
+      },
+      "Signer": {
+        "CertNotFound": "Certificado não encontrado",
+        "NetworkError": "O assinador não está acessível no momento.",
+        "KeyNotFound": "Chave não encontrada",
+        "TokenNotAvailable": "Token não disponível",
+        "TokenNotFound": "Token não encontrado",
+        "UnknownMember": "X-Road core - assinador: Membro desconhecido"
+      }
+    },
+    "csr_not_found": "CSR não encontrado",
+    "diagnostic_request_failed": "Solicitação de diagnóstico falhou",
+    "duplicate_accessright": "Direito de acesso duplicado",
+    "endpoint_already_exists": "Endpoint já existe",
+    "endpoint_not_found": "Endpoint não encontrado",
+    "global_conf_download_request_failed": "Falha na solicitação de download da configuração global",
+    "global_conf_outdated": "A configuração global está desatualizada",
+    "gpg_key_generation_failed": "Falha na geração do par de chaves GPG",
+    "gpg_key_generation_interrupted": "Geração do par de chaves GPG interrompida",
+    "identifier_not_found": "Identificador não encontrado",
+    "illegal_generated_endpoint_remove": "Remoção do endpoint gerado não é permitida",
+    "illegal_generated_endpoint_update": "Atualização do endpoint gerado não é permitida",
+    "import_internal_cert_failed": "Falha ao importar certificado interno",
+    "internal_anchor_upload_invalid_instance_id": "Âncora contém um ID de instância inválido",
+    "internal_error": "Erro interno. Consulte os logs do Servidor Seguro para mais detalhes.",
+    "internal_key_cert_interrupted": "Certificado de chave interna interrompido",
+    "invalid_cert": "Certificado inválido",
+    "invalid_characters_pin": "O PIN contém caracteres inválidos",
+    "invalid_dn_parameter": "Parâmetro DN inválido",
+    "invalid_https_url": "A URL não utiliza HTTPS",
+    "invalid_init_params": "Parâmetros de inicialização inválidos",
+    "invalid_instance_identifier": "Identificador de instância inválido",
+    "invalid_member_class": "Classe de membro inválida",
+    "invalid_service_client_id": "ID de cliente de serviço inválido",
+    "invalid_service_url": "URL de serviço inválida",
+    "invalid_wsdl": "WSDL inválido",
+    "invalid_wsdl_service_identifier": "Identificador de serviço WSDL inválido",
+    "key_and_cert_generation_failed": "Falha na geração da chave e certificado",
+    "key_not_found": "Chave não encontrada",
+    "local_group_code_already_exists": "Código do grupo local já existe",
+    "local_group_member_already_exists": "Membro do grupo local já existe",
+    "local_group_member_not_found": "Membro do grupo local não encontrado",
+    "local_group_not_found": "Grupo local não encontrado",
+    "malformed_anchor": "Âncora malformada",
+    "malformed_url": "URL malformada",
+    "management_request_sending_failed": "Falha no envio da solicitação de gerenciamento",
+    "member_already_owner": "Membro já é o proprietário",
+    "member_class_exists": "Classe de membro já existe",
+    "member_class_not_provided": "Classe de membro não fornecida",
+    "member_code_exists": "Código de membro já existe",
+    "member_code_not_provided": "Código de membro não fornecido",
+    "missing_parameter": "Parâmetro ausente",
+    "openapi_parsing_error": "Falha ao analisar a descrição OpenApi3",
+    "orphans_not_found": "Chaves órfãs, certificados e/ou CSRs associados ao cliente não foram encontrados",
+    "pin_code_exists": "Código PIN já existe",
+    "pin_code_not_provided": "Código PIN não fornecido",
+    "pin_incorrect": "PIN incorreto. Por favor, tente novamente.",
+    "pin_min_char_classes_count": "Contagem mínima de classes de caracteres no PIN",
+    "pin_min_length": "Comprimento mínimo do PIN",
+    "process_failed": "Processo falhou",
+    "process_not_executable": "Processo não é executável",
+    "server_already_fully_initialized": "O servidor já está totalmente inicializado",
+    "server_code_exists": "Código do servidor já existe",
+    "server_code_not_provided": "Código do servidor não fornecido",
+    "service_already_exists": "Serviço já existe",
+    "service_client_not_found": "Cliente de serviço não encontrado",
+    "service_code_already_exists": "Código de serviço já existe",
+    "service_description_not_found": "Descrição do serviço não encontrada",
+    "service_not_found": "Serviço não encontrado",
+    "sign_cert_not_supported": "Certificado de assinatura não suportado",
+    "software_token_init_failed": "Falha na inicialização do token de software",
+    "timestamping_service_already_configured": "Serviço de carimbo de tempo já configurado",
+    "timestamping_service_not_found": "Serviço de carimbo de tempo não encontrado",
+    "token": {
+      "malformed_csr": "Os dados do CSR estão malformados"
+    },
+    "token_not_active": "Token não está ativo",
+    "unsupported_openapi_version": "Versão OpenAPI não suportada. Apenas as versões 3.0.x e 3.1.0 são suportadas atualmente.",
+    "url_already_exists": "URL já existe",
+    "warnings_detected": "Avisos detectados",
+    "weak_pin": "PIN fraco",
+    "wrong_key_usage": "Uso incorreto da chave",
+    "wrong_servicedescription_type": "Tipo de descrição de serviço incorreto",
+    "wsdl_download_failed": "Falha no download do WSDL",
+    "wsdl_exists": "WSDL já existe",
+    "wsdl_validator_interrupted": "Validador WSDL interrompido",
+    "wsdl_validator_not_executable": "Validador WSDL não é executável"
+  },
+  "fields": {
+    "addClient": {
+      "memberClass": "Classe do Membro",
+      "memberCode": "Código do Membro",
+      "subsystemCode": "Código do Subsistema"
+    },
+    "C": "Código do País",
+    "clientAdd": {
+      "client": {
+        "memberCode": "Código do Membro",
+        "subsystemCode": "Código do Subsistema"
+      }
+    },
+    "CN": "Nome DNS do Servidor",
+    "confirmPin": "Confirmar PIN",
+    "csr": {
+      "certService": "Serviço de Certificação",
+      "client": "Cliente",
+      "csrFormat": "Formato do CSR",
+      "usage": "Uso",
+      "certificationService": "Serviço de Certificação"
+    },
+    "dns": "DNS",
+    "keys": {
+      "name": "Nome"
+    },
+    "O": "Nome da Organização",
+    "path": "Caminho",
+    "pin": "PIN",
+    "memberCode": "Código do Membro",
+    "securityServerAddress": "Endereço do Servidor Seguro",
+    "serialNumber": "Número de Série",
+    "serviceCode": "Código do Serviço",
+    "serviceDescriptionAdd": {
+      "restServiceCode": "Código do Serviço"
+    },
+    "serviceDescriptionUpdate": {
+      "newRestServiceCode": "Código do Serviço"
+    },
+    "serviceTimeout": "Tempo limite",
+    "serviceType": "Tipo de Serviço",
+    "serviceUrl": "URL",
+    "subjectAltName": "Nome Alternativo",
+    "token": {
+      "friendlyName": "Nome amigável",
+      "newPin": "Novo PIN",
+      "newPinConfirm": "Confirmar novo PIN",
+      "oldPin": "PIN antigo"
+    },
+    "tokenPin": "PIN do Token",
+    "url": "URL",
+    "username": "Nome de Usuário",
+    "certificationService": "Serviço de Certificação"
+  },
+  "global": {
+    "appTitle": "X-Road Servidor Seguro"
+  },
+  "general": {
+    "instance": "Instância",
+    "memberClass": "Classe do Membro",
+    "memberCode": "Código do Membro",
+    "name": "Nome",
+    "subsystem": "Subsistema",
+    "subsystemCode": "Código do Subsistema",
+    "type": "Tipo"
+  },
+  "globalAlert": {
+    "backupRestoreInProgress": "A configuração do Servidor Seguro está sendo restaurada a partir de um backup. Processo iniciado em {startTime}",
+    "globalConfigurationInvalid": "A configuração global está expirada",
+    "secondaryNode": "Você está em um nó secundário de um cluster do Servidor Seguro. Modificar a configuração está desativado.",
+    "softTokenPinNotEntered": "Por favor, insira o PIN do token de software",
+    "certificateRenewalJobFailure": "A última renovação de certificado falhou.",
+    "certificateRenewalJobFailureAuth": "Certificado(s) de autenticação com falha:",
+    "certificateRenewalJobFailureSign": "Certificado(s) de assinatura com falha:",
+    "navigateToKeysPage": "Veja a página de chaves e certificados para mais detalhes"
+  },
+  "initialConfiguration": {
+    "anchor": {
+      "generated": "Gerado",
+      "hash": "Hash (SHA-224)",
+      "info": "Importe a âncora de configuração fornecida pelo administrador do Servidor Central.",
+      "title": "Âncora de Configuração"
+    },
+    "member": {
+      "info": "Defina o membro que será o proprietário do Servidor Seguro:",
+      "serverCodeHelp": "Código do Servidor Seguro que identifica este servidor de forma única entre todos os servidores do mesmo proprietário.",
+      "title": "Membro Proprietário"
+    },
+    "noInitializationStatus": "Nenhum status de inicialização disponível",
+    "noPermission": "Este Servidor Seguro ainda não foi inicializado, entre em contato com um administrador para realizar a configuração inicial.",
+    "pin": {
+      "confirmPin": "Confirmar PIN",
+      "info1": "O token de software é onde as chaves AUTH do Servidor Seguro são armazenadas. Defina um PIN para acessar o token de software.",
+      "info2": "Todas as informações necessárias foram coletadas, pressione o botão Enviar para inicializar o Servidor Seguro.",
+      "info3": "Após a inicialização, conclua a configuração do Servidor Seguro clicando no botão Configurar na notificação que aparecerá em breve.",
+      "pin": "PIN",
+      "pinMatchError": "A confirmação do PIN não corresponde",
+      "title": "PIN do Token"
+    },
+    "success": "Servidor inicializado",
+    "title": "Configuração Inicial",
+    "warning": {
+      "init_server_id_exists": "ID do servidor já existe",
+      "init_server_owner_exists": "Proprietário do servidor já existe",
+      "init_servercode_exists": "Código do servidor já existe",
+      "init_software_token_initialized": "Token de software já inicializado",
+      "init_unregistered_member": "Membro não registrado"
+    }
+  },
+  "internalServers": {
+    "certHash": "Hash do Certificado",
+    "connTypeUpdated": "Tipo de conexão atualizado",
+    "connectionInfo": "O tipo de conexão para servidores no papel de provedor de serviço é definido na aba Serviços pela URL do serviço (http/https).",
+    "connectionType": "Tipo de conexão",
+    "ssCertTitle": "Certificado do Servidor Seguro",
+    "tlsTitle": "Certificado TLS do Sistema de Informação"
+  },
+  "certificate": {
+    "hash": "Hash do Certificado",
+    "subjectDistinguishedName": "Titular do Certificado (DN)",
+    "notBefore": "Não Antes de",
+    "notAfter": "Não Depois de"
+  },
+  "keys": {
+    "addKey": "Adicionar chave",
+    "authDetailsTitle": "Detalhes da Chave AUTH",
+    "authKeyCert": "Chaves e Certificados AUTH",
+    "authNotSupported": "Chave AUTH não suportada",
+    "auth_key_with_registered_cert_warning": "A chave possui certificados que precisam ser desregistrados antes da exclusão. Deseja continuar com o desregistro e a exclusão dos certificados associados e da chave da configuração do servidor? ID da Chave:",
+    "certMarkedForDeletion": "Certificado marcado para exclusão",
+    "certRegistrationInfo": "Nome DNS ou endereço IP do Servidor Seguro",
+    "certStatus": {
+      "deletion": "Exclusão em andamento",
+      "globalError": "Erro global",
+      "onlyInHWToken": "Somente no token",
+      "registered": "Registrado",
+      "registration": "Registro em andamento",
+      "saved": "Salvo"
+    },
+    "certificateRegistered": "Solicitação de registro do certificado enviada com sucesso",
+    "certificateUnregistered": "Solicitação de desregistro do certificado enviada com sucesso",
+    "csrDeleted": "CSR excluído",
+    "deleteCsr": "Excluir CSR",
+    "deleteCsrText": "Tem certeza de que deseja excluir este CSR?",
+    "deleteCsrTitle": "Excluir CSR?",
+    "deleteKeyText": "Tem certeza de que deseja excluir esta chave e todos os certificados associados da configuração do servidor?",
+    "deleteTitle": "Excluir chave?",
+    "detailsTitle": "Detalhes da Chave",
+    "expires": "Expira em",
+    "friendlyName": "Nome amigável",
+    "generateCsr": "Gerar CSR",
+    "globalErrors": "Erros globais",
+    "gotIt": "Entendido",
+    "helpTextApi": "As chaves API são usadas para autenticar chamadas de API na REST API de gerenciamento do Servidor Seguro. As chaves API estão associadas a funções que definem as permissões concedidas.",
+    "helpTextKeys": "A chave e o certificado de autenticação certificam a autenticidade de um Servidor Seguro. Eles são usados para autenticação em conexões entre Servidores de Seguros. A chave e o certificado de assinatura certificam a autenticidade de um membro do X-Road. Eles são usados para assinar e verificar a integridade de mensagens mediadas.",
+    "helpTextSS": "O certificado TLS do Servidor Seguro é usado em conexões entre o Servidor Seguro e um sistema de informação. O certificado TLS interno é usado tanto como cliente quanto como servidor, dependendo dos papéis de cada um.",
+    "helpTitleApi": "Chaves API",
+    "helpTitleKeys": "Chaves AUTH e SIGN",
+    "helpTitleSS": "Certificado TLS do Servidor Seguro",
+    "id": "ID",
+    "importCert": "Importar cert.",
+    "importCertSuccess": "Upload do certificado realizado com sucesso",
+    "incorrectPin": "PIN incorreto. Por favor, tente novamente.",
+    "keyDeleted": "Chave excluída",
+    "keyId": "ID da Chave:",
+    "keyInfo": "Informações da Chave",
+    "keyLabelInput": "Etiqueta da Chave",
+    "keySaved": "Chave salva",
+    "label": "Etiqueta:",
+    "logIn": "Entrar",
+    "logOut": "Sair",
+    "logOutText": "Sair do token?",
+    "logOutTitle": "Sair",
+    "loggedIn": "Token conectado",
+    "loggedOut": "Token desconectado",
+    "noIssues": "Sem problemas",
+    "ocsp": "OCSP",
+    "ocspStatus": {
+      "disabled": "Desativado",
+      "expired": "Expirado",
+      "good": "Válido",
+      "revoked": "Revogado",
+      "suspended": "Suspenso",
+      "unknown": "Desconhecido"
+    },
+    "orderAcmeCertificate": "Solicitar Certificado",
+    "acmeCertOrdered": "Certificado solicitado com sucesso",
+    "readOnly": "Somente leitura:",
+    "keyAlgorithm": "Algoritmo da Chave:",
+    "registrationRequest": "Solicitação de registro",
+    "renewal": "Renovação Automática",
+    "request": "Solicitação",
+    "signDetailsTitle": "Detalhes da Chave SIGN",
+    "signKeyCert": "Chaves e Certificados SIGN",
+    "status": "Status",
+    "token": "Token:",
+    "tokenDetails": "Detalhes do Token",
+    "tokenId": "ID do Token:",
+    "tokenInfo": "Informações do Token",
+    "tokenPin": "PIN do Token",
+    "tokenSaved": "Token salvo",
+    "tokenStatus": {
+      "active": "Ativo",
+      "available": "Disponível",
+      "inactive": "Inativo",
+      "unavailable": "Bloqueado",
+      "unsaved": "Não salvo"
+    },
+    "type": "Tipo:",
+    "unknown": "Tipo de chave não especificado",
+    "unregisterError": "Falha ao desregistrar o certificado. Continuar com a exclusão do certificado mesmo assim?",
+    "unregisterText": "Deseja desregistrar este certificado?",
+    "unregisterTitle": "Desregistrar certificado"
+  },
+  "localGroup": {
+    "accessDate": "Direitos de Acesso Concedidos",
+    "addLocalGroup": "Adicionar Grupo Local",
+    "addMembers": "Adicionar Membros",
+    "addSelected": "Adicionar selecionados",
+    "code": "Código",
+    "deleteText": "Tem certeza de que deseja excluir este grupo?",
+    "deleteTitle": "Excluir grupo?",
+    "descSaved": "Descrição salva",
+    "description": "Descrição",
+    "groupDeleted": "Grupo excluído",
+    "groupMembers": "Membros do Grupo",
+    "id": "ID",
+    "localGroup": "Grupo Local",
+    "localGroupAdded": "Grupo local adicionado",
+    "name": "Nome do Membro",
+    "noResults": "Sua busca não encontrou resultados.",
+    "removeAllText": "Tem certeza de que deseja remover todos os membros deste grupo?",
+    "removeAllTitle": "Remover todos os membros?",
+    "removeText": "Tem certeza de que deseja remover este membro?",
+    "removeTitle": "Remover membro?",
+    "searchOptions": "Opções de busca"
+  },
+  "localGroups": {
+    "addGroup": "Adicionar grupo",
+    "code": "Código",
+    "description": "Descrição",
+    "memberCount": "Quantidade de Membros",
+    "updated": "Atualizado"
+  },
+  "noData": {
+    "noBackUpEncryptionKeys": "Nenhuma chave de criptografia de backup configurada",
+    "noClientData": "Nenhum dado de cliente",
+    "noCertificateAuthorities": "Nenhuma autoridade certificadora",
+    "noLocalGroups": "Nenhum grupo local",
+    "noServiceClients": "Nenhum cliente de serviço",
+    "noTimestampingServices": "Nenhum serviço de carimbo de tempo"
+  },
+  "serviceClientType": {
+    "globalGroup": "GRUPO GLOBAL",
+    "localGroup": "GRUPO LOCAL",
+    "subsystem": "SUBSISTEMA"
+  },
+  "serviceClients": {
+    "accessRights": "Direitos de acesso",
+    "accessRightsGiven": "Direitos de Acesso Concedidos",
+    "addSelected": "Adicionar selecionados",
+    "addService": "Adicionar serviço",
+    "addServiceClient": "Adicionar cliente de serviço",
+    "addServiceClientAccessRightSuccess": "Direitos de acesso adicionados com sucesso",
+    "addServiceClientTitle": "Adicionar cliente de serviço",
+    "id": "ID",
+    "memberGroupCodeLabel": "Código do Membro/Grupo",
+    "memberGroupStep": "Membro / Grupo",
+    "name": "Nome do Membro / Descrição do Grupo",
+    "noAccessRights": "Sem direitos de acesso para este cliente",
+    "noAvailableServices": "Nenhum serviço disponível",
+    "removeAll": "Remover todos",
+    "removeAllText": "Tem certeza de que deseja remover todos os direitos de acesso deste cliente de serviço?",
+    "removeAllTitle": "Remover todos os direitos de acesso?",
+    "removeOneText": "Tem certeza de que deseja remover os direitos de acesso deste cliente de serviço?",
+    "removeOneTitle": "Remover direitos de acesso?",
+    "searchPlaceHolder": "Clientes de serviço",
+    "serviceCode": "Código do Serviço",
+    "serviceSelectionStep": "Código do Serviço",
+    "servicesStep": "Serviços",
+    "title": "Título"
+  },
+  "services": {
+    "OpenApi3Description": "Descrição OpenAPI 3",
+    "addRest": "Adicionar REST",
+    "addWsdl": "Adicionar WSDL",
+    "applyToAll": "Aplicar a todos no WSDL",
+    "deleteRestText": "Tem certeza de que deseja excluir este Serviço REST?",
+    "deleteTitle": "Excluir descrição do serviço?",
+    "deleteWsdlText": "Tem certeza de que deseja excluir este WSDL?",
+    "deleted": "Descrição do serviço excluída",
+    "disableNotice": "Aviso de desativação",
+    "disableSuccess": "Descrição do serviço desativada",
+    "disableTitle": "Desativar?",
+    "editUrl": "Editar URL",
+    "enableSuccess": "Descrição do serviço ativada",
+    "idGroupCode": "ID / Código do Grupo",
+    "lastRefreshed": "Última atualização: ",
+    "memberNameGroupDesc": "Nome do Membro / Descrição do Grupo",
+    "noMatches": "Nenhum registro correspondente",
+    "openApi3Added": "Serviço OpenAPI 3 adicionado",
+    "openapiDetails": "Detalhes do OpenAPI 3",
+    "refreshed": "Atualizado",
+    "restAdded": "Serviço REST adicionado",
+    "restApiBasePath": "Caminho Base da API REST",
+    "restDetails": "Detalhes do REST",
+    "service": "Serviço",
+    "serviceCode": "Código do Serviço",
+    "serviceCodePlaceholder": "Insira o código do serviço",
+    "serviceSaved": "Serviço salvo",
+    "serviceType": "Tipo de URL",
+    "serviceUrl": "URL do Serviço",
+    "service_parameters_ssl_test_warnings": {
+      "internal_server_ssl_error": "Falha ao verificar os certificados do servidor interno. A URL do servidor upstream está correta e acessível pelo Servidor Seguro?",
+      "internal_server_ssl_handshake_error": "Falha no handshake TLS com o servidor upstream, certificado do servidor ausente na configuração:"
+    },
+    "timeout": "Tempo limite",
+    "timeoutSec": "Tempo limite (s)",
+    "timeoutTooltip": "A duração máxima de uma solicitação ao serviço, em segundos",
+    "tlsTooltip": "Verifique o certificado TLS ao estabelecer uma conexão segura",
+    "url": "URL",
+    "urlPlaceholder": "Insira a URL",
+    "urlTooltip": "A URL para onde as solicitações direcionadas ao serviço são enviadas",
+    "warning": "Aviso",
+    "warningCode": {
+      "adding_endpoints": "Adicionando endpoints:",
+      "adding_services": "Adicionando serviços:",
+      "deleting_endpoints": "Excluindo endpoints:",
+      "deleting_services": "Excluindo serviços:",
+      "wsdl_validation_warnings": "Avisos de validação:",
+      "openapi_validation_warnings": "Avisos de validação:"
+    },
+    "verifyTls": "Verificar certificado TLS",
+    "wsdlAdded": "WSDL adicionado",
+    "wsdlDescription": "Descrição do WSDL",
+    "wsdlDetails": "Detalhes do WSDL"
+  },
+  "ssTlsCertificate": {
+    "certificateImported": "Certificado importado",
+    "exportCertificate": "Exportar cert.",
+    "generateCsr": "Gerar CSR",
+    "generateInternalCsr": {
+      "cancel": "CANCELAR",
+      "done": "CONCLUÍDO",
+      "step1": {
+        "description": "1) Primeiro, Forneça o Titular do Certificado (DN)",
+        "label": "Titular do Certificado (DN)",
+        "placeholder": "CN=meuservidordeseguranca.exemplo.com, O=Minha Organização, C=BR",
+        "tooltip": "O Titular do Certificado (DN) identifica de forma exclusiva uma entidade em um certificado X.509. Os seguintes tipos de atributos são comumente encontrados no DN: CN = Nome comum, O = Nome da organização, C = Código do país."
+      },
+      "step2": {
+        "description": "2) Gere um novo CSR e salve-o em um local seguro",
+        "generateCSR": "Gerar CSR"
+      },
+      "title": "Gerar Solicitação de Assinatura de Certificado TLS"
+    },
+    "generateKey": "Gerar chave",
+    "generateTlsAndCertificateDialog": {
+      "confirmation": "Gerar uma nova chave e certificado TLS do Servidor Seguro?",
+      "explanation": "O sistema gerará uma nova chave TLS do Servidor Seguro e um certificado autoassinado, substituindo a chave e o certificado existentes.",
+      "success": "Nova chave e certificado TLS do Servidor Seguro gerados com sucesso",
+      "title": "Chave TLS do Servidor Seguro"
+    },
+    "importCertificate": "Importar cert.",
+    "keyCertTitle": "Chave e Certificado TLS",
+    "keyText": "Chave TLS Interna"
+  },
+  "stores": {
+    "user": {
+      "currentSecurityServerNotFound": "Falha ao determinar as informações do Servidor Seguro atual. A resposta da API é inválida."
+    }
+  },
+  "systemParameters": {
+    "approvedCertificateAuthorities": {
+      "table": {
+        "header": {
+          "distinguishedName": "Titular do Certificado (DN)",
+          "expires": "Expira em",
+          "ocspResponse": "Resposta OCSP",
+          "acmeIpAddresses": "IP do Servidor ACME"
+        },
+        "notAvailable": "N/D",
+        "ocspResponse": {
+          "NOT_AVAILABLE": "N/D",
+          "OCSP_RESPONSE_GOOD": "Válido",
+          "OCSP_RESPONSE_REVOKED": "Revogado",
+          "OCSP_RESPONSE_SUSPENDED": "Suspenso",
+          "OCSP_RESPONSE_UNKNOWN": "Desconhecido"
+        }
+      },
+      "title": "Autoridades Certificadoras Aprovadas"
+    },
+    "configurationAnchor": {
+      "action": {
+        "download": "Baixar",
+        "upload": {
+          "button": "Carregar",
+          "dialog": {
+            "confirmation": "Continuar com a importação?",
+            "field": {
+              "generated": "Gerado",
+              "hash": "Hash (SHA-224)"
+            },
+            "info": "Detalhes da âncora de configuração:",
+            "success": "Âncora de configuração carregada",
+            "title": "Confirmar detalhes da âncora de configuração"
+          }
+        }
+      },
+      "table": {
+        "header": {
+          "distinguishedName": "Hash (SHA-224)",
+          "generated": "Gerado"
+        }
+      },
+      "title": "Âncora de Configuração"
+    },
+    "timestampingServices": {
+      "action": {
+        "add": {
+          "button": "Adicionar",
+          "dialog": {
+            "info": "Serviços de Timestamp confiáveis:",
+            "success": "Serviço de Timestamp adicionado",
+            "title": "Adicionar Serviço de Timestamp"
+          }
+        }
+      },
+      "table": {
+        "action": {
+          "delete": {
+            "button": "Excluir",
+            "confirmation": {
+              "text": "Tem certeza de que deseja excluir o serviço de carimbo de tempo?",
+              "title": "Tem certeza?"
+            },
+            "success": "Serviço de carimbo de tempo excluído com sucesso"
+          }
+        },
+        "header": {
+          "serviceURL": "URL do Serviço",
+          "timestampingService": "Serviço de carimbo de tempo"
+        }
+      },
+      "title": "Serviços de carimbo de tempo"
+    },
+    "securityServer": {
+      "securityServer": "Servidor Seguro",
+      "serverAddress": "Endereço do Servidor",
+      "editDialog": {
+        "title": "Editar endereço do Servidor Seguro"
+      },
+      "addressChangeInProgress": "ALTERAÇÃO EM ANDAMENTO",
+      "updateSubmitted": "Alteração de endereço do Servidor Seguro enviada com sucesso"
+    },
+    "title": "Parâmetros do sistema"
+  },
+  "tab": {
+    "client": {
+      "details": "Detalhes",
+      "internalServers": "Servidores internos",
+      "localGroups": "Grupos locais",
+      "serviceClients": "Clientes de serviço",
+      "services": "Serviços"
+    },
+    "keys": {
+      "apiKey": "Chaves API",
+      "signAndAuthKeys": "Chaves SIGN e AUTH",
+      "ssTlsCertificate": "Chave TLS do Servidor Seguro"
+    },
+    "main": {
+      "clients": "Clientes",
+      "diagnostics": "Diagnósticos",
+      "keys": "Chaves e certificados",
+      "settings": "Configurações"
+    },
+    "services": {
+      "endpoints": "Endpoints",
+      "parameters": "Parâmetros do Serviço"
+    },
+    "settings": {
+      "backupAndRestore": "Backup e Restauração",
+      "systemParameters": "Parâmetros do Sistema"
+    }
+  },
+  "token": {
+    "changePin": "Alterar PIN",
+    "pinChanged": "PIN do token alterado – faça login no token com o novo PIN",
+    "tokenPinPolicyHeader": "A política de PIN do Token está ativada.",
+    "tokenPinPolicy": "O PIN do token de software deve conter pelo menos 10 caracteres ASCII de, no mínimo, três classes de caracteres (letras minúsculas, letras maiúsculas, dígitos, caracteres especiais)."
+  },
+  "toolbar": {
+    "securityServerNodeType": {
+      "undefined": "",
+      "PRIMARY": "Nó primário",
+      "SECONDARY": "Nó secundário"
+    }
+  },
+  "validationError": {
+    "IdentifierChars": "Caracteres inválidos no identificador"
+  },
+  "wizard": {
+    "addClientTitle": "Adicionar cliente",
+    "addMemberTitle": "Adicionar membro",
+    "addSubsystemTitle": "Adicionar subsistema",
+    "client": {
+      "addClient": "Adicionar Cliente",
+      "clientExists": "Cliente já existe",
+      "memberClassTooltip": "Código que identifica a classe do membro (ex.: agência governamental, empresa privada etc.).",
+      "memberCodeTooltip": "Código do membro que identifica exclusivamente este membro do X-Road dentro de sua classe (ex.: ID comercial).",
+      "memberNameTooltip": "Nome da organização do membro.",
+      "register": "Registrar cliente",
+      "searchLabel": "Cliente",
+      "subsystemCodeTooltip": "Código do subsistema que identifica um sistema de informação pertencente ao membro."
+    },
+    "clientDetails": "Detalhes do Cliente",
+    "clientInfo1": "Especifique os detalhes do Cliente que deseja adicionar.",
+    "clientInfo2": "Se o Cliente já existir, você pode selecioná-lo na lista Global.",
+    "finish": {
+      "acme": {
+        "infoLine": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes, e a nova chave e certificado aparecerão na visualização de Chaves e Certificados. O certificado será solicitado ao Servidor ACME da AC e importado automaticamente. Depois disso, você poderá registrar o novo cliente."
+      },
+      "infoLine1": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes, e a nova chave e CSR aparecerão na visualização de Chaves e Certificados.",
+      "infoLine2": "Para registrar o novo cliente, conclua os seguintes passos:",
+      "note": "NOTA: se você clicar em Cancelar, todos os dados serão perdidos",
+      "title": "Concluir",
+      "todo1": "1) Envie o CSR para uma Autoridade Certificadora para assinatura",
+      "todo2": "2) Após receber de volta, importe o certificado resultante para a chave correspondente",
+      "todo3": "3) Neste ponto, você pode registrar o novo cliente"
+    },
+    "member": {
+      "info1": "Especifique os detalhes do Membro que deseja adicionar.",
+      "info2": "Se o Membro já existir, você pode selecioná-lo na lista Global.",
+      "memberExists": "Membro já existe",
+      "register": "Registrar membro",
+      "searchLabel": "Membro",
+      "select": "Selecionar membro",
+      "title": "Detalhes do Membro"
+    },
+    "memberClass": "Classe do Membro",
+    "memberCode": "Código do Membro",
+    "memberName": "Nome do Membro",
+    "selectClient": "Selecionar Cliente",
+    "selectMemberClass": "Selecionar Classe do Membro",
+    "signKey": {
+      "info": "Você pode definir um Descrição para a nova chave SIGN criada (opcional)",
+      "keyLabel": "Descrição da Chave",
+      "title": "Chave SIGN"
+    },
+    "subsystem": {
+      "info1": "Especifique o código do subsistema a ser adicionado.",
+      "info2": "Se o subsistema já existir, você pode selecioná-lo na lista Global.",
+      "registerSubsystem": "Registrar subsistema",
+      "searchLabel": "Subsistema",
+      "selectSubsystem": "Selecionar Subsistema",
+      "subsystemAdded": "Subsistema adicionado",
+      "subsystemExists": "Subsistema já existe"
+    },
+    "subsystemCode": "Código do Subsistema",
+    "token": {
+      "info": "Selecione o token onde deseja adicionar a chave SIGN para o novo Cliente. Nota: o token deve estar no estado Conectado.",
+      "loggedIn": "Conectado",
+      "title": "Token",
+      "tokenName": "Nome do Token"
+    },
+    "warning": {
+      "unregistered_member": "Membro não registrado"
+    }
+  }
+}

--- a/src/security-server/admin-service/ui/src/locales/pt.json
+++ b/src/security-server/admin-service/ui/src/locales/pt.json
@@ -1,9 +1,9 @@
 {
   "403": {
     "goBack": "Voltar",
-    "mainTitle": "Acesso negado",
-    "text": "Parece que você não tem permissão para acessar esta página. Verifique se está na conta correta ou entre em contato com o administrador.",
-    "topTitle": "Acesso negado"
+    "mainTitle": "Permissão negada",
+    "text": "Parece que você não tem permissão para visualizar esta página. Se você acha que isso é um engano, verifique se está conectado à conta correta ou entre em contato com o administrador para revisar suas permissões.",
+    "topTitle": "Acesso proibido"
   },
   "404": {
     "pageNotFound": "404 - página não encontrada",
@@ -17,23 +17,21 @@
     "addSubjectsSuccess": "Direitos de acesso adicionados com sucesso",
     "id": "ID",
     "memberName": "Nome do Membro / Descrição do Grupo",
-    "removeAllText": "Você tem certeza de que deseja remover os direitos de acesso de todos os clientes?",
+    "removeAllText": "Tem certeza de que deseja remover os direitos de acesso de todos os clientes?",
     "removeAllTitle": "Remover todos os direitos de acesso?",
     "removeSuccess": "Direitos de acesso removidos com sucesso",
-    "removeText": "Você tem certeza de que deseja remover os direitos de acesso deste cliente?",
+    "removeText": "Tem certeza de que deseja remover os direitos de acesso deste cliente?",
     "removeTitle": "Remover direitos de acesso?",
-    "rightsGiven": "Direitos de Acesso concedidos",
+    "rightsGiven": "Direitos de Acesso Concedidos",
     "title": "Direitos de Acesso"
   },
   "action": {
-    "cancel": "Cancelar",
-    "delete": "Excluir",
     "disable": "Desativar",
     "enable": "Ativar",
     "order": "Ordenar"
   },
   "alert": {
-    "warningCount": "Quantidade de avisos iguais"
+    "warningCount": "Quantidade de alertas iguais"
   },
   "apiKey": {
     "role": {
@@ -44,22 +42,28 @@
   "backup": {
     "createBackup": {
       "messages": {
-        "localConfWarning": "Aviso! O arquivo “/etc/xroad/services/local.conf” usado para sobrescrever configurações está obsoleto e não é mais incluído nos backups. Use o arquivo “/etc/xroad/services/local.properties” em vez disso."
+        "localConfWarning": "Atenção! O arquivo “/etc/xroad/services/local.conf” usado para sobreposição de configurações está obsoleto e não será incluído nos backups. Utilize o arquivo “/etc/xroad/services/local.properties”."
       }
     }
   },
   "cert": {
-    "activateSuccess": "Certificado ativado",
+    "activateSuccess": "Certificado ativado com sucesso",
     "certDeleted": "Certificado excluído",
     "deleteCertConfirm": "Tem certeza de que deseja excluir este certificado?",
     "deleteCertTitle": "Excluir certificado?",
-    "disableSuccess": "Certificado desativado",
-    "disabled": "Desativado",
+    "disableSuccess": "Certificado desativado com sucesso",
+    "disabled": "desativado",
     "expires": "Expira em",
-    "inUse": "Em uso",
+    "inUse": "em uso",
     "serialNumber": "Número de Série",
     "signCertificate": "Assinar Certificado",
     "state": "Estado"
+  },
+  "certificate": {
+    "hash": "Hash do Certificado",
+    "notAfter": "Válido até",
+    "notBefore": "Válido de",
+    "subjectDistinguishedName": "Titular do Certificado (DN)"
   },
   "certificateProfile": {
     "COMMON_NAME": "Nome Comum (CN)",
@@ -77,44 +81,50 @@
     "SERIAL_NUMBER_SN": "Número de Série (SN)",
     "SERVER_CODE": "Código do Servidor (CN)",
     "SERVER_DNS_NAME": "Nome DNS do Servidor (CN)",
-    "SUBJECT_ALTERNATIVE_NAME": "Nome Alternativo do  (SAN)"
+    "SUBJECT_ALTERNATIVE_NAME": "Nome Alternativo do Titular (SAN)"
   },
   "client": {
     "action": {
       "delete": {
-        "confirmText": "Você deseja excluir este cliente?",
+        "confirmText": "Deseja excluir este cliente?",
         "confirmTitle": "Excluir cliente",
         "success": "Cliente excluído"
       },
-      "makeOwner": {
-        "button": "Tornar Proprietário",
-        "confirmText1": "Você deseja tornar o membro abaixo o novo Membro Proprietário deste Servidor Seguro?",
-        "confirmText2": "Ao pressionar o botão \"Tornar proprietário\" abaixo, uma solicitação de alteração de proprietário será enviada à autoridade gestora do X-Road.",
-        "confirmTitle": "Tornar Membro Proprietário",
-        "success": "Proprietário alterado"
-      },
-      "removeOrphans": {
-        "cancelButtonText": "Não",
-        "confirmText": "A chave de assinatura e o certificado associados ao cliente excluído não possuem usuários. Deseja excluir a chave e o certificado?",
-        "confirmTitle": "Exclusão de chave e certificado",
-        "success": "Certificado excluído"
-      },
-      "unregister": {
-        "confirmText": "Você deseja desregistrar este cliente?",
-        "confirmTitle": "Desregistrar cliente",
-        "success": "Cliente desregistrado"
-      },
       "disable": {
-        "confirmText": "Você deseja desativar este cliente?",
+        "confirmText": "Deseja desativar este cliente?",
         "confirmTitle": "Desativar cliente",
         "success": "Desativação do cliente em andamento"
       },
       "enable": {
-        "confirmText": "Você deseja ativar este cliente?",
+        "confirmText": "Deseja ativar este cliente?",
         "confirmTitle": "Ativar cliente",
         "success": "Ativação do cliente em andamento"
+      },
+      "makeOwner": {
+        "button": "Tornar proprietário",
+        "confirmText1": "Deseja tornar o membro abaixo o novo proprietário deste Servidor de Segurança?",
+        "confirmText2": "Ao clicar no botão \"Tornar proprietário\" abaixo, uma solicitação será enviada à autoridade gestora do X-Road.",
+        "confirmTitle": "Definir como membro proprietário",
+        "success": "Proprietário alterado"
+      },
+      "removeOrphans": {
+        "cancelButtonText": "Não",
+        "confirmText": "A chave e o certificado de assinatura associados ao cliente excluído não possuem usuários. Deseja excluir a chave e o certificado?",
+        "confirmTitle": "Exclusão de chave e certificado",
+        "success": "Certificado excluído"
+      },
+      "renameSubsystem": {
+        "changeAdded": "Alteração do nome do subsistema adicionada com sucesso. Será aplicada no registro do cliente",
+        "changeSubmitted": "Alteração do nome do subsistema enviada com sucesso",
+        "title": "Editar nome do subsistema"
+      },
+      "unregister": {
+        "confirmText": "Deseja cancelar o registro deste cliente?",
+        "confirmTitle": "Cancelar registro do cliente",
+        "success": "Cliente com registro cancelado"
       }
     },
+    "defaultSubsystemNameTooltip": "Nome do subsistema não definido",
     "id": "ID",
     "member": "Membro",
     "memberClass": "Classe do Membro",
@@ -125,15 +135,18 @@
     "status": "Status",
     "statusText": {
       "deletionInProgress": "EXCLUSÃO EM ANDAMENTO",
-      "globalError": "ERRO GLOBAL",
-      "registered": "REGISTRADO",
-      "registrationInProgress": "REGISTRO EM ANDAMENTO",
-      "saved": "SALVO",
       "disabled": "DESATIVADO",
       "disablingInProgress": "DESATIVAÇÃO EM ANDAMENTO",
-      "enablingInProgress": "ATIVAÇÃO EM ANDAMENTO"
+      "enablingInProgress": "ATIVAÇÃO EM ANDAMENTO",
+      "globalError": "ERRO GLOBAL",
+      "nameSet": "Alteração de nome será aplicada no registro do cliente",
+      "nameSubmitted": "Alteração de nome enviada",
+      "registered": "REGISTRADO",
+      "registrationInProgress": "REGISTRO EM ANDAMENTO",
+      "saved": "SALVO"
     },
     "subsystemCode": "Código do Subsistema",
+    "subsystemName": "Nome do Subsistema",
     "unknownMember": "membro desconhecido"
   },
   "clients": {
@@ -149,39 +162,63 @@
   },
   "csr": {
     "addKey": "Adicionar chave",
-    "certificationService": "Serviço de Certificação",
+    "certificationService": "Autoridade Certificadora",
     "client": "Cliente",
     "csrDetails": "Detalhes do CSR",
     "csrFormat": "Formato do CSR",
-    "eabCredRequired": "A Autoridade Certificadora selecionada exige vinculação de conta externa para ACME, mas as credenciais estão ausentes na configuração.",
-    "failedFetchAcmeMetadata": "Falha ao buscar os metadados ACME para a Autoridade Certificadora selecionada, o que pode causar erros nas próximas etapas.",
+    "eabCredRequired": "A Autoridade Certificadora selecionada requer vinculação de conta externa (ACME), mas as credenciais estão ausentes na configuração.",
+    "failedFetchAcmeMetadata": "Falha ao buscar os metadados ACME da Autoridade Certificadora selecionada. Isso pode causar erros nos próximos passos.",
     "generateCsr": "Gerar CSR",
     "helpCertificationService": "Autoridade Certificadora (CA) que emitirá o certificado.",
     "helpClient": "Membro X-Road para o qual o certificado será emitido.",
-    "helpCsrFormat": "Formato do pedido de assinatura de certificado conforme os requisitos da CA.",
-    "helpUsage": "Política de uso do certificado: assinar mensagens ou autenticar o Servidor Seguro.",
-    "saveInfo": "Gere um novo CSR e salve-o em um local seguro.",
-    "usage": "Uso",
-    "orderAcmeCertificate": "Solicite um certificado do Servidor ACME com o CSR gerado e importe o certificado retornado para o token."
+    "helpCsrFormat": "Formato do CSR conforme os requisitos da CA.",
+    "helpUsage": "Política de uso do certificado: assinatura de mensagens ou autenticação do Security Server.",
+    "orderAcmeCertificate": "Solicitar certificado ao servidor ACME com o CSR gerado e importar o certificado retornado para o token.",
+    "saveInfo": "Gere um novo CSR e salve-o em local seguro.",
+    "usage": "Uso"
   },
   "customValidation": {
-    "invalidEndpoint": "O endpoint contém caracteres inválidos",
-    "invalidUrl": "A URL não é válida",
+    "invalidEndpoint": "O endpoint contém caracteres ilegais",
+    "invalidUrl": "URL inválida",
     "invalidXrdIdentifier": "O identificador contém caracteres inválidos",
     "requiredIf": "O campo {fieldName} é obrigatório"
   },
   "diagnostics": {
     "addOnStatus": {
-      "messageLogDisabled": "Desativado pela configuração"
+      "messageLogDisabled": "Desativado por configuração"
+    },
+    "downloadReport": "Baixar relatório de diagnóstico",
+    "encryption": {
+      "backup": {
+        "configuredKeyId": "ID da chave configurada",
+        "title": "Criptografia de backup"
+      },
+      "messageLog": {
+        "archive": {
+          "defaultKeyNote": "Este membro está configurado para usar a chave padrão do servidor. Para maior segurança, considere definir uma chave específica.",
+          "groupingTitle": "Regra de agrupamento:",
+          "keyId": "ID da chave",
+          "memberIdentifier": "Identificador do membro",
+          "title": "Criptografia do log de mensagens (arquivo)"
+        },
+        "database": {
+          "title": "Criptografia do banco de dados do log de mensagens"
+        }
+      },
+      "status": {
+        "false": "Desativada",
+        "true": "Ativada"
+      },
+      "statusTitle": "Status da criptografia:"
     },
     "globalConfiguration": {
       "configurationStatus": {
         "ERROR_CODE_CANNOT_DOWNLOAD_CONF": "Não foi possível baixar a configuração global. Verifique a conexão de rede.",
         "ERROR_CODE_EXPIRED_CONF": "A configuração global baixada expirou.",
-        "ERROR_CODE_INTERNAL": "Ocorreu um erro interno.",
-        "ERROR_CODE_INVALID_SIGNATURE_VALUE": "Valor de assinatura inválido.",
-        "ERROR_CODE_MISSING_PRIVATE_PARAMS": "A configuração global baixada não contém parâmetros privados.",
-        "ERROR_CODE_UNINITIALIZED": "O cliente de configuração está inicializando.",
+        "ERROR_CODE_INTERNAL": "Erro interno.",
+        "ERROR_CODE_INVALID_SIGNATURE_VALUE": "Valor da assinatura inválido.",
+        "ERROR_CODE_MISSING_PRIVATE_PARAMS": "A configuração global baixada não contém parâmetros privados",
+        "ERROR_CODE_UNINITIALIZED": "O cliente de configuração está sendo inicializado.",
         "SUCCESS": "Tudo certo",
         "UNKNOWN": "Desconhecido"
       },
@@ -196,33 +233,34 @@
       "vendor": "Nome do fornecedor"
     },
     "mailNotificationConfiguration": {
-      "title": "Status das notificações por e-mail",
-      "help": {
-        "title": "Status de notificações por e-mail disponíveis",
-        "description": "Notificações por e-mail são enviadas automaticamente para os destinatários configurados nos seguintes eventos, dependendo da configuração: renovação do certificado de autenticação via ACME (sucesso/falha), renovação do certificado de assinatura via ACME (sucesso/falha) e registro do certificado de autenticação (sucesso). Ativar notificações por e-mail exige alterações na configuração do Servidor Seguro. Consulte o Guia do Usuário do Servidor Seguro para mais detalhes."
+      "authCertRegisteredEnabled": "Notificações de certificado AUTH registrado",
+      "confStatus": {
+        "false": "Configuração incompleta",
+        "true": "Configurado"
+      },
+      "configuration": "Configuração do servidor de e-mail",
+      "enabled": {
+        "false": "Desativadas",
+        "true": "Ativadas"
       },
       "failureEnabled": "Notificações de falha",
-      "successEnabled": "Notificações de sucesso",
-      "configuration": "Configuração do servidor de e-mail",
-      "recipientsEmails": "E-mails dos destinatários",
-      "enabled": {
-        "true": "Ativado",
-        "false": "Desativado"
+      "help": {
+        "description": "Notificações por e-mail são enviadas automaticamente para os destinatários configurados nos seguintes eventos (dependendo da configuração): renovação de certificado AUTH via ACME bem-sucedida / com falha, renovação de certificado SIGN via ACME bem-sucedida / com falha, registro de certificado AUTH bem-sucedido. A ativação das notificações requer alterações na configuração do Servidor Seguro. Consulte o Guia do Usuário para mais detalhes.",
+        "title": "Status das notificações por e-mail"
       },
-      "confStatus": {
-        "true": "Configurado",
-        "false": "Configuração incompleta"
-      }
+      "recipientsEmails": "E-mails dos destinatários",
+      "successEnabled": "Notificações de sucesso",
+      "title": "Status das notificações por e-mail"
     },
     "message": "Mensagem",
     "nextUpdate": "Próxima atualização",
     "ocspResponders": {
-      "certificationService": "Serviço de Certificação:",
+      "certificationService": "Autoridade Certificadora:",
       "ocspStatus": {
-        "ERROR_CODE_OCSP_CONNECTION_ERROR": "Não foi possível conectar ao validador OCSP",
-        "ERROR_CODE_OCSP_FAILED": "Não foi possível obter a resposta do validador OCSP",
-        "ERROR_CODE_OCSP_RESPONSE_INVALID": "Não foi possível interpretar a resposta do OCSP",
-        "ERROR_CODE_OCSP_RESPONSE_UNVERIFIED": "Não foi possível verificar a resposta do OCSP",
+        "ERROR_CODE_OCSP_CONNECTION_ERROR": "Não foi possível conectar ao respondedor OCSP",
+        "ERROR_CODE_OCSP_FAILED": "Não foi possível obter resposta do respondedor OCSP",
+        "ERROR_CODE_OCSP_RESPONSE_INVALID": "Não foi possível interpretar a resposta OCSP",
+        "ERROR_CODE_OCSP_RESPONSE_UNVERIFIED": "Não foi possível verificar a resposta OCSP",
         "ERROR_CODE_OCSP_UNINITIALIZED": "Solicitação de status ainda não enviada",
         "SUCCESS": "Tudo certo",
         "UNKNOWN": "Desconhecido"
@@ -230,55 +268,42 @@
       "title": "Validadores OCSP"
     },
     "previousUpdate": "Atualização anterior",
-    "serviceUrl": "URL do Serviço",
+    "proxyMemoryUsage": {
+      "alertOverThreshold": "Aviso: o uso de memória do proxy está acima do limite configurado",
+      "max": "Memória máxima",
+      "ok": "Tudo certo",
+      "threshold": "Limite",
+      "title": "Uso de memória do proxy",
+      "total": "Memória total alocada",
+      "usagePercent": "Uso de memória (%)",
+      "used": "Memória usada"
+    },
+    "serviceUrl": "URL do serviço",
     "status": "Status",
     "timestamping": {
       "timestampingStatus": {
-        "ERROR_CODE_INTERNAL": "Ocorreu um erro interno",
+        "ERROR_CODE_INTERNAL": "Erro interno",
         "ERROR_CODE_MALFORMED_TIMESTAMP_SERVER_URL": "URL do servidor de carimbo de tempo malformada. Verifique a URL.",
-        "ERROR_CODE_TIMESTAMP_REQUEST_TIMED_OUT": "Conexão expirou. Verifique a rede com o provedor da configuração global.",
-        "ERROR_CODE_TIMESTAMP_UNINITIALIZED": "Conexão ok, nenhuma solicitação de carimbo de tempo feita ainda",
+        "ERROR_CODE_TIMESTAMP_REQUEST_TIMED_OUT": "Tempo de conexão excedido. Verifique a conexão com o provedor de configuração global.",
+        "ERROR_CODE_TIMESTAMP_UNINITIALIZED": "Conexão ok, nenhuma solicitação de carimbo enviada ainda",
         "SUCCESS": "Tudo certo",
         "UNKNOWN": "Desconhecido"
       },
-      "title": "Carimbo de Tempo"
-    },
-    "encryption": {
-      "status": {
-        "false": "Desativada",
-        "true": "Ativada"
-      },
-      "statusTitle": "Status da criptografia:",
-      "backup": {
-        "title": "Criptografia de backup",
-        "configuredKeyId": "ID da Chave Configurada"
-      },
-      "messageLog": {
-        "archive": {
-          "title": "Criptografia do arquivo de logs de mensagens",
-          "groupingTitle": "Regra de agrupamento:",
-          "memberIdentifier": "Identificador do membro",
-          "keyId": "ID da chave",
-          "defaultKeyNote": "Este membro está configurado para usar a chave padrão de criptografia do servidor. Para maior segurança, considere definir uma chave específica."
-        },
-        "database": {
-          "title": "Criptografia do banco de dados de logs de mensagens"
-        }
-      }
+      "title": "Carimbo de tempo"
     }
   },
   "endpoints": {
-    "addEndpoint": "Adicionar Endpoint",
+    "addEndpoint": "Adicionar endpoint",
     "all": "TODOS",
-    "deleteEndpointText": "Tem certeza de que deseja excluir este endpoint?",
+    "deleteEndpointText": "Tem certeza de que deseja excluir este endpoint",
     "deleteSuccess": "Endpoint removido com sucesso",
     "deleteTitle": "Excluir endpoint",
-    "details": "Detalhes do Endpoint",
+    "details": "Detalhes do endpoint",
     "editSuccess": "Alterações no endpoint salvas com sucesso",
-    "endpointHelp1": "Os caminhos são relativos ao caminho base da API, por exemplo, '/pets'. O asterisco (*) pode ser usado como um caractere curinga.",
-    "endpointHelp2": "* = corresponde a um segmento de caminho.",
-    "endpointHelp3": "** = corresponde a zero ou mais segmentos, por exemplo, '/pets/**'.",
-    "endpointHelp4": "Parâmetros de caminho devem ser substituídos por um asterisco, por exemplo, '/pets/{id}/images' => '/pets/*/images'.",
+    "endpointHelp1": "O caminho é relativo à base da API, por exemplo '/pets'. O asterisco (*) pode ser usado como curinga",
+    "endpointHelp2": "* = corresponde a um segmento do caminho.",
+    "endpointHelp3": "** = corresponde a zero ou mais segmentos, por exemplo '/pets/**'.",
+    "endpointHelp4": "Parâmetros de caminho devem ser substituídos por asteriscos, ex: '/pets/{id}/images' => '/pets/*/images'.",
     "httpRequestMethod": "Método HTTP",
     "path": "Caminho",
     "saveNewEndpointSuccess": "Novo endpoint criado com sucesso"
@@ -286,52 +311,52 @@
   "error_code": {
     "accessright_not_found": "Direito de acesso não encontrado",
     "acme": {
-      "eab_credentials_missing": "Credenciais de vinculação de conta externa ausentes, mas necessárias",
-      "eab_secret_length": "Comprimento do segredo base64 da vinculação de conta externa inválido",
-      "account_key_pair_error": "Erro ao obter o par de chaves para a conta do servidor ACME",
+      "account_creation_failure": "Falha ao criar conta no servidor ACME. Se for necessário vincular conta externa, verifique se as credenciais estão corretas no acme.yml",
+      "account_key_pair_error": "Falha ao obter o par de chaves da conta ACME",
       "account_keystore_password_missing": "Senha do keystore da conta ACME ausente no arquivo de configuração acme.yml",
-      "fetching_metadata_error": "Falha ao buscar metadados do servidor ACME. O servidor ACME pode estar inacessível",
-      "account_creation_failure": "Falha ao criar conta no servidor ACME. Se a vinculação de conta externa for necessária, verifique se as credenciais corretas estão configuradas no acme.yml",
-      "order_creation_failure": "Falha ao criar nova Ordem no servidor ACME",
-      "order_finalization_failure": "Falha ao finalizar a Ordem no servidor ACME",
-      "http_challenge_file_creation": "Falha ao criar o arquivo de desafio HTTP do ACME",
-      "http_challenge_file_deletion": "Falha ao excluir o arquivo de desafio HTTP do ACME",
-      "http_challenge_missing": "Atualmente o X-Road suporta apenas o desafio HTTP, mas ele está ausente das opções disponíveis no servidor ACME",
-      "challenge_trigger_failure": "Falha ao solicitar ao servidor ACME a validação do desafio",
-      "authorization_failure": "Falha na autorização. Geralmente está relacionada à falha na validação do desafio necessária para provar a propriedade do domínio",
+      "authorization_failure": "Falha na autorização. Normalmente está relacionado à validação de propriedade do domínio",
       "authorization_wait_failure": "Falha ao aguardar a conclusão da autorização",
-      "certificate_failure": "Falha ao obter o Certificado do servidor ACME",
-      "certificate_wait_failure": "Falha ao aguardar a criação do novo Certificado"
+      "certificate_failure": "Falha ao obter certificado do servidor ACME",
+      "certificate_wait_failure": "Falha ao aguardar a criação do novo certificado",
+      "challenge_trigger_failure": "Falha ao solicitar ao servidor ACME a validação do desafio",
+      "eab_credentials_missing": "Credenciais de vinculação externa ausentes, mas requeridas",
+      "eab_secret_length": "Tamanho inválido do segredo EAB codificado em base64",
+      "fetching_metadata_error": "Falha ao buscar os metadados do servidor ACME. O servidor pode estar inacessível",
+      "http_challenge_file_creation": "Falha ao criar arquivo de desafio HTTP do ACME",
+      "http_challenge_file_deletion": "Falha ao excluir arquivo de desafio HTTP do ACME",
+      "http_challenge_missing": "Atualmente o X-Road só suporta desafio HTTP, mas essa opção está ausente no servidor ACME",
+      "order_creation_failure": "Falha ao criar nova ordem no servidor ACME",
+      "order_finalization_failure": "Falha ao finalizar ordem no servidor ACME"
     },
-    "action_not_possible": "Ação não é possível",
+    "action_not_possible": "Ação não permitida",
     "additional_member_already_exists": "Membro adicional já existe",
     "anchor_already_exists": "Âncora já existe",
     "anchor_file_not_found": "Arquivo de âncora não encontrado",
     "anchor_not_found": "Âncora não encontrada",
-    "anchor_upload_failed": "Falha ao enviar a âncora",
+    "anchor_upload_failed": "Falha no envio da âncora",
     "auth_cert_not_supported": "Certificado de autenticação não suportado",
     "base_endpoint_not_found": "Endpoint base não encontrado",
-    "ca_cert_status_processing_failure": "Falha ao processar o status do certificado da CA",
+    "ca_cert_status_processing_failure": "Falha ao processar status do certificado da AC",
     "cannot_delete_owner": "Não é possível excluir o proprietário",
     "cannot_register_owner": "Não é possível registrar o proprietário",
-    "cannot_unregister_owner": "Não é possível desregistrar o proprietário",
+    "cannot_unregister_owner": "Não é possível cancelar registro do proprietário",
     "cert_wrong_usage": "Uso incorreto do certificado",
     "certificate_already_exists": "Certificado já existe",
-    "certificate_authority_not_found": "Autoridade Certificadora não encontrada",
-    "certificate_id_not_found": "ID do Certificado não encontrado",
+    "certificate_authority_not_found": "Autoridade certificadora não encontrada",
+    "certificate_id_not_found": "ID do certificado não encontrado",
     "certificate_not_found": "Certificado não encontrado",
-    "certificate_profile_instantiation_failure": "Falha ao instanciar o perfil do certificado",
+    "certificate_profile_instantiation_failure": "Falha ao instanciar perfil de certificado",
     "client_already_exists": "Cliente já existe",
     "client_not_deleted": "Não foi possível excluir chaves, certificados e CSRs porque pertencem a um cliente existente",
     "client_not_found": "Cliente não encontrado",
-    "conf_download_failed": "Falha no download da configuração",
+    "conf_download_failed": "Falha ao baixar configuração",
     "conf_verification": {
-      "anchor_not_for_external_source": "Âncora aponta para uma fonte de configuração interna. Apenas âncoras de fontes externas são suportadas como âncoras confiáveis.",
-      "missing_private_params": "Falha na importação da âncora de configuração: arquivo de âncora inválido",
-      "other": "Configuração da fonte falhou na verificação",
+      "anchor_not_for_external_source": "A âncora aponta para uma fonte interna. Apenas âncoras externas são permitidas.",
+      "missing_private_params": "Falha ao importar âncora: arquivo inválido",
+      "other": "Falha na verificação da fonte de configuração",
       "outdated": "Configuração da fonte está desatualizada",
-      "signature_invalid": "A assinatura da configuração não pode ser verificada",
-      "unreachable": "A fonte de configuração não pode ser acessada, verifique a URL da fonte no arquivo de âncora enviado"
+      "signature_invalid": "A assinatura da configuração não pôde ser verificada",
+      "unreachable": "Fonte de configuração inacessível. Verifique a URL da âncora"
     },
     "core": {
       "Server": {
@@ -343,34 +368,24 @@
           },
           "UnknownService": "Serviço desconhecido"
         }
-      },
-      "Signer": {
-        "CertNotFound": "Certificado não encontrado",
-        "NetworkError": "O assinador não está acessível no momento.",
-        "KeyNotFound": "Chave não encontrada",
-        "TokenNotAvailable": "Token não disponível",
-        "TokenNotFound": "Token não encontrado",
-        "UnknownMember": "X-Road core - assinador: Membro desconhecido"
       }
     },
     "csr_not_found": "CSR não encontrado",
-    "diagnostic_request_failed": "Solicitação de diagnóstico falhou",
+    "diagnostic_request_failed": "Falha na solicitação de diagnóstico",
     "duplicate_accessright": "Direito de acesso duplicado",
     "endpoint_already_exists": "Endpoint já existe",
     "endpoint_not_found": "Endpoint não encontrado",
-    "global_conf_download_request_failed": "Falha na solicitação de download da configuração global",
-    "global_conf_outdated": "A configuração global está desatualizada",
-    "gpg_key_generation_failed": "Falha na geração do par de chaves GPG",
-    "gpg_key_generation_interrupted": "Geração do par de chaves GPG interrompida",
+    "global_conf_download_request_failed": "Falha ao solicitar download da configuração global",
+    "global_conf_outdated": "Configuração global está desatualizada",
+    "gpg_key_generation_failed": "Falha ao gerar chave GPG",
+    "gpg_key_generation_interrupted": "Geração de chave GPG interrompida",
     "identifier_not_found": "Identificador não encontrado",
-    "illegal_generated_endpoint_remove": "Remoção do endpoint gerado não é permitida",
-    "illegal_generated_endpoint_update": "Atualização do endpoint gerado não é permitida",
+    "illegal_generated_endpoint_remove": "Não é permitido remover endpoint gerado automaticamente",
+    "illegal_generated_endpoint_update": "Não é permitido editar endpoint gerado automaticamente",
     "import_internal_cert_failed": "Falha ao importar certificado interno",
-    "internal_anchor_upload_invalid_instance_id": "Âncora contém um ID de instância inválido",
-    "internal_error": "Erro interno. Consulte os logs do Servidor Seguro para mais detalhes.",
-    "internal_key_cert_interrupted": "Certificado de chave interna interrompido",
-    "invalid_cert": "Certificado inválido",
-    "invalid_characters_pin": "O PIN contém caracteres inválidos",
+    "internal_anchor_upload_invalid_instance_id": "A âncora possui identificador de instância inválido",
+    "internal_key_cert_interrupted": "Interrupção ao processar chave/certificado interno",
+    "invalid_characters_pin": "PIN contém caracteres inválidos",
     "invalid_dn_parameter": "Parâmetro DN inválido",
     "invalid_https_url": "A URL não utiliza HTTPS",
     "invalid_init_params": "Parâmetros de inicialização inválidos",
@@ -380,87 +395,87 @@
     "invalid_service_url": "URL de serviço inválida",
     "invalid_wsdl": "WSDL inválido",
     "invalid_wsdl_service_identifier": "Identificador de serviço WSDL inválido",
-    "key_and_cert_generation_failed": "Falha na geração da chave e certificado",
+    "key_and_cert_generation_failed": "Falha ao gerar chave e certificado",
     "key_not_found": "Chave não encontrada",
-    "local_group_code_already_exists": "Código do grupo local já existe",
+    "local_group_code_already_exists": "Código de grupo local já existe",
     "local_group_member_already_exists": "Membro do grupo local já existe",
     "local_group_member_not_found": "Membro do grupo local não encontrado",
     "local_group_not_found": "Grupo local não encontrado",
     "malformed_anchor": "Âncora malformada",
     "malformed_url": "URL malformada",
-    "management_request_sending_failed": "Falha no envio da solicitação de gerenciamento",
+    "management_request_sending_failed": "Falha ao enviar solicitação de gerenciamento",
     "member_already_owner": "Membro já é o proprietário",
     "member_class_exists": "Classe de membro já existe",
-    "member_class_not_provided": "Classe de membro não fornecida",
+    "member_class_not_provided": "Classe de membro não informada",
     "member_code_exists": "Código de membro já existe",
-    "member_code_not_provided": "Código de membro não fornecido",
+    "member_code_not_provided": "Código de membro não informado",
     "missing_parameter": "Parâmetro ausente",
-    "openapi_parsing_error": "Falha ao analisar a descrição OpenApi3",
-    "orphans_not_found": "Chaves órfãs, certificados e/ou CSRs associados ao cliente não foram encontrados",
-    "pin_code_exists": "Código PIN já existe",
-    "pin_code_not_provided": "Código PIN não fornecido",
-    "pin_incorrect": "PIN incorreto. Por favor, tente novamente.",
-    "pin_min_char_classes_count": "Contagem mínima de classes de caracteres no PIN",
-    "pin_min_length": "Comprimento mínimo do PIN",
+    "openapi_parsing_error": "Falha ao interpretar descrição OpenAPI 3",
+    "orphans_not_found": "Não foram encontradas chaves, certificados ou CSRs órfãos vinculados ao cliente",
+    "pin_code_exists": "PIN já existe",
+    "pin_code_not_provided": "PIN não informado",
+    "pin_incorrect": "PIN incorreto. Tente novamente.",
     "process_failed": "Processo falhou",
-    "process_not_executable": "Processo não é executável",
-    "server_already_fully_initialized": "O servidor já está totalmente inicializado",
-    "server_code_exists": "Código do servidor já existe",
-    "server_code_not_provided": "Código do servidor não fornecido",
+    "process_not_executable": "Processo não pode ser executado",
+    "server_already_fully_initialized": "Servidor já está completamente inicializado",
+    "server_code_exists": "Código de servidor já existe",
+    "server_code_not_provided": "Código de servidor não informado",
     "service_already_exists": "Serviço já existe",
     "service_client_not_found": "Cliente de serviço não encontrado",
     "service_code_already_exists": "Código de serviço já existe",
-    "service_description_not_found": "Descrição do serviço não encontrada",
+    "service_code_reserved": "O código informado é reservado para uso interno e não pode ser atribuído",
+    "service_description_not_found": "Descrição de serviço não encontrada",
     "service_not_found": "Serviço não encontrado",
     "sign_cert_not_supported": "Certificado de assinatura não suportado",
-    "software_token_init_failed": "Falha na inicialização do token de software",
+    "software_token_init_failed": "Falha ao inicializar o token de software",
     "timestamping_service_already_configured": "Serviço de carimbo de tempo já configurado",
     "timestamping_service_not_found": "Serviço de carimbo de tempo não encontrado",
     "token": {
-      "malformed_csr": "Os dados do CSR estão malformados"
+      "malformed_csr": "Dados do CSR malformados"
     },
     "token_not_active": "Token não está ativo",
-    "unsupported_openapi_version": "Versão OpenAPI não suportada. Apenas as versões 3.0.x e 3.1.0 são suportadas atualmente.",
+    "unsupported_openapi_version": "Versão OpenAPI não suportada. Apenas 3.0.x e 3.1.0 são aceitas.",
     "url_already_exists": "URL já existe",
     "warnings_detected": "Avisos detectados",
-    "weak_pin": "PIN fraco",
     "wrong_key_usage": "Uso incorreto da chave",
-    "wrong_servicedescription_type": "Tipo de descrição de serviço incorreto",
-    "wsdl_download_failed": "Falha no download do WSDL",
+    "wrong_servicedescription_type": "Tipo de descrição de serviço inválido",
+    "wsdl_download_failed": "Falha ao baixar WSDL",
     "wsdl_exists": "WSDL já existe",
-    "wsdl_validator_interrupted": "Validador WSDL interrompido",
-    "wsdl_validator_not_executable": "Validador WSDL não é executável"
+    "wsdl_validator_interrupted": "Validador de WSDL interrompido",
+    "wsdl_validator_not_executable": "Validador de WSDL não pode ser executado"
   },
   "fields": {
+    "C": "Código do País",
+    "CN": "Nome Comum (CN)",
+    "O": "Nome da Organização (O)",
     "addClient": {
       "memberClass": "Classe do Membro",
       "memberCode": "Código do Membro",
-      "subsystemCode": "Código do Subsistema"
+      "subsystemCode": "Código do Subsistema",
+      "subsystemName": "Nome do Subsistema"
     },
-    "C": "Código do País",
+    "certificationService": "Autoridade Certificadora",
     "clientAdd": {
       "client": {
         "memberCode": "Código do Membro",
         "subsystemCode": "Código do Subsistema"
       }
     },
-    "CN": "Nome DNS do Servidor",
     "confirmPin": "Confirmar PIN",
     "csr": {
-      "certService": "Serviço de Certificação",
+      "certService": "Autoridade Certificadora",
+      "certificationService": "Autoridade Certificadora",
       "client": "Cliente",
       "csrFormat": "Formato do CSR",
-      "usage": "Uso",
-      "certificationService": "Serviço de Certificação"
+      "usage": "Uso"
     },
     "dns": "DNS",
     "keys": {
       "name": "Nome"
     },
-    "O": "Nome da Organização",
+    "memberCode": "Código do Membro",
     "path": "Caminho",
     "pin": "PIN",
-    "memberCode": "Código do Membro",
     "securityServerAddress": "Endereço do Servidor Seguro",
     "serialNumber": "Número de Série",
     "serviceCode": "Código do Serviço",
@@ -468,25 +483,21 @@
       "restServiceCode": "Código do Serviço"
     },
     "serviceDescriptionUpdate": {
-      "newRestServiceCode": "Código do Serviço"
+      "newRestServiceCode": "Novo Código do Serviço"
     },
     "serviceTimeout": "Tempo limite",
     "serviceType": "Tipo de Serviço",
-    "serviceUrl": "URL",
-    "subjectAltName": "Nome Alternativo",
+    "serviceUrl": "URL do Serviço",
+    "subjectAltName": "Nome alternativo do titular",
     "token": {
       "friendlyName": "Nome amigável",
       "newPin": "Novo PIN",
       "newPinConfirm": "Confirmar novo PIN",
-      "oldPin": "PIN antigo"
+      "oldPin": "PIN atual"
     },
     "tokenPin": "PIN do Token",
     "url": "URL",
-    "username": "Nome de Usuário",
-    "certificationService": "Serviço de Certificação"
-  },
-  "global": {
-    "appTitle": "X-Road Servidor Seguro"
+    "username": "Nome de usuário"
   },
   "general": {
     "instance": "Instância",
@@ -497,15 +508,18 @@
     "subsystemCode": "Código do Subsistema",
     "type": "Tipo"
   },
+  "global": {
+    "appTitle": "Servidor Seguro X-Road"
+  },
   "globalAlert": {
     "backupRestoreInProgress": "A configuração do Servidor Seguro está sendo restaurada a partir de um backup. Processo iniciado em {startTime}",
-    "globalConfigurationInvalid": "A configuração global está expirada",
-    "secondaryNode": "Você está em um nó secundário de um cluster do Servidor Seguro. Modificar a configuração está desativado.",
-    "softTokenPinNotEntered": "Por favor, insira o PIN do token de software",
     "certificateRenewalJobFailure": "A última renovação de certificado falhou.",
-    "certificateRenewalJobFailureAuth": "Certificado(s) de autenticação com falha:",
-    "certificateRenewalJobFailureSign": "Certificado(s) de assinatura com falha:",
-    "navigateToKeysPage": "Veja a página de chaves e certificados para mais detalhes"
+    "certificateRenewalJobFailureAuth": "Certificados de Autenticação com falha:",
+    "certificateRenewalJobFailureSign": "Certificados de Assinatura com falha:",
+    "globalConfigurationInvalid": "A configuração global está expirada",
+    "navigateToKeysPage": "Veja mais detalhes na página de Chaves e Certificados",
+    "secondaryNode": "Você está em um nó secundário de um cluster de Servidor Seguro. Modificações na configuração estão desabilitadas.",
+    "softTokenPinNotEntered": "Por favor, insira o PIN do token de software"
   },
   "initialConfiguration": {
     "anchor": {
@@ -515,51 +529,46 @@
       "title": "Âncora de Configuração"
     },
     "member": {
-      "info": "Defina o membro que será o proprietário do Servidor Seguro:",
-      "serverCodeHelp": "Código do Servidor Seguro que identifica este servidor de forma única entre todos os servidores do mesmo proprietário.",
+      "info": "Defina o membro que atuará como proprietário do Servidor Seguro:",
+      "serverCodeHelp": "Código que identifica exclusivamente este Servidor Seguro entre os servidores do mesmo proprietário.",
       "title": "Membro Proprietário"
     },
-    "noInitializationStatus": "Nenhum status de inicialização disponível",
-    "noPermission": "Este Servidor Seguro ainda não foi inicializado, entre em contato com um administrador para realizar a configuração inicial.",
+    "noInitializationStatus": "Status de inicialização indisponível",
+    "noPermission": "Este Servidor Seguro ainda não foi inicializado. Contate um administrador para realizar a configuração inicial.",
     "pin": {
       "confirmPin": "Confirmar PIN",
-      "info1": "O token de software é onde as chaves AUTH do Servidor Seguro são armazenadas. Defina um PIN para acessar o token de software.",
-      "info2": "Todas as informações necessárias foram coletadas, pressione o botão Enviar para inicializar o Servidor Seguro.",
-      "info3": "Após a inicialização, conclua a configuração do Servidor Seguro clicando no botão Configurar na notificação que aparecerá em breve.",
+      "info1": "O token de software armazena a chave AUTH do Servidor Seguro. Defina um PIN para acessá-lo.",
+      "info2": "Todas as informações necessárias foram fornecidas. Pressione Enviar para inicializar o servidor.",
+      "info3": "Após a inicialização, conclua a configuração clicando em 'Configurar' na notificação exibida.",
       "pin": "PIN",
-      "pinMatchError": "A confirmação do PIN não corresponde",
+      "pinMatchError": "O PIN e sua confirmação não coincidem",
       "title": "PIN do Token"
     },
-    "success": "Servidor inicializado",
+    "success": "Servidor inicializado com sucesso",
     "title": "Configuração Inicial",
     "warning": {
       "init_server_id_exists": "ID do servidor já existe",
       "init_server_owner_exists": "Proprietário do servidor já existe",
       "init_servercode_exists": "Código do servidor já existe",
-      "init_software_token_initialized": "Token de software já inicializado",
-      "init_unregistered_member": "Membro não registrado"
+      "init_software_token_initialized": "Token de software já foi inicializado",
+      "init_unregistered_member": "Membro não está registrado"
     }
   },
   "internalServers": {
     "certHash": "Hash do Certificado",
     "connTypeUpdated": "Tipo de conexão atualizado",
-    "connectionInfo": "O tipo de conexão para servidores no papel de provedor de serviço é definido na aba Serviços pela URL do serviço (http/https).",
-    "connectionType": "Tipo de conexão",
+    "connectionInfo": "O tipo de conexão de servidores no papel de provedor de serviço é definido na aba Serviços pela URL do serviço (http/https).",
+    "connectionType": "Tipo de Conexão",
     "ssCertTitle": "Certificado do Servidor Seguro",
     "tlsTitle": "Certificado TLS do Sistema de Informação"
   },
-  "certificate": {
-    "hash": "Hash do Certificado",
-    "subjectDistinguishedName": "Titular do Certificado (DN)",
-    "notBefore": "Não Antes de",
-    "notAfter": "Não Depois de"
-  },
   "keys": {
+    "acmeCertOrdered": "Certificado solicitado com sucesso",
     "addKey": "Adicionar chave",
     "authDetailsTitle": "Detalhes da Chave AUTH",
     "authKeyCert": "Chaves e Certificados AUTH",
-    "authNotSupported": "Chave AUTH não suportada",
-    "auth_key_with_registered_cert_warning": "A chave possui certificados que precisam ser desregistrados antes da exclusão. Deseja continuar com o desregistro e a exclusão dos certificados associados e da chave da configuração do servidor? ID da Chave:",
+    "authNotSupported": "Chave de autenticação não suportada",
+    "auth_key_with_registered_cert_warning": "A chave possui certificados registrados que precisam ser desregistrados antes da exclusão. Deseja prosseguir com a remoção dos certificados e da chave?",
     "certMarkedForDeletion": "Certificado marcado para exclusão",
     "certRegistrationInfo": "Nome DNS ou endereço IP do Servidor Seguro",
     "certStatus": {
@@ -576,35 +585,37 @@
     "deleteCsr": "Excluir CSR",
     "deleteCsrText": "Tem certeza de que deseja excluir este CSR?",
     "deleteCsrTitle": "Excluir CSR?",
-    "deleteKeyText": "Tem certeza de que deseja excluir esta chave e todos os certificados associados da configuração do servidor?",
+    "deleteKeyText": "Tem certeza de que deseja excluir esta chave e todos os certificados associados?",
     "deleteTitle": "Excluir chave?",
     "detailsTitle": "Detalhes da Chave",
     "expires": "Expira em",
     "friendlyName": "Nome amigável",
     "generateCsr": "Gerar CSR",
     "globalErrors": "Erros globais",
-    "gotIt": "Entendido",
-    "helpTextApi": "As chaves API são usadas para autenticar chamadas de API na REST API de gerenciamento do Servidor Seguro. As chaves API estão associadas a funções que definem as permissões concedidas.",
-    "helpTextKeys": "A chave e o certificado de autenticação certificam a autenticidade de um Servidor Seguro. Eles são usados para autenticação em conexões entre Servidores de Seguros. A chave e o certificado de assinatura certificam a autenticidade de um membro do X-Road. Eles são usados para assinar e verificar a integridade de mensagens mediadas.",
-    "helpTextSS": "O certificado TLS do Servidor Seguro é usado em conexões entre o Servidor Seguro e um sistema de informação. O certificado TLS interno é usado tanto como cliente quanto como servidor, dependendo dos papéis de cada um.",
-    "helpTitleApi": "Chaves API",
+    "gotIt": "Entendi",
+    "helpTextApi": "Chaves de API são usadas para autenticar chamadas na API REST de gerenciamento do Servidor Seguro.",
+    "helpTextKeys": "As chaves de autenticação e assinatura certificam a autenticidade do servidor e das mensagens trocadas.",
+    "helpTextSS": "O certificado TLS é utilizado nas conexões entre o Servidor Seguro e os sistemas de informação.",
+    "helpTitleApi": "Chaves de API",
     "helpTitleKeys": "Chaves AUTH e SIGN",
     "helpTitleSS": "Certificado TLS do Servidor Seguro",
     "id": "ID",
     "importCert": "Importar cert.",
-    "importCertSuccess": "Upload do certificado realizado com sucesso",
-    "incorrectPin": "PIN incorreto. Por favor, tente novamente.",
+    "importCertOcspVerifyWarning": "Não foi possível ativar o certificado. A verificação OCSP falhou. Erro: {errorMessage}",
+    "importCertSuccess": "Certificado importado com sucesso",
+    "incorrectPin": "PIN incorreto. Tente novamente.",
+    "keyAlgorithm": "Algoritmo da Chave:",
     "keyDeleted": "Chave excluída",
     "keyId": "ID da Chave:",
     "keyInfo": "Informações da Chave",
-    "keyLabelInput": "Etiqueta da Chave",
+    "keyLabelInput": "Rótulo da Chave",
     "keySaved": "Chave salva",
-    "label": "Etiqueta:",
+    "label": "Rótulo:",
     "logIn": "Entrar",
     "logOut": "Sair",
-    "logOutText": "Sair do token?",
-    "logOutTitle": "Sair",
-    "loggedIn": "Token conectado",
+    "logOutText": "Deseja sair do token?",
+    "logOutTitle": "Sair do Token",
+    "loggedIn": "Token autenticado",
     "loggedOut": "Token desconectado",
     "noIssues": "Sem problemas",
     "ocsp": "OCSP",
@@ -617,36 +628,37 @@
       "unknown": "Desconhecido"
     },
     "orderAcmeCertificate": "Solicitar Certificado",
-    "acmeCertOrdered": "Certificado solicitado com sucesso",
     "readOnly": "Somente leitura:",
-    "keyAlgorithm": "Algoritmo da Chave:",
     "registrationRequest": "Solicitação de registro",
-    "renewal": "Renovação Automática",
+    "renewal": "Renovação automática",
     "request": "Solicitação",
     "signDetailsTitle": "Detalhes da Chave SIGN",
     "signKeyCert": "Chaves e Certificados SIGN",
     "status": "Status",
-    "token": "Token:",
-    "tokenDetails": "Detalhes do Token",
-    "tokenId": "ID do Token:",
-    "tokenInfo": "Informações do Token",
-    "tokenPin": "PIN do Token",
-    "tokenSaved": "Token salvo",
+    "token": {
+      "details": "Detalhes do Token",
+      "id": "ID do Token:",
+      "info": "Informações do Token",
+      "saved": "Token salvo",
+      "deleteText": "Tem certeza de que deseja excluir este token e todas as informações associadas?",
+      "deleteTitle": "Excluir token?",
+      "deleteSuccess": "Token excluído com sucesso"
+    },
     "tokenStatus": {
-      "active": "Ativo",
-      "available": "Disponível",
+      "active": "",
+      "available": "",
       "inactive": "Inativo",
       "unavailable": "Bloqueado",
       "unsaved": "Não salvo"
     },
     "type": "Tipo:",
     "unknown": "Tipo de chave não especificado",
-    "unregisterError": "Falha ao desregistrar o certificado. Continuar com a exclusão do certificado mesmo assim?",
+    "unregisterError": "Falha ao desregistrar certificado. Deseja continuar com a exclusão?",
     "unregisterText": "Deseja desregistrar este certificado?",
     "unregisterTitle": "Desregistrar certificado"
   },
   "localGroup": {
-    "accessDate": "Direitos de Acesso Concedidos",
+    "accessDate": "Acesso concedido em",
     "addLocalGroup": "Adicionar Grupo Local",
     "addMembers": "Adicionar Membros",
     "addSelected": "Adicionar selecionados",
@@ -660,47 +672,48 @@
     "id": "ID",
     "localGroup": "Grupo Local",
     "localGroupAdded": "Grupo local adicionado",
-    "name": "Nome do Membro",
-    "noResults": "Sua busca não encontrou resultados.",
-    "removeAllText": "Tem certeza de que deseja remover todos os membros deste grupo?",
+    "memberName": "Nome do Membro",
+    "noResults": "Sua busca não retornou resultados.",
+    "removeAllText": "Deseja remover todos os membros deste grupo?",
     "removeAllTitle": "Remover todos os membros?",
-    "removeText": "Tem certeza de que deseja remover este membro?",
+    "removeText": "Deseja remover este membro?",
     "removeTitle": "Remover membro?",
-    "searchOptions": "Opções de busca"
+    "searchOptions": "Opções de busca",
+    "subsystemName": "Nome do Subsistema"
   },
   "localGroups": {
     "addGroup": "Adicionar grupo",
     "code": "Código",
     "description": "Descrição",
-    "memberCount": "Quantidade de Membros",
+    "memberCount": "Qtd. de Membros",
     "updated": "Atualizado"
   },
   "noData": {
     "noBackUpEncryptionKeys": "Nenhuma chave de criptografia de backup configurada",
-    "noClientData": "Nenhum dado de cliente",
-    "noCertificateAuthorities": "Nenhuma autoridade certificadora",
-    "noLocalGroups": "Nenhum grupo local",
+    "noCertificateAuthorities": "Nenhuma autoridade certificadora disponível",
+    "noClientData": "Nenhum dado de cliente disponível",
+    "noLocalGroups": "Nenhum grupo local cadastrado",
     "noServiceClients": "Nenhum cliente de serviço",
     "noTimestampingServices": "Nenhum serviço de carimbo de tempo"
   },
   "serviceClientType": {
-    "globalGroup": "GRUPO GLOBAL",
-    "localGroup": "GRUPO LOCAL",
+    "globalGroup": "GRUPO_GLOBAL",
+    "localGroup": "GRUPO_LOCAL",
     "subsystem": "SUBSISTEMA"
   },
   "serviceClients": {
     "accessRights": "Direitos de acesso",
-    "accessRightsGiven": "Direitos de Acesso Concedidos",
+    "accessRightsGiven": "Direitos de acesso concedidos",
     "addSelected": "Adicionar selecionados",
     "addService": "Adicionar serviço",
-    "addServiceClient": "Adicionar cliente de serviço",
+    "addServiceClient": "Adicionar cliente",
     "addServiceClientAccessRightSuccess": "Direitos de acesso adicionados com sucesso",
-    "addServiceClientTitle": "Adicionar cliente de serviço",
+    "addServiceClientTitle": "Adicionar um cliente",
     "id": "ID",
-    "memberGroupCodeLabel": "Código do Membro/Grupo",
+    "memberGroupCodeLabel": "Código do Membro / Grupo",
     "memberGroupStep": "Membro / Grupo",
-    "name": "Nome do Membro / Descrição do Grupo",
-    "noAccessRights": "Sem direitos de acesso para este cliente",
+    "name": "Nome do Membro (Subsistema) / Descrição do Grupo",
+    "noAccessRights": "Sem direitos de acesso a este cliente",
     "noAvailableServices": "Nenhum serviço disponível",
     "removeAll": "Remover todos",
     "removeAllText": "Tem certeza de que deseja remover todos os direitos de acesso deste cliente de serviço?",
@@ -708,8 +721,8 @@
     "removeOneText": "Tem certeza de que deseja remover os direitos de acesso deste cliente de serviço?",
     "removeOneTitle": "Remover direitos de acesso?",
     "searchPlaceHolder": "Clientes de serviço",
-    "serviceCode": "Código do Serviço",
-    "serviceSelectionStep": "Código do Serviço",
+    "serviceCode": "Código do serviço",
+    "serviceSelectionStep": "Código do serviço",
     "servicesStep": "Serviços",
     "title": "Título"
   },
@@ -718,7 +731,7 @@
     "addRest": "Adicionar REST",
     "addWsdl": "Adicionar WSDL",
     "applyToAll": "Aplicar a todos no WSDL",
-    "deleteRestText": "Tem certeza de que deseja excluir este Serviço REST?",
+    "deleteRestText": "Tem certeza de que deseja excluir este serviço REST?",
     "deleteTitle": "Excluir descrição do serviço?",
     "deleteWsdlText": "Tem certeza de que deseja excluir este WSDL?",
     "deleted": "Descrição do serviço excluída",
@@ -727,43 +740,43 @@
     "disableTitle": "Desativar?",
     "editUrl": "Editar URL",
     "enableSuccess": "Descrição do serviço ativada",
-    "idGroupCode": "ID / Código do Grupo",
+    "idGroupCode": "ID / Código do grupo",
     "lastRefreshed": "Última atualização: ",
-    "memberNameGroupDesc": "Nome do Membro / Descrição do Grupo",
+    "memberNameGroupDesc": "Nome do membro / Descrição do grupo",
     "noMatches": "Nenhum registro correspondente",
     "openApi3Added": "Serviço OpenAPI 3 adicionado",
-    "openapiDetails": "Detalhes do OpenAPI 3",
+    "openapiDetails": "Detalhes OpenAPI 3",
     "refreshed": "Atualizado",
     "restAdded": "Serviço REST adicionado",
-    "restApiBasePath": "Caminho Base da API REST",
+    "restApiBasePath": "Caminho base da API REST",
     "restDetails": "Detalhes do REST",
     "service": "Serviço",
     "serviceCode": "Código do Serviço",
-    "serviceCodePlaceholder": "Insira o código do serviço",
+    "serviceCodePlaceholder": "Inserir código do serviço",
     "serviceSaved": "Serviço salvo",
     "serviceType": "Tipo de URL",
     "serviceUrl": "URL do Serviço",
     "service_parameters_ssl_test_warnings": {
-      "internal_server_ssl_error": "Falha ao verificar os certificados do servidor interno. A URL do servidor upstream está correta e acessível pelo Servidor Seguro?",
-      "internal_server_ssl_handshake_error": "Falha no handshake TLS com o servidor upstream, certificado do servidor ausente na configuração:"
+      "internal_server_ssl_error": "Falha ao verificar os certificados do servidor interno. A URL está correta e acessível pelo Servidor Seguro?",
+      "internal_server_ssl_handshake_error": "Falha no handshake TLS com o servidor upstream. O certificado do servidor está ausente da configuração:"
     },
-    "timeout": "Tempo limite",
+    "timeout": "Timeout",
     "timeoutSec": "Tempo limite (s)",
-    "timeoutTooltip": "A duração máxima de uma solicitação ao serviço, em segundos",
-    "tlsTooltip": "Verifique o certificado TLS ao estabelecer uma conexão segura",
+    "timeoutTooltip": "Duração máxima de uma requisição ao serviço, em segundos",
+    "tlsTooltip": "Verificar certificado TLS ao estabelecer conexão segura",
     "url": "URL",
-    "urlPlaceholder": "Insira a URL",
-    "urlTooltip": "A URL para onde as solicitações direcionadas ao serviço são enviadas",
+    "urlPlaceholder": "Inserir URL",
+    "urlTooltip": "URL onde as requisições ao serviço serão direcionadas",
+    "verifyTls": "Verificar certificado TLS",
     "warning": "Aviso",
     "warningCode": {
       "adding_endpoints": "Adicionando endpoints:",
       "adding_services": "Adicionando serviços:",
-      "deleting_endpoints": "Excluindo endpoints:",
-      "deleting_services": "Excluindo serviços:",
-      "wsdl_validation_warnings": "Avisos de validação:",
-      "openapi_validation_warnings": "Avisos de validação:"
+      "deleting_endpoints": "Removendo endpoints:",
+      "deleting_services": "Removendo serviços:",
+      "openapi_validation_warnings": "Avisos de validação:",
+      "wsdl_validation_warnings": "Avisos de validação:"
     },
-    "verifyTls": "Verificar certificado TLS",
     "wsdlAdded": "WSDL adicionado",
     "wsdlDescription": "Descrição do WSDL",
     "wsdlDetails": "Detalhes do WSDL"
@@ -776,13 +789,13 @@
       "cancel": "CANCELAR",
       "done": "CONCLUÍDO",
       "step1": {
-        "description": "1) Primeiro, Forneça o Titular do Certificado (DN)",
-        "label": "Titular do Certificado (DN)",
-        "placeholder": "CN=meuservidordeseguranca.exemplo.com, O=Minha Organização, C=BR",
-        "tooltip": "O Titular do Certificado (DN) identifica de forma exclusiva uma entidade em um certificado X.509. Os seguintes tipos de atributos são comumente encontrados no DN: CN = Nome comum, O = Nome da organização, C = Código do país."
+        "description": "1) Primeiro, forneça um Distinguished Name",
+        "label": "Distinguished Name",
+        "placeholder": "CN=meuservidorseguro.exemplo.com, O=Minha Organização, C=BR",
+        "tooltip": "O Distinguished Name (DN) identifica de forma única uma entidade em um certificado X.509. Os atributos comuns incluem: CN = Nome comum, O = Nome da organização, C = Código do país."
       },
       "step2": {
-        "description": "2) Gere um novo CSR e salve-o em um local seguro",
+        "description": "2) Gere um novo CSR e salve em local seguro",
         "generateCSR": "Gerar CSR"
       },
       "title": "Gerar Solicitação de Assinatura de Certificado TLS"
@@ -790,8 +803,8 @@
     "generateKey": "Gerar chave",
     "generateTlsAndCertificateDialog": {
       "confirmation": "Gerar uma nova chave e certificado TLS do Servidor Seguro?",
-      "explanation": "O sistema gerará uma nova chave TLS do Servidor Seguro e um certificado autoassinado, substituindo a chave e o certificado existentes.",
-      "success": "Nova chave e certificado TLS do Servidor Seguro gerados com sucesso",
+      "explanation": "O sistema irá gerar uma nova chave TLS e um certificado autoassinado, substituindo os existentes.",
+      "success": "Nova chave e certificado TLS gerados com sucesso",
       "title": "Chave TLS do Servidor Seguro"
     },
     "importCertificate": "Importar cert.",
@@ -800,25 +813,25 @@
   },
   "stores": {
     "user": {
-      "currentSecurityServerNotFound": "Falha ao determinar as informações do Servidor Seguro atual. A resposta da API é inválida."
+      "currentSecurityServerNotFound": "Não foi possível obter as informações do Servidor Seguro atual. A resposta da API é inválida."
     }
   },
   "systemParameters": {
     "approvedCertificateAuthorities": {
       "table": {
         "header": {
+          "acmeIpAddresses": "IP do Servidor ACME",
           "distinguishedName": "Titular do Certificado (DN)",
           "expires": "Expira em",
-          "ocspResponse": "Resposta OCSP",
-          "acmeIpAddresses": "IP do Servidor ACME"
+          "ocspResponse": "Resposta OCSP"
         },
         "notAvailable": "N/D",
         "ocspResponse": {
           "NOT_AVAILABLE": "N/D",
-          "OCSP_RESPONSE_GOOD": "Válido",
-          "OCSP_RESPONSE_REVOKED": "Revogado",
-          "OCSP_RESPONSE_SUSPENDED": "Suspenso",
-          "OCSP_RESPONSE_UNKNOWN": "Desconhecido"
+          "OCSP_RESPONSE_GOOD": "Válida",
+          "OCSP_RESPONSE_REVOKED": "Revogada",
+          "OCSP_RESPONSE_SUSPENDED": "Suspensa",
+          "OCSP_RESPONSE_UNKNOWN": "Desconhecida"
         }
       },
       "title": "Autoridades Certificadoras Aprovadas"
@@ -827,7 +840,7 @@
       "action": {
         "download": "Baixar",
         "upload": {
-          "button": "Carregar",
+          "button": "Enviar",
           "dialog": {
             "confirmation": "Continuar com a importação?",
             "field": {
@@ -835,7 +848,7 @@
               "hash": "Hash (SHA-224)"
             },
             "info": "Detalhes da âncora de configuração:",
-            "success": "Âncora de configuração carregada",
+            "success": "Âncora de configuração enviada com sucesso",
             "title": "Confirmar detalhes da âncora de configuração"
           }
         }
@@ -848,14 +861,23 @@
       },
       "title": "Âncora de Configuração"
     },
+    "securityServer": {
+      "addressChangeInProgress": "MUDANÇA EM ANDAMENTO",
+      "editDialog": {
+        "title": "Editar endereço do Servidor Seguro"
+      },
+      "securityServer": "Servidor Seguro",
+      "serverAddress": "Endereço do servidor",
+      "updateSubmitted": "Alteração de endereço do Servidor Seguro enviada com sucesso"
+    },
     "timestampingServices": {
       "action": {
         "add": {
           "button": "Adicionar",
           "dialog": {
-            "info": "Serviços de Timestamp confiáveis:",
-            "success": "Serviço de Timestamp adicionado",
-            "title": "Adicionar Serviço de Timestamp"
+            "info": "Serviços confiáveis de Carimbo do Tempo:",
+            "success": "Serviço de Carimbo do Tempo adicionado",
+            "title": "Adicionar Serviço de Carimbo do Tempo"
           }
         }
       },
@@ -864,140 +886,133 @@
           "delete": {
             "button": "Excluir",
             "confirmation": {
-              "text": "Tem certeza de que deseja excluir o serviço de carimbo de tempo?",
+              "text": "Tem certeza de que deseja excluir este serviço de carimbo do tempo?",
               "title": "Tem certeza?"
             },
-            "success": "Serviço de carimbo de tempo excluído com sucesso"
+            "success": "Serviço de Carimbo do Tempo excluído com sucesso"
           }
         },
         "header": {
           "serviceURL": "URL do Serviço",
-          "timestampingService": "Serviço de carimbo de tempo"
+          "timestampingService": "Serviço de Carimbo do Tempo"
         }
       },
-      "title": "Serviços de carimbo de tempo"
+      "title": "Serviços de Carimbo do Tempo"
     },
-    "securityServer": {
-      "securityServer": "Servidor Seguro",
-      "serverAddress": "Endereço do Servidor",
-      "editDialog": {
-        "title": "Editar endereço do Servidor Seguro"
+    "title": "Parâmetros do Sistema"
+  },
+    "tab": {
+      "client": {
+        "details": "Detalhes",
+        "internalServers": "Servidores internos",
+        "localGroups": "Grupos locais",
+        "serviceClients": "Clientes de serviço",
+        "services": "Serviços"
       },
-      "addressChangeInProgress": "ALTERAÇÃO EM ANDAMENTO",
-      "updateSubmitted": "Alteração de endereço do Servidor Seguro enviada com sucesso"
-    },
-    "title": "Parâmetros do sistema"
-  },
-  "tab": {
-    "client": {
-      "details": "Detalhes",
-      "internalServers": "Servidores internos",
-      "localGroups": "Grupos locais",
-      "serviceClients": "Clientes de serviço",
-      "services": "Serviços"
-    },
-    "keys": {
-      "apiKey": "Chaves API",
-      "signAndAuthKeys": "Chaves SIGN e AUTH",
-      "ssTlsCertificate": "Chave TLS do Servidor Seguro"
-    },
-    "main": {
-      "clients": "Clientes",
-      "diagnostics": "Diagnósticos",
-      "keys": "Chaves e certificados",
-      "settings": "Configurações"
-    },
-    "services": {
-      "endpoints": "Endpoints",
-      "parameters": "Parâmetros do Serviço"
-    },
-    "settings": {
-      "backupAndRestore": "Backup e Restauração",
-      "systemParameters": "Parâmetros do Sistema"
-    }
-  },
-  "token": {
-    "changePin": "Alterar PIN",
-    "pinChanged": "PIN do token alterado – faça login no token com o novo PIN",
-    "tokenPinPolicyHeader": "A política de PIN do Token está ativada.",
-    "tokenPinPolicy": "O PIN do token de software deve conter pelo menos 10 caracteres ASCII de, no mínimo, três classes de caracteres (letras minúsculas, letras maiúsculas, dígitos, caracteres especiais)."
-  },
-  "toolbar": {
-    "securityServerNodeType": {
-      "undefined": "",
-      "PRIMARY": "Nó primário",
-      "SECONDARY": "Nó secundário"
-    }
-  },
-  "validationError": {
-    "IdentifierChars": "Caracteres inválidos no identificador"
-  },
-  "wizard": {
-    "addClientTitle": "Adicionar cliente",
-    "addMemberTitle": "Adicionar membro",
-    "addSubsystemTitle": "Adicionar subsistema",
-    "client": {
-      "addClient": "Adicionar Cliente",
-      "clientExists": "Cliente já existe",
-      "memberClassTooltip": "Código que identifica a classe do membro (ex.: agência governamental, empresa privada etc.).",
-      "memberCodeTooltip": "Código do membro que identifica exclusivamente este membro do X-Road dentro de sua classe (ex.: ID comercial).",
-      "memberNameTooltip": "Nome da organização do membro.",
-      "register": "Registrar cliente",
-      "searchLabel": "Cliente",
-      "subsystemCodeTooltip": "Código do subsistema que identifica um sistema de informação pertencente ao membro."
-    },
-    "clientDetails": "Detalhes do Cliente",
-    "clientInfo1": "Especifique os detalhes do Cliente que deseja adicionar.",
-    "clientInfo2": "Se o Cliente já existir, você pode selecioná-lo na lista Global.",
-    "finish": {
-      "acme": {
-        "infoLine": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes, e a nova chave e certificado aparecerão na visualização de Chaves e Certificados. O certificado será solicitado ao Servidor ACME da AC e importado automaticamente. Depois disso, você poderá registrar o novo cliente."
+      "keys": {
+        "apiKey": "Chaves de API",
+        "signAndAuthKeys": "Chaves SIGN e AUTH",
+        "ssTlsCertificate": "Chave TLS do Servidor Seguro"
       },
-      "infoLine1": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes, e a nova chave e CSR aparecerão na visualização de Chaves e Certificados.",
-      "infoLine2": "Para registrar o novo cliente, conclua os seguintes passos:",
-      "note": "NOTA: se você clicar em Cancelar, todos os dados serão perdidos",
-      "title": "Concluir",
-      "todo1": "1) Envie o CSR para uma Autoridade Certificadora para assinatura",
-      "todo2": "2) Após receber de volta, importe o certificado resultante para a chave correspondente",
-      "todo3": "3) Neste ponto, você pode registrar o novo cliente"
+      "main": {
+        "clients": "Clientes",
+        "diagnostics": "Diagnósticos",
+        "keys": "Chaves e certificados",
+        "settings": "Configurações"
+      },
+      "services": {
+        "endpoints": "Endpoints",
+        "parameters": "Parâmetros do Serviço"
+      },
+      "settings": {
+        "backupAndRestore": "Backup e Restauração",
+        "systemParameters": "Parâmetros do Sistema"
+      }
     },
-    "member": {
-      "info1": "Especifique os detalhes do Membro que deseja adicionar.",
-      "info2": "Se o Membro já existir, você pode selecioná-lo na lista Global.",
-      "memberExists": "Membro já existe",
-      "register": "Registrar membro",
-      "searchLabel": "Membro",
-      "select": "Selecionar membro",
-      "title": "Detalhes do Membro"
-    },
-    "memberClass": "Classe do Membro",
-    "memberCode": "Código do Membro",
-    "memberName": "Nome do Membro",
-    "selectClient": "Selecionar Cliente",
-    "selectMemberClass": "Selecionar Classe do Membro",
-    "signKey": {
-      "info": "Você pode definir um Descrição para a nova chave SIGN criada (opcional)",
-      "keyLabel": "Descrição da Chave",
-      "title": "Chave SIGN"
-    },
-    "subsystem": {
-      "info1": "Especifique o código do subsistema a ser adicionado.",
-      "info2": "Se o subsistema já existir, você pode selecioná-lo na lista Global.",
-      "registerSubsystem": "Registrar subsistema",
-      "searchLabel": "Subsistema",
-      "selectSubsystem": "Selecionar Subsistema",
-      "subsystemAdded": "Subsistema adicionado",
-      "subsystemExists": "Subsistema já existe"
-    },
-    "subsystemCode": "Código do Subsistema",
     "token": {
-      "info": "Selecione o token onde deseja adicionar a chave SIGN para o novo Cliente. Nota: o token deve estar no estado Conectado.",
-      "loggedIn": "Conectado",
-      "title": "Token",
-      "tokenName": "Nome do Token"
+      "changePin": "Alterar PIN",
+      "pinChanged": "PIN do token alterado – faça login com o novo PIN",
+      "tokenPinPolicy": "O PIN do token de software deve conter pelo menos 10 caracteres ASCII, abrangendo ao menos três classes de caracteres (letras minúsculas, letras maiúsculas, números e caracteres especiais).",
+      "tokenPinPolicyHeader": "Política de PIN do Token ativada."
     },
-    "warning": {
-      "unregistered_member": "Membro não registrado"
+    "toolbar": {
+      "securityServerNodeType": {
+        "PRIMARY": "Nó primário",
+        "SECONDARY": "Nó secundário",
+        "undefined": ""
+      }
+    },
+    "validationError": {
+      "IdentifierChars": "caracteres inválidos no identificador"
+    },
+    "wizard": {
+      "addClientTitle": "Adicionar cliente",
+      "addMemberTitle": "Adicionar membro",
+      "addSubsystemTitle": "Adicionar subsistema",
+      "client": {
+        "addClient": "Adicionar Cliente",
+        "clientExists": "Cliente já existe",
+        "memberClassTooltip": "Código que identifica a classe do membro (ex: órgão governamental, empresa privada etc.).",
+        "memberCodeTooltip": "Código do membro que o identifica de forma única dentro da sua classe (ex: CNPJ).",
+        "memberNameTooltip": "Nome da organização do membro.",
+        "register": "Registrar cliente",
+        "searchLabel": "Cliente",
+        "subsystemCodeTooltip": "Código do subsistema que identifica um sistema de informação pertencente ao membro.",
+        "subsystemNameTooltip": "Nome do sistema de informação pertencente ao membro."
+      },
+      "clientDetails": "Detalhes do cliente",
+      "clientInfo1": "Informe os dados do cliente que deseja adicionar.",
+      "clientInfo2": "Se o cliente já existir, você pode selecioná-lo na lista global.",
+      "finish": {
+        "acme": {
+          "infoLine": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes e a nova chave e certificado aparecerão na visualização de Chaves e Certificados. O certificado será solicitado ao servidor ACME da AC e importado automaticamente. Depois, você poderá registrar o novo cliente."
+        },
+        "infoLine1": "Todas as informações necessárias foram coletadas. Ao clicar em \"Enviar\", o novo cliente será adicionado à lista de Clientes e a nova chave e CSR aparecerão na visualização de Chaves e Certificados.",
+        "infoLine2": "Para registrar o novo cliente, siga os passos abaixo:",
+        "note": "OBS: se clicar em Cancelar, todos os dados serão perdidos",
+        "title": "Finalizar",
+        "todo1": "1) Envie o CSR para uma Autoridade Certificadora",
+        "todo2": "2) Após o recebimento, importe o certificado resultante para a chave correspondente",
+        "todo3": "3) Agora você pode registrar o novo cliente"
+      },
+      "member": {
+        "info1": "Informe os dados do membro que deseja adicionar.",
+        "info2": "Se o membro já existir, você pode selecioná-lo na lista global.",
+        "memberExists": "Membro já existe",
+        "register": "Registrar membro",
+        "searchLabel": "Membro",
+        "select": "Selecionar membro",
+        "title": "Detalhes do membro"
+      },
+      "memberClass": "Classe do Membro",
+      "memberCode": "Código do Membro",
+      "memberName": "Nome do Membro",
+      "selectClient": "Selecionar Cliente",
+      "selectMemberClass": "Selecionar Classe do Membro",
+      "signKey": {
+        "info": "Você pode definir um rótulo para a nova chave SIGN (opcional)",
+        "keyLabel": "Rótulo da Chave",
+        "title": "Chave de Assinatura"
+      },
+      "subsystem": {
+        "info1": "Informe o código do subsistema a ser adicionado.",
+        "info2": "Se o subsistema já existir, você pode selecioná-lo da lista global.",
+        "registerSubsystem": "Registrar subsistema",
+        "searchLabel": "Subsistema",
+        "selectSubsystem": "Selecionar Subsistema",
+        "subsystemAdded": "Subsistema adicionado",
+        "subsystemExists": "Subsistema já existe"
+      },
+      "subsystemCode": "Código do Subsistema",
+      "subsystemName": "Nome do Subsistema",
+      "token": {
+        "info": "Selecione o token onde deseja adicionar a chave SIGN para o novo cliente. Obs: o token deve estar com login ativo.",
+        "loggedIn": "Logado",
+        "title": "Token",
+        "tokenName": "Nome do Token"
+      },
+      "warning": {
+        "unregistered_member": "Membro não registrado"
+      }
     }
   }
-}

--- a/src/security-server/admin-service/ui/src/plugins/i18n.ts
+++ b/src/security-server/admin-service/ui/src/plugins/i18n.ts
@@ -25,8 +25,7 @@
  */
 import { prepareI18n } from '@niis/shared-ui';
 
-export const availableLanguages = ['en', 'es', 'et', 'ru', 'tk'];
-
+export const availableLanguages = ['en', 'es', 'et', 'ru', 'tk','pt']; // adicionado suporte para pt (Português do Brasil)
 export const { i18n, languageHelper } = prepareI18n(loadMessages);
 
 // Fetches all language-specific messages for the given language

--- a/src/shared-ui/src/language-helper.ts
+++ b/src/shared-ui/src/language-helper.ts
@@ -27,8 +27,11 @@
 
 import { createI18n } from 'vue-i18n';
 import merge from 'deepmerge';
+import enSharedMessages from './locales/en.json';
+import ptSharedMessages from './locales/pt.json';  // suporte adicionado para mensagens da interface em pt-BR
+import enValidationMessages from '@vee-validate/i18n/dist/locale/en.json';
+import ptValidationMessages from '@vee-validate/i18n/dist/locale/pt_BR.json'; // suporte adicionado para mensagens de validação em pt-BR (vee-validate)
 import axios from 'axios';
-import { nextTick } from 'vue';
 
 interface MessageLoader {
   (language: string): Promise<any>
@@ -36,21 +39,22 @@ interface MessageLoader {
 
 interface LanguageHelper {
   selectLanguage(language: string): Promise<void>;
-
   loadLanguage(language: string): Promise<void>;
-
   getCurrentLanguage(): string;
 }
 
 export const defaultLanguage = import.meta.env.VITE_I18N_LOCALE || 'en';
 export const defaultFallbackLanguage = import.meta.env.VITE_FALLBACK_LOCALE || defaultLanguage;
 
-export function prepareI18n(...loaders: MessageLoader[]) {
-  const loadedLanguages = new Set();
+export function prepareI18n(fallbackMessages: any, ...loaders: MessageLoader[]) {
+  const loadedLanguages = new Set(defaultLanguage);
 
-  const _loaders = [loadValidationMessages, loadVuetifyMessages, loadSharedMessages, ...loaders];
+  const _loaders = [loadValidationMessages, loadSharedMessages, ...loaders];
 
-  const missingAndFallbackWarn = import.meta.env.VITE_WARN_MISSING_TRANSLATION == 'true';
+  const enMessages = merge.all([{ validation: enValidationMessages }, enSharedMessages, fallbackMessages]) as any;
+  const ptMessages = merge.all([{ validation: ptValidationMessages }, ptSharedMessages]) as any; // combina mensagens de validação e interface para pt-BR
+
+  const missingAndFallbackWarn = import.meta.env.VITE_WARN_MISSING_TRANSLATION === 'true';
 
   const i18n = createI18n({
     legacy: false,
@@ -59,33 +63,31 @@ export function prepareI18n(...loaders: MessageLoader[]) {
     missingWarn: missingAndFallbackWarn,
     fallbackWarn: missingAndFallbackWarn,
     allowComposition: true,
+    messages: {
+      en: enMessages,
+      pt: ptMessages, // suporte adicionado para pt-BR
+    },
   });
-
-  loadLanguage(defaultLanguage);
 
   async function load(language: string) {
     return Promise.all(_loaders.map(loader => loader(language)))
-      .then(msgs => {
-        return msgs
-      })
-      .then((msgs) => merge.all(msgs));
+      .then(msgs => merge.all(msgs));
   }
 
   async function loadLanguage(language: string) {
     if (!loadedLanguages.has(language)) {
       const messages = await load(language);
       i18n.global.setLocaleMessage(language, messages);
-      loadedLanguages.add(language)
+      loadedLanguages.add(language);
     }
-    return nextTick();
   }
 
   async function selectLanguage(language: string) {
     await loadLanguage(language);
     i18n.global.locale.value = language;
 
-    axios.defaults.headers.common['Accept-Language'] = language
-    document.querySelector('html')?.setAttribute('lang', language)
+    axios.defaults.headers.common['Accept-Language'] = language;
+    document.querySelector('html')?.setAttribute('lang', language);
   }
 
   const languageHelper: LanguageHelper = {
@@ -94,7 +96,7 @@ export function prepareI18n(...loaders: MessageLoader[]) {
     getCurrentLanguage() {
       return i18n.global.locale.value;
     },
-  }
+  };
 
   return { i18n, languageHelper };
 }
@@ -104,31 +106,19 @@ async function loadSharedMessages(language: string) {
     const module = await import(`./locales/${language}.json`);
     return module.default;
   } catch (e) {
-    console.warn("Failed to load shared translations for: " + language);
+    console.error("Failed to load translations for: " + language);
     return {};
   }
 }
 
 async function loadValidationMessages(language: string) {
   try {
-    const msg = await import(`../../node_modules/@vee-validate/i18n/dist/locale/${language}.json`);
+    const normalizedLanguage = language === 'pt' ? 'pt_BR' : language; // normaliza 'pt' para 'pt_BR' ao carregar mensagens de validação do vee-validate
+    const msg = await import(`../../node_modules/@vee-validate/i18n/dist/locale/${normalizedLanguage}.json`);
     return { validation: msg.default };
   } catch (e) {
-    console.warn("Failed to load veeValidate translations for: " + language);
-    return {}
-  }
-}
-
-async function loadVuetifyMessages(language: string) {
-  try {
-    const locales = await import('vuetify/locale') as any;
-    if (!locales[language]) {
-      console.warn("Missing Vuetify translations for: " + language);
-    }
-    return { $vuetify: (locales[language] || {}) };
-  } catch (e) {
-    console.warn("Failed to load Vuetify translations for: " + language);
-    return {}
+    console.error("Failed to load validation messages for: " + language);
+    return {};
   }
 }
 

--- a/src/shared-ui/src/locales/pt.json
+++ b/src/shared-ui/src/locales/pt.json
@@ -1,256 +1,276 @@
 {
-  "locals_demo": "Isso está localizado na biblioteca",
-  "type": "Tipo",
-  "warning": "Aviso",
   "action": {
-    "activate": "Ativar",
-    "cancel": "Cancelar",
-    "add": "Adicionar",
-    "addClient": "Adicionar cliente",
-    "addMember": "Adicionar membro",
-    "addSubsystem": "Adicionar subsistema",
-    "close": "Fechar",
-    "confirm": "Confirmar",
-    "continue": "Continuar",
-    "copy": "Copiar",
-    "copyId": "Copiar ID",
-    "delete": "Excluir",
-    "deactivate": "Desativar",
-    "done": "Concluído",
-    "download": "Baixar",
-    "edit": "Editar",
-    "emptySearch": "Sua busca por {msg} não encontrou resultados.",
-    "export": "Exportar",
-    "finish": "Finalizar",
-    "goToFront": "Ir para a página inicial",
-    "next": "Próximo",
-    "no": "Não",
-    "noData": "Sem dados",
+    "activate": "Activate",
+    "add": "Add",
+    "addClient": "Add client",
+    "addMember": "Add member",
+    "addSubsystem": "Add subsystem",
+    "cancel": "Cancel",
+    "close": "Close",
+    "confirm": "Confirm",
+    "continue": "Continue",
+    "copy": "Copy",
+    "copyId": "Copy ID",
+    "deactivate": "Disable",
+    "delete": "Delete",
+    "done": "Done",
+    "download": "Download",
+    "edit": "Edit",
+    "emptySearch": "Your search for {msg} found no results.",
+    "export": "Export",
+    "finish": "Finish",
+    "goToFront": "Go to the front page",
+    "next": "Next",
+    "no": "No",
+    "noData": "No data",
     "ok": "Ok",
-    "previous": "Anterior",
-    "refresh": "Atualizar",
-    "register": "Registrar",
-    "remove": "Remover",
-    "removeAll": "Remover tudo",
-    "restore": "Restaurar",
-    "save": "Salvar",
-    "search": "Pesquisar",
-    "searching": "Pesquisando...",
-    "submit": "Enviar",
-    "unregister": "Cancelar registro",
-    "upload": "Carregar",
-    "yes": "Sim"
+    "previous": "Previous",
+    "refresh": "Refresh",
+    "register": "Register",
+    "remove": "Remove",
+    "removeAll": "Remove All",
+    "restore": "Restore",
+    "save": "Save",
+    "search": "Search",
+    "searching": "Searching...",
+    "submit": "Submit",
+    "unregister": "Unregister",
+    "upload": "Upload",
+    "yes": "Yes"
   },
   "alert": {
-    "count": "Quantidade de erros iguais:",
+    "count": "Amount of same errors:",
     "id": "ID"
   },
   "apiKey": {
     "createApiKey": {
-      "button": "CRIAR CHAVE DE API",
+      "button": "CREATE API KEY",
       "step": {
         "keyDetails": {
-          "apiKey": "Chave de API",
-          "apiKeyID": "ID da chave de API",
-          "assignedRoles": "Papéis atribuídos",
-          "createKeyButton": "Criar Chave",
-          "name": "Detalhes da Chave",
-          "note": "NOTA: salve a chave de API em um local seguro. A chave de API é visível apenas no momento da geração. Ela não será exibida novamente e não poderá ser recuperada posteriormente."
+          "apiKey": "API key",
+          "apiKeyID": "API key ID",
+          "assignedRoles": "Roles assigned",
+          "createKeyButton": "Create Key",
+          "name": "Key Details",
+          "note": "NOTE: save the API key in a secure place. The API key is visible only at the time of key generation. It will not be presented again and cannot be retrieved later."
         },
         "roles": {
-          "description": "Por favor, selecione os papéis associados à chave de API. Os papéis definem as permissões concedidas à chave de API.",
-          "name": "Papéis",
-          "selectRoles": "Selecionar papéis"
+          "description": "Please select the roles associated with the API key. The roles define the permissions granted to the API key.",
+          "name": "Roles",
+          "selectRoles": "Select roles"
         }
       },
-      "success": "Chave de API criada com sucesso",
-      "title": "Criar chave de API"
-    },
-    "role": {
-      "XROAD_REGISTRATION_OFFICER": "Agente de Registro",
-      "XROAD_SECURITY_OFFICER": "Agente de Segurança",
-      "XROAD_SYSTEM_ADMINISTRATOR": "Administrador do Sistema"
+      "success": "API key successfully created",
+      "title": "Create API key"
     },
     "edit": {
-      "roleRemoveOnly": "(remover apenas)"
+      "roleRemoveOnly": "(remove only)"
+    },
+    "role": {
+      "XROAD_REGISTRATION_OFFICER": "Registration Officer",
+      "XROAD_SECURITY_OFFICER": "Security Officer",
+      "XROAD_SYSTEM_ADMINISTRATOR": "System Administrator"
     },
     "table": {
       "action": {
         "edit": {
-          "button": "Editar",
+          "button": "Edit",
           "dialog": {
-            "message": "Papéis associados à chave de API:",
-            "title": "Editar Chave de API (ID: {id})"
+            "message": "Roles associated with the API key:",
+            "title": "Edit API Key (ID: {id})"
           },
-          "success": "Chave de API com ID {id} salva"
+          "success": "API key with ID {id} saved"
         },
         "revoke": {
-          "button": "Revogar chave",
+          "button": "Revoke key",
           "confirmationDialog": {
-            "message": "Tem certeza de que deseja revogar a chave de API com ID {id}?",
-            "title": "Você tem certeza?"
+            "message": "Are you sure you want to revoke the API key with ID {id}?",
+            "title": "Are you sure?"
           },
-          "success": "Chave de API com ID {id} revogada com sucesso"
+          "success": "API key with ID {id} successfully revoked"
         }
       },
       "header": {
         "id": "ID",
-        "roles": "Papéis"
+        "roles": "Roles"
       }
     }
   },
-  "keys": {
-    "gotIt": "Entendido"
-  },
   "backup": {
+    "createBackup": {
+      "button": "Back up config.",
+      "messages": {
+        "localConfWarning": "Warning! The file “/etc/xroad/services/local.conf” used for configuration overrides is deprecated and not included in the backups anymore. The file “/etc/xroad/services/local.properties” should be used instead.",
+        "success": "Backup {file} successfully created"
+      }
+    },
     "deleteBackup": {
       "dialog": {
-        "confirmation": "Tem certeza de que deseja excluir o backup {file}?",
-        "title": "Você tem certeza?"
+        "confirmation": "Are you sure you want to delete backup {file}?",
+        "title": "Are you sure?"
       },
-      "success": "Backup {file} excluído"
+      "success": "Backup {file} deleted"
     },
     "restoreFromBackup": {
       "dialog": {
-        "confirmation": "Tem certeza de que deseja restaurar a partir de {file}?",
-        "title": "Você tem certeza?"
+        "confirmation": "Are you sure you want to restore from {file}?",
+        "title": "Are you sure?"
       },
-      "success": "Configuração restaurada a partir de {file}"
-    },
-    "createBackup": {
-      "button": "Fazer backup da configuração",
-      "messages": {
-        "success": "Backup {file} criado com sucesso",
-        "localConfWarning": "Aviso! O arquivo “/etc/xroad/services/local.conf” usado para sobrescrita de configurações está obsoleto e não é mais incluído nos backups. O arquivo “/etc/xroad/services/local.properties” deve ser usado em seu lugar."
-      }
+      "success": "Configuration restored from {file}"
     },
     "uploadBackup": {
-      "button": "Carregar backup",
+      "button": "Upload backup",
       "confirmationDialog": {
-        "confirmation": "O arquivo {name} já existe, tem certeza de que deseja sobrescrevê-lo?",
-        "title": "Arquivo já existe"
+        "confirmation": "File {name} already exists, are you sure you want to overwrite it?",
+        "title": "File already exists"
       },
-      "success": "Backup {file} carregado com sucesso"
-      }
-    },
-    "cert": {
-      "certificate": "Certificado",
-      "hashInfo": "Hash (SHA-256)",
-      "keyUsage": {
-        "CRL_SIGN": "Assinatura CRL",
-        "DATA_ENCIPHERMENT": "Cifrar Dados",
-        "DECIPHER_ONLY": "Decifrar Somente",
-        "DIGITAL_SIGNATURE": "Assinatura Digital",
-        "ENCIPHER_ONLY": "Cifrar Somente",
-        "KEY_AGREEMENT": "Acordo de Chave",
-        "KEY_CERT_SIGN": "Assinatura de Certificado",
-        "KEY_ENCIPHERMENT": "Cifrar Chave",
-        "NON_REPUDIATION": "Não Repúdio"
-      },
-      "rsaExp": "Expoente da Chave Pública RSA",
-      "rsaModulus": "Módulo da Chave Pública RSA",
-      "ecParameters": "Parâmetros da Chave Pública EC",
-      "ecPoint": "Ponto da Chave Pública EC"
-    },
-    "error_code": {
-      "api_key_not_found": "Chave de API não encontrada",
-      "backup_file_not_found": "Backup não encontrado",
-      "backup_generation_failed": "Falha ao gerar o backup",
-      "backup_restore_interrupted": "A restauração do backup foi interrompida",
-      "generate_backup_interrupted": "A geração do backup foi interrompida",
-      "internal_error": "Erro interno. Consulte os logs do servidor para mais detalhes",
-      "invalid_backup_file": "Arquivo de backup inválido",
-      "invalid_distinguished_name": "Nome diferenciado inválido",
-      "invalid_filename": "Nome de arquivo inválido",
-      "resource_read_failed": "Falha ao ler o recurso",
-      "restore_process_failed": "Falha no processo de restauração",
-      "token_fetch_failed": "Erro ao buscar tokens.",
-      "token_not_found": "Token não encontrado.",
-      "validation_failure": "Falha de validação"
-    },
-    "fields": {
-      "password": "Senha",
-      "username": "Usuário da Biblioteca",
-      "shared": "biblioteca_compartilhada",
-      "code": "Código",
-      "description": "Descrição",
-      "memberClass": "Classe de Membro",
-      "securityServerCode": "Código do Servidor Seguro "
-    },
-    "footer": {
-      "copyright": {
-        "company": "X-Road Tecnologia LTDA.",
-        "licenceInfo": "Informações da licença",
-        "title": "Copyright"
-      },
-      "software": {
-        "feedback": "Feedback",
-        "title": "Software",
-        "versionPrefix": "X-Road"
-      }
-    },
-    "global": {
-      "all": "Todos",
-      "name": "Nome"
-    },
-    "login": {
-      "errorMsg401": "Usuário ou senha incorretos",
-      "generalError": "Falha no login. Por favor, tente novamente.",
-      "logIn": "Entrar",
-      "logOut": "Sair"
-    },
-    "logout": {
-      "idleWarning": "Você esteve inativo por 30 minutos e sua sessão expirou. Por motivos de segurança, você será desconectado.",
-      "sessionExpired": "Sessão expirada"
-    },
-    "meta": {
-      "check_signer_logs": "Por favor, verifique o log do assinador para detalhes."
-    },
-    "noData": {
-      "loading": "Carregando... Por favor, aguarde",
-      "noBackups": "Ainda não há backups",
-      "noCertificate": "Nenhum certificado",
-      "noCertificates": "Nenhum certificado",
-      "noData": "Sem dados",
-      "noMatches": "Nenhum item correspondente aos critérios",
-      "noServices": "Nenhum serviço",
-      "noTokens": "Nenhum token"
-    },
-    "validationError": {
-      "AssertFalse": "o valor deve ser 'falso'",
-      "AssertTrue": "o valor deve ser 'verdadeiro'",
-      "DecimalMax": "o valor numérico excede o máximo permitido",
-      "DecimalMin": "o valor numérico está abaixo do mínimo permitido",
-      "Digits": "o valor deve conter apenas dígitos",
-      "Email": "o valor não corresponde ao formato de email",
-      "Future": "o valor da data deve estar no futuro",
-      "FutureOrPresent": "o valor da data deve ser agora ou no futuro",
-      "Max": "o valor numérico excede o máximo permitido",
-      "Min": "o valor numérico está abaixo do mínimo permitido",
-      "Negative": "o valor numérico deve ser menor que zero",
-      "NegativeOrZero": "o valor numérico deve ser menor ou igual a zero",
-      "NoBackslashes": "o valor não deve conter o símbolo de barra invertida (\\)",
-      "NoColons": "o valor não deve conter o símbolo de dois pontos (:)",
-      "NoForwardslashes": "o valor não deve conter o símbolo de barra (/)",
-      "NoPercents": "o valor não deve conter o símbolo de porcentagem (%)",
-      "NoSemicolons": "o valor não deve conter o símbolo de ponto e vírgula (;)",
-      "Normalized": "o valor deve ser normalizado",
-      "NotBlank": "o valor não deve estar em branco",
-      "NotEmpty": "o valor não deve estar vazio",
-      "NotNull": "o valor é obrigatório",
-      "Null": "o valor não deve estar definido",
-      "Past": "o valor da data deve estar no passado",
-      "PastOrPresent": "o valor da data deve ser agora ou no passado",
-      "Pattern": "o valor não corresponde ao formato exigido",
-      "Positive": "o valor numérico deve ser maior que zero",
-      "PositiveOrZero": "o valor numérico deve ser maior ou igual a zero",
-      "Size": "o valor não atende aos requisitos de comprimento",
-      "ValidHostAddress": "É necessário um nome de domínio totalmente qualificado válido (ex. host.exemplo.org) ou endereço IP público (ex. 192.168.123.123)",
-      "ValidHostAddressField": "É necessário um endereço IP ou nome de domínio totalmente qualificado válido"
-    },
-    "validation": {
-      "messages": {
-        "address": "O campo {field} contém caracteres inválidos"
+      "success": "Backup {file} uploaded successfully"
     }
-  }
+  },
+  "cert": {
+    "certificate": "Certificate",
+    "ecParameters": "EC Public Key Parameters",
+    "ecPoint": "EC Public Key Point",
+    "hashInfo": "Hash (SHA-256)",
+    "keyUsage": {
+      "CRL_SIGN": "CRL Sign",
+      "DATA_ENCIPHERMENT": "Data Encipherment",
+      "DECIPHER_ONLY": "Decipher Only",
+      "DIGITAL_SIGNATURE": "Digital Signature",
+      "ENCIPHER_ONLY": "Encipher Only",
+      "KEY_AGREEMENT": "Key Agreement",
+      "KEY_CERT_SIGN": "Certificate Sign",
+      "KEY_ENCIPHERMENT": "Key Encipherment",
+      "NON_REPUDIATION": "Non Repudiation"
+    },
+    "rsaExp": "RSA Public Key Exponent",
+    "rsaModulus": "RSA Public Key Modulus"
+  },
+  "error_code": {
+    "api_key_not_found": "API key not found",
+    "backup_file_not_found": "Backup was not found",
+    "backup_generation_failed": "Failed to generate backup",
+    "backup_restore_interrupted": "Backup restoration has been interrupted",
+    "core": {
+      "Signer": {
+        "CertNotFound": "Certification is not found",
+        "KeyNotFound": "Key is not found",
+        "NetworkError": "Signer is not currently reachable.",
+        "PinIncorrect": "Invalid PIN",
+        "TokenNotAvailable": "Token is not available",
+        "TokenNotFound": "Token is not found",
+        "UnknownMember": "X-Road core - signer: Unknown member"
+      }
+    },
+    "generate_backup_interrupted": "Backup generation has been interrupted",
+    "internal_error": "Internal error. See server logs for more details",
+    "invalid_backup_file": "Invalid backup file",
+    "invalid_certificate": "Invalid X.509 certificate",
+    "invalid_distinguished_name": "Distinguished name is invalid",
+    "invalid_filename": "Invalid filename",
+    "resource_read_failed": "Failed to read resource",
+    "restore_process_failed": "Restore process failed",
+    "token_fetch_failed": "Error getting tokens.",
+    "token_not_found": "Token not found.",
+    "token_weak_pin": "The provided pin code was too weak",
+    "tr": {
+      "check_signer_logs": "Please check the signer log for details.",
+      "code": "Code: {0}",
+      "pin_min_char_classes_count": "PIN minimum character classes count: {0}",
+      "pin_min_length": "PIN minimum length: {0}"
+    },
+    "validation_failure": "Validation failure"
+  },
+  "fields": {
+    "code": "Code",
+    "description": "Description",
+    "memberClass": "Member Class",
+    "password": "Password",
+    "securityServerCode": "Security Server Code",
+    "shared": "sharedlib",
+    "subsystemName": "Subsystem Name",
+    "username": "LIB-Username"
+  },
+  "footer": {
+    "copyright": {
+      "company": "Nordic Institute for Interoperability Solutions (NIIS)",
+      "licenceInfo": "Licence info",
+      "title": "Copyright"
+    },
+    "software": {
+      "feedback": "Feedback",
+      "title": "Software",
+      "versionPrefix": "X-Road"
+    }
+  },
+  "global": {
+    "all": "All",
+    "name": "Name"
+  },
+  "keys": {
+    "gotIt": "Got it",
+    "token": {
+      "label": "Token:"
+    }
+  },
+  "locals_demo": "This is localised in library",
+  "login": {
+    "errorMsg401": "Wrong username or password",
+    "generalError": "Login failed. Please try again.",
+    "logIn": "Log in",
+    "logOut": "Log out"
+  },
+  "logout": {
+    "idleWarning": "You have been idle for 30 minutes and your session has expired. For security reasons, you will be logged out.",
+    "sessionExpired": "Session expired"
+  },
+  "noData": {
+    "loading": "Loading... Please wait",
+    "noBackups": "No backups yet",
+    "noCertificate": "No certificate",
+    "noCertificates": "No certificates",
+    "noData": "No data",
+    "noMatches": "No items matching criteria",
+    "noServices": "No services",
+    "noTokens": "No tokens"
+  },
+  "type": "Type",
+  "validation": {
+    "messages": {
+      "address": "The {field} field contains invalid characters"
+    }
+  },
+  "validationError": {
+    "AssertFalse": "value should be 'false'",
+    "AssertTrue": "value should be 'true'",
+    "DecimalMax": "numeric value exceeds the maximum allowed",
+    "DecimalMin": "numeric value is under the minimum allowed",
+    "Digits": "value should contain only digits",
+    "Email": "value does not meet the email format",
+    "Future": "datetime value should be in the future",
+    "FutureOrPresent": "datetime value should be now or in the future",
+    "Max": "numeric value exceeds the maximum allowed",
+    "Min": "numeric value is under the minimum allowed",
+    "Negative": "numeric value should be less than zero",
+    "NegativeOrZero": "numeric value should be less or equal to zero",
+    "NoBackslashes": "value should not contain backslash (\\) symbols",
+    "NoColons": "value should not contain colon (:) symbols",
+    "NoForwardslashes": "value should not contain forward slash (/) symbols",
+    "NoPercents": "value should not contain percentage (%) symbols",
+    "NoSemicolons": "value should not contain semicolon (;) symbols",
+    "Normalized": "value should be normalized",
+    "NotBlank": "value should not be blank",
+    "NotEmpty": "value should not be empty",
+    "NotNull": "value is required",
+    "Null": "value should not be set",
+    "Past": "datetime value should be in the past",
+    "PastOrPresent": "datetime value should be now or in the past",
+    "Pattern": "value did not match the required format",
+    "Positive": "numeric value should be greater that zero",
+    "PositiveOrZero": "numeric value should be greater or equal to zero",
+    "Size": "value does not meet length requirements",
+    "ValidHostAddress": "Valid fully qualified domain name (e.g. host.example.org) or public IP address (eg. 192.168.123.123) needed",
+    "ValidHostAddressField": "Valid IP address or fully qualified domain name needed"
+  },
+  "warning": "Warning"
 }

--- a/src/shared-ui/src/locales/pt.json
+++ b/src/shared-ui/src/locales/pt.json
@@ -1,0 +1,256 @@
+{
+  "locals_demo": "Isso está localizado na biblioteca",
+  "type": "Tipo",
+  "warning": "Aviso",
+  "action": {
+    "activate": "Ativar",
+    "cancel": "Cancelar",
+    "add": "Adicionar",
+    "addClient": "Adicionar cliente",
+    "addMember": "Adicionar membro",
+    "addSubsystem": "Adicionar subsistema",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "continue": "Continuar",
+    "copy": "Copiar",
+    "copyId": "Copiar ID",
+    "delete": "Excluir",
+    "deactivate": "Desativar",
+    "done": "Concluído",
+    "download": "Baixar",
+    "edit": "Editar",
+    "emptySearch": "Sua busca por {msg} não encontrou resultados.",
+    "export": "Exportar",
+    "finish": "Finalizar",
+    "goToFront": "Ir para a página inicial",
+    "next": "Próximo",
+    "no": "Não",
+    "noData": "Sem dados",
+    "ok": "Ok",
+    "previous": "Anterior",
+    "refresh": "Atualizar",
+    "register": "Registrar",
+    "remove": "Remover",
+    "removeAll": "Remover tudo",
+    "restore": "Restaurar",
+    "save": "Salvar",
+    "search": "Pesquisar",
+    "searching": "Pesquisando...",
+    "submit": "Enviar",
+    "unregister": "Cancelar registro",
+    "upload": "Carregar",
+    "yes": "Sim"
+  },
+  "alert": {
+    "count": "Quantidade de erros iguais:",
+    "id": "ID"
+  },
+  "apiKey": {
+    "createApiKey": {
+      "button": "CRIAR CHAVE DE API",
+      "step": {
+        "keyDetails": {
+          "apiKey": "Chave de API",
+          "apiKeyID": "ID da chave de API",
+          "assignedRoles": "Papéis atribuídos",
+          "createKeyButton": "Criar Chave",
+          "name": "Detalhes da Chave",
+          "note": "NOTA: salve a chave de API em um local seguro. A chave de API é visível apenas no momento da geração. Ela não será exibida novamente e não poderá ser recuperada posteriormente."
+        },
+        "roles": {
+          "description": "Por favor, selecione os papéis associados à chave de API. Os papéis definem as permissões concedidas à chave de API.",
+          "name": "Papéis",
+          "selectRoles": "Selecionar papéis"
+        }
+      },
+      "success": "Chave de API criada com sucesso",
+      "title": "Criar chave de API"
+    },
+    "role": {
+      "XROAD_REGISTRATION_OFFICER": "Agente de Registro",
+      "XROAD_SECURITY_OFFICER": "Agente de Segurança",
+      "XROAD_SYSTEM_ADMINISTRATOR": "Administrador do Sistema"
+    },
+    "edit": {
+      "roleRemoveOnly": "(remover apenas)"
+    },
+    "table": {
+      "action": {
+        "edit": {
+          "button": "Editar",
+          "dialog": {
+            "message": "Papéis associados à chave de API:",
+            "title": "Editar Chave de API (ID: {id})"
+          },
+          "success": "Chave de API com ID {id} salva"
+        },
+        "revoke": {
+          "button": "Revogar chave",
+          "confirmationDialog": {
+            "message": "Tem certeza de que deseja revogar a chave de API com ID {id}?",
+            "title": "Você tem certeza?"
+          },
+          "success": "Chave de API com ID {id} revogada com sucesso"
+        }
+      },
+      "header": {
+        "id": "ID",
+        "roles": "Papéis"
+      }
+    }
+  },
+  "keys": {
+    "gotIt": "Entendido"
+  },
+  "backup": {
+    "deleteBackup": {
+      "dialog": {
+        "confirmation": "Tem certeza de que deseja excluir o backup {file}?",
+        "title": "Você tem certeza?"
+      },
+      "success": "Backup {file} excluído"
+    },
+    "restoreFromBackup": {
+      "dialog": {
+        "confirmation": "Tem certeza de que deseja restaurar a partir de {file}?",
+        "title": "Você tem certeza?"
+      },
+      "success": "Configuração restaurada a partir de {file}"
+    },
+    "createBackup": {
+      "button": "Fazer backup da configuração",
+      "messages": {
+        "success": "Backup {file} criado com sucesso",
+        "localConfWarning": "Aviso! O arquivo “/etc/xroad/services/local.conf” usado para sobrescrita de configurações está obsoleto e não é mais incluído nos backups. O arquivo “/etc/xroad/services/local.properties” deve ser usado em seu lugar."
+      }
+    },
+    "uploadBackup": {
+      "button": "Carregar backup",
+      "confirmationDialog": {
+        "confirmation": "O arquivo {name} já existe, tem certeza de que deseja sobrescrevê-lo?",
+        "title": "Arquivo já existe"
+      },
+      "success": "Backup {file} carregado com sucesso"
+      }
+    },
+    "cert": {
+      "certificate": "Certificado",
+      "hashInfo": "Hash (SHA-256)",
+      "keyUsage": {
+        "CRL_SIGN": "Assinatura CRL",
+        "DATA_ENCIPHERMENT": "Cifrar Dados",
+        "DECIPHER_ONLY": "Decifrar Somente",
+        "DIGITAL_SIGNATURE": "Assinatura Digital",
+        "ENCIPHER_ONLY": "Cifrar Somente",
+        "KEY_AGREEMENT": "Acordo de Chave",
+        "KEY_CERT_SIGN": "Assinatura de Certificado",
+        "KEY_ENCIPHERMENT": "Cifrar Chave",
+        "NON_REPUDIATION": "Não Repúdio"
+      },
+      "rsaExp": "Expoente da Chave Pública RSA",
+      "rsaModulus": "Módulo da Chave Pública RSA",
+      "ecParameters": "Parâmetros da Chave Pública EC",
+      "ecPoint": "Ponto da Chave Pública EC"
+    },
+    "error_code": {
+      "api_key_not_found": "Chave de API não encontrada",
+      "backup_file_not_found": "Backup não encontrado",
+      "backup_generation_failed": "Falha ao gerar o backup",
+      "backup_restore_interrupted": "A restauração do backup foi interrompida",
+      "generate_backup_interrupted": "A geração do backup foi interrompida",
+      "internal_error": "Erro interno. Consulte os logs do servidor para mais detalhes",
+      "invalid_backup_file": "Arquivo de backup inválido",
+      "invalid_distinguished_name": "Nome diferenciado inválido",
+      "invalid_filename": "Nome de arquivo inválido",
+      "resource_read_failed": "Falha ao ler o recurso",
+      "restore_process_failed": "Falha no processo de restauração",
+      "token_fetch_failed": "Erro ao buscar tokens.",
+      "token_not_found": "Token não encontrado.",
+      "validation_failure": "Falha de validação"
+    },
+    "fields": {
+      "password": "Senha",
+      "username": "Usuário da Biblioteca",
+      "shared": "biblioteca_compartilhada",
+      "code": "Código",
+      "description": "Descrição",
+      "memberClass": "Classe de Membro",
+      "securityServerCode": "Código do Servidor Seguro "
+    },
+    "footer": {
+      "copyright": {
+        "company": "X-Road Tecnologia LTDA.",
+        "licenceInfo": "Informações da licença",
+        "title": "Copyright"
+      },
+      "software": {
+        "feedback": "Feedback",
+        "title": "Software",
+        "versionPrefix": "X-Road"
+      }
+    },
+    "global": {
+      "all": "Todos",
+      "name": "Nome"
+    },
+    "login": {
+      "errorMsg401": "Usuário ou senha incorretos",
+      "generalError": "Falha no login. Por favor, tente novamente.",
+      "logIn": "Entrar",
+      "logOut": "Sair"
+    },
+    "logout": {
+      "idleWarning": "Você esteve inativo por 30 minutos e sua sessão expirou. Por motivos de segurança, você será desconectado.",
+      "sessionExpired": "Sessão expirada"
+    },
+    "meta": {
+      "check_signer_logs": "Por favor, verifique o log do assinador para detalhes."
+    },
+    "noData": {
+      "loading": "Carregando... Por favor, aguarde",
+      "noBackups": "Ainda não há backups",
+      "noCertificate": "Nenhum certificado",
+      "noCertificates": "Nenhum certificado",
+      "noData": "Sem dados",
+      "noMatches": "Nenhum item correspondente aos critérios",
+      "noServices": "Nenhum serviço",
+      "noTokens": "Nenhum token"
+    },
+    "validationError": {
+      "AssertFalse": "o valor deve ser 'falso'",
+      "AssertTrue": "o valor deve ser 'verdadeiro'",
+      "DecimalMax": "o valor numérico excede o máximo permitido",
+      "DecimalMin": "o valor numérico está abaixo do mínimo permitido",
+      "Digits": "o valor deve conter apenas dígitos",
+      "Email": "o valor não corresponde ao formato de email",
+      "Future": "o valor da data deve estar no futuro",
+      "FutureOrPresent": "o valor da data deve ser agora ou no futuro",
+      "Max": "o valor numérico excede o máximo permitido",
+      "Min": "o valor numérico está abaixo do mínimo permitido",
+      "Negative": "o valor numérico deve ser menor que zero",
+      "NegativeOrZero": "o valor numérico deve ser menor ou igual a zero",
+      "NoBackslashes": "o valor não deve conter o símbolo de barra invertida (\\)",
+      "NoColons": "o valor não deve conter o símbolo de dois pontos (:)",
+      "NoForwardslashes": "o valor não deve conter o símbolo de barra (/)",
+      "NoPercents": "o valor não deve conter o símbolo de porcentagem (%)",
+      "NoSemicolons": "o valor não deve conter o símbolo de ponto e vírgula (;)",
+      "Normalized": "o valor deve ser normalizado",
+      "NotBlank": "o valor não deve estar em branco",
+      "NotEmpty": "o valor não deve estar vazio",
+      "NotNull": "o valor é obrigatório",
+      "Null": "o valor não deve estar definido",
+      "Past": "o valor da data deve estar no passado",
+      "PastOrPresent": "o valor da data deve ser agora ou no passado",
+      "Pattern": "o valor não corresponde ao formato exigido",
+      "Positive": "o valor numérico deve ser maior que zero",
+      "PositiveOrZero": "o valor numérico deve ser maior ou igual a zero",
+      "Size": "o valor não atende aos requisitos de comprimento",
+      "ValidHostAddress": "É necessário um nome de domínio totalmente qualificado válido (ex. host.exemplo.org) ou endereço IP público (ex. 192.168.123.123)",
+      "ValidHostAddressField": "É necessário um endereço IP ou nome de domínio totalmente qualificado válido"
+    },
+    "validation": {
+      "messages": {
+        "address": "O campo {field} contém caracteres inválidos"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces full support for **Brazilian Portuguese (pt-BR)** across all X-Road admin interfaces, including:

- **Shared UI**
  - Added `pt.json`.
  - Updated `language-helper.ts` to support `pt` for UI and `vee-validate` messages.
  
- **Security Server Admin UI**
  - Added `pt.json`.
  - Updated `i18n.ts` including `pt` in `availableLanguages`.

- **Central Server Admin UI**
  - Added `pt.json`.
  - Updated `i18n.ts` including `pt` in `availableLanguages`.

## Additional info
This contribution follows the existing i18n implementation using `vue-i18n`, ensuring English remains the default fallback language.  
All translations were carefully aligned with the existing EN and ET files for consistency.

Tested locally in each module with successful UI and validation message rendering.

## Related issues
N/A

---

## Checklist

- [x] Added `pt.json` in Shared UI, Security Server UI, and Central Server UI.
- [x] Updated `language-helper.ts` in Shared UI to merge UI and validation (`vee-validate`) messages.
- [x] Updated `i18n.ts` in Security and Central Server to include `pt` in `availableLanguages`.
- [x] Confirmed `pt-BR` appears correctly in language selectors.
- [x] Verified validation messages in forms display in `pt-BR`.
- [x] Ensured fallback behavior remains functional to English.
- [x] No backend changes, only frontend i18n enhancements.

---

_Contribution by George Oliveira — Brazil 🇧🇷_
