### PR TITLE
fix: MapStruct reports warnings for unmapped fields in MessageRecordMapper

### DIFF
--- a/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/mapper/MessageRecordMapper.java
+++ b/src/addons/messagelog/messagelog-db/src/main/java/ee/ria/xroad/messagelog/database/mapper/MessageRecordMapper.java
@@ -64,8 +64,10 @@ public interface MessageRecordMapper {
     }
 
     @Mapping(target = "messageCipher", ignore = true)
+    @Mapping(target = "attachmentStreams", ignore = true)
     MessageRecord toDTO(MessageRecordEntity source);
 
+    @Mapping(target = "attachmentCipher", ignore = true)
     MessageAttachment toDTO(MessageAttachmentEntity source);
 
     TimestampRecord toDTO(TimestampRecordEntity source);


### PR DESCRIPTION


refs: XRDDEV-2920