### PR TITLE
feat: switch to using CODEOWNERS due to reviewers deprecation in dependaboy.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @nordic-institute/xrd-developers
+
+*.md @nordic-institute/xrd-developers @raits @petkivim
+
+.github/CODEOWNERS @raits @petkivim

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,6 @@ updates:
           - "io.opentelemetry.instrumentation*"
           - "org.hibernate*"
           - "com.zaxxer:HikariCP"
-    reviewers:
-      - "nordic-institute/xrd-developers"
   - package-ecosystem: "npm"
     directory: "/src"
     schedule:
@@ -46,8 +44,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    reviewers:
-      - "nordic-institute/xrd-developers"
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
@@ -58,5 +54,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    reviewers:
-      - "nordic-institute/xrd-developers"


### PR DESCRIPTION
Making the change due to https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.

Info on the CODEOWNERS file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

If I understand correctly, this should also mean that all PR-s will automatically get the `xrd-developers` reviewer added to them.

Additionally made it so markdown files need to be also reviewed by me and @petkivim, as those are documentation changes.

Any changes to `CODEOWNERS` itself must always be reviewed by me or @petkivim.