### PR TITLE
fix: removed cascading from some hibernate relations

### DIFF
--- a/src/addons/metaservice/src/test/java/org/niis/xroad/proxy/core/serverproxy/MetadataServiceHandlerTest.java
+++ b/src/addons/metaservice/src/test/java/org/niis/xroad/proxy/core/serverproxy/MetadataServiceHandlerTest.java
@@ -660,8 +660,6 @@ public class MetadataServiceHandlerTest {
         ClientEntity client = new ClientEntity();
         client.setConf(conf);
 
-        conf.getClients().add(client);
-
         client.setIdentifier(serviceId.getClientId());
 
         ServiceDescriptionEntity wsdl = new ServiceDescriptionEntity();
@@ -683,6 +681,8 @@ public class MetadataServiceHandlerTest {
         client.getServiceDescriptions().add(wsdl);
 
         doInTransaction(session -> {
+            session.persist(client.getIdentifier());
+            session.persist(client);
             session.persist(conf);
             return null;
         });

--- a/src/addons/metaservice/src/test/java/org/niis/xroad/proxy/core/testsuite/testcases/GetWSDLMessage.java
+++ b/src/addons/metaservice/src/test/java/org/niis/xroad/proxy/core/testsuite/testcases/GetWSDLMessage.java
@@ -147,8 +147,6 @@ public class GetWSDLMessage extends MessageTestCase {
         ClientEntity client = new ClientEntity();
         client.setConf(conf);
 
-        conf.getClients().add(client);
-
         client.setIdentifier(expectedProviderQuery);
 
         ServiceDescriptionEntity wsdl = new ServiceDescriptionEntity();
@@ -166,6 +164,8 @@ public class GetWSDLMessage extends MessageTestCase {
         client.getServiceDescriptions().add(wsdl);
 
         doInTransaction(session -> {
+            session.persist(client.getIdentifier());
+            session.persist(client);
             session.persist(conf);
             return null;
         });

--- a/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/ClientEntity.java
+++ b/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/ClientEntity.java
@@ -72,7 +72,7 @@ public class ClientEntity {
     @JsonIgnore
     private ServerConfEntity conf;
 
-    @ManyToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "identifier")
     private ClientIdEntity identifier;
 
@@ -94,4 +94,9 @@ public class ClientEntity {
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinColumn(name = "client_id")
     private List<EndpointEntity> endpoints = new ArrayList<>();
+
+    public void setConf(ServerConfEntity conf) {
+        this.conf = conf;
+        conf.getClients().add(this);
+    }
 }

--- a/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/GroupMemberEntity.java
+++ b/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/GroupMemberEntity.java
@@ -27,7 +27,6 @@
 package org.niis.xroad.serverconf.impl.entity;
 
 import jakarta.persistence.Access;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -61,7 +60,7 @@ public class GroupMemberEntity {
     @Column(name = "added", nullable = false)
     private Date added;
 
-    @ManyToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "groupmemberid", nullable = false)
     private ClientIdEntity groupMemberId;
 }

--- a/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/ServerConfEntity.java
+++ b/src/lib/serverconf-impl/src/main/java/org/niis/xroad/serverconf/impl/entity/ServerConfEntity.java
@@ -44,7 +44,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static jakarta.persistence.AccessType.FIELD;
 
@@ -69,9 +71,9 @@ public class ServerConfEntity {
     @JoinColumn(name = "owner")
     private ClientEntity owner;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "conf", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "conf")
     @JsonIgnore
-    private List<ClientEntity> clients = new ArrayList<>();
+    private Set<ClientEntity> clients = new HashSet<>();
 
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @OrderBy("id ASC")

--- a/src/lib/serverconf-impl/src/test/java/org/niis/xroad/serverconf/impl/TestUtil.java
+++ b/src/lib/serverconf-impl/src/test/java/org/niis/xroad/serverconf/impl/TestUtil.java
@@ -28,7 +28,6 @@ package org.niis.xroad.serverconf.impl;
 
 import ee.ria.xroad.common.SystemProperties;
 import ee.ria.xroad.common.identifier.ClientId;
-import ee.ria.xroad.common.identifier.LocalGroupId;
 import ee.ria.xroad.common.identifier.ServiceId;
 
 import org.hibernate.Session;
@@ -39,6 +38,7 @@ import org.niis.xroad.serverconf.impl.entity.ClientIdEntity;
 import org.niis.xroad.serverconf.impl.entity.EndpointEntity;
 import org.niis.xroad.serverconf.impl.entity.GroupMemberEntity;
 import org.niis.xroad.serverconf.impl.entity.LocalGroupEntity;
+import org.niis.xroad.serverconf.impl.entity.LocalGroupIdEntity;
 import org.niis.xroad.serverconf.impl.entity.ServerConfEntity;
 import org.niis.xroad.serverconf.impl.entity.ServiceDescriptionEntity;
 import org.niis.xroad.serverconf.impl.entity.ServiceEntity;
@@ -152,12 +152,9 @@ public final class TestUtil {
         for (int i = 0; i < NUM_CLIENTS; i++) {
             ClientEntity client = new ClientEntity();
             client.setConf(conf);
-            conf.getClients().add(client);
-
             if (i == 0) {
                 client.setIdentifier(createClientIdConfEntity());
                 conf.setOwner(client);
-                continue;
             } else {
                 ClientIdEntity id;
                 if (i == NUM_CLIENTS - 1) {
@@ -169,7 +166,11 @@ public final class TestUtil {
                 client.setIdentifier(id);
                 client.setClientStatus(CLIENT_STATUS + i);
             }
-
+            session.persist(client.getIdentifier());
+            session.persist(client);
+            if (i == 0) {
+                continue;
+            }
             switch (i) {
                 case 1:
                     client.setIsAuthentication("SSLAUTH");
@@ -230,15 +231,18 @@ public final class TestUtil {
             client.getAccessRights().add(
                     createAccessRight(endpoint, client.getIdentifier()));
 
-            ClientIdEntity cl = XRoadIdMapper.get().toEntity(ClientId.Conf.create("XX", "memberClass", "memberCode" + i));
+            ClientIdEntity cl = ClientIdEntity.createMember("XX", "memberClass", "memberCode" + i);
+            session.persist(cl);
             client.getAccessRights().add(createAccessRight(endpoint, cl));
 
-            ServiceIdEntity se = XRoadIdMapper.get().toEntity(ServiceId.Conf.create("XX", "memberClass",
-                    "memberCode" + i, "subsystemCode", "serviceCode" + i));
+            ServiceIdEntity se = ServiceIdEntity.create("XX", "memberClass",
+                    "memberCode" + i, "subsystemCode", "serviceCode" + i);
+            session.persist(se);
             client.getAccessRights().add(createAccessRight(endpoint, se));
 
-            LocalGroupId.Conf lg = LocalGroupId.Conf.create("testGroup" + i);
-            client.getAccessRights().add(createAccessRight(endpoint, XRoadIdMapper.get().toEntity(lg)));
+            LocalGroupIdEntity lg = LocalGroupIdEntity.create("testGroup" + i);
+            session.persist(lg);
+            client.getAccessRights().add(createAccessRight(endpoint, lg));
 
             //rest service
             ServiceDescriptionEntity serviceDescription = new ServiceDescriptionEntity();

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiController.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/openapi/ClientsApiController.java
@@ -303,8 +303,8 @@ public class ClientsApiController implements ClientsApi {
     @PreAuthorize("hasAuthority('ADD_LOCAL_GROUP')")
     @AuditEventMethod(event = ADD_LOCAL_GROUP)
     public ResponseEntity<LocalGroupDto> addClientLocalGroup(String id, LocalGroupAddDto localGroupAdd) {
-        Client client = getClientFromDb(id);
-        LocalGroup localGroup = localGroupService.addLocalGroup(client.getIdentifier(),
+        final ClientId clientId = clientIdConverter.convertId(id);
+        LocalGroup localGroup = localGroupService.addLocalGroup(clientId,
                 localGroupConverter.convert(localGroupAdd));
 
         LocalGroupDto createdGroupDto = localGroupConverter.convert(localGroup);

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ClientRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ClientRepository.java
@@ -47,6 +47,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * client repository
@@ -77,9 +78,9 @@ public class ClientRepository extends AbstractRepository<ClientEntity> {
     public List<ClientEntity> getAllLocalClients() {
         ServerConfDAOImpl serverConfDao = new ServerConfDAOImpl();
         ServerConfEntity serverConfEntity = serverConfDao.getConf(persistenceUtils.getCurrentSession());
-        List<ClientEntity> clientEntities = serverConfEntity.getClients();
+        Set<ClientEntity> clientEntities = serverConfEntity.getClients();
         Hibernate.initialize(clientEntities);
-        return clientEntities;
+        return List.copyOf(clientEntities);
     }
 
     /**
@@ -136,5 +137,9 @@ public class ClientRepository extends AbstractRepository<ClientEntity> {
             throw new ClientNotFoundException("Client not found for localGroup with id: " + localGroupEntity.getId());
         }
         return clientEntity;
+    }
+
+    public void remove(ClientEntity client) {
+        persistenceUtils.getCurrentSession().remove(client);
     }
 }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/IdentifierRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/IdentifierRepository.java
@@ -54,7 +54,7 @@ public class IdentifierRepository {
      * Executes a Hibernate persist(XRoadId) for multiple group members
      * @param identifiers identifiers
      */
-    public void persist(Collection<XRoadIdEntity> identifiers) {
+    public void persist(Collection<? extends XRoadIdEntity> identifiers) {
         Session session = persistenceUtils.getCurrentSession();
         for (XRoadIdEntity identifier : identifiers) {
             session.persist(identifier);

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepository.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/repository/ServerConfRepository.java
@@ -54,8 +54,10 @@ public class ServerConfRepository {
 
     /**
      * Save or update ServerConfEntity
+     *
+     * @return managed entity instance
      */
-    public void saveOrUpdate(ServerConfEntity serverConfEntity) {
-        persistenceUtils.getCurrentSession().merge(serverConfEntity);
+    public ServerConfEntity saveOrUpdate(ServerConfEntity serverConfEntity) {
+        return persistenceUtils.getCurrentSession().merge(serverConfEntity);
     }
 }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ClientService.java
@@ -84,6 +84,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.niis.xroad.common.core.exception.ErrorCodes.INVALID_CLIENT_NAME;
@@ -123,6 +124,7 @@ public class ClientService {
     private final GlobalConfService globalConfService;
     private final GlobalConfProvider globalConfProvider;
     private final ServerConfService serverConfService;
+    private final IdentifierService identifierService;
     private final IdentifierRepository identifierRepository;
     private final LocalGroupRepository localGroupRepository;
     private final AccessRightRepository accessRightRepository;
@@ -176,6 +178,15 @@ public class ClientService {
             members.add(ClientId.Conf.create(id.getXRoadInstance(), id.getMemberClass(), id.getMemberCode()));
         }
         return members;
+    }
+
+    Set<ClientId> getAllClientIds() {
+        List<ClientEntity> localClients = getAllLocalClientEntities();
+        List<ClientEntity> globalClients = getAllGlobalClientEntities();
+
+        return Stream.concat(localClients.stream(), globalClients.stream())
+                .map(ClientEntity::getIdentifier)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -763,7 +774,7 @@ public class ClientService {
             throw new InvalidMemberClassException(INVALID_MEMBER_CLASS + memberClass);
         }
 
-        ClientId.Conf clientId = ClientId.Conf.create(globalConfProvider.getInstanceIdentifier(),
+        ClientId clientId = ClientId.Conf.create(globalConfProvider.getInstanceIdentifier(),
                 memberClass,
                 memberCode,
                 subsystemCode);
@@ -777,7 +788,7 @@ public class ClientService {
             throw new ClientAlreadyExistsException("client " + clientId + " already exists");
         }
         if (clientId.getSubsystemCode() == null) {
-            // adding member - check that we dont already have owner + one additional member
+            // adding member - check that we don't already have owner + one additional member
             List<ClientEntity> existingMembers = getAllLocalMemberEntities();
             Optional<ClientEntity> additionalMember = existingMembers.stream()
                     .filter(m -> !ownerId.equals(m.getIdentifier()))
@@ -789,7 +800,7 @@ public class ClientService {
         }
 
         // check if the member associated with clientId exists in global conf
-        ClientId.Conf memberId = clientId.getMemberId();
+        ClientId memberId = clientId.getMemberId();
         if (globalConfProvider.getMemberName(memberId) == null) {
             // unregistered member
             if (!ignoreWarnings) {
@@ -799,25 +810,26 @@ public class ClientService {
         }
 
         boolean clientRegistered = globalConfService.isSecurityServerClientForThisInstance(clientId);
-        ClientEntity client = new ClientEntity();
-        client.setIdentifier(getPossiblyManagedEntity(clientId));
-        if (clientRegistered) {
-            client.setClientStatus(Client.STATUS_REGISTERED);
-        } else {
-            client.setClientStatus(Client.STATUS_SAVED);
-        }
+
+        ClientEntity client = addClient(clientId,
+                serverConfService.getServerConfEntity(),
+                isAuthentication,
+                clientRegistered ? Client.STATUS_REGISTERED : Client.STATUS_SAVED);
         putClientStatusToAudit(client);
 
-        client.setIsAuthentication(isAuthentication.name());
-        ServerConfEntity serverConfEntity = serverConfService.getServerConfEntity();
-        client.setConf(serverConfEntity);
-        serverConfEntity.getClients().add(client);
-
-        ClientEntity persisted = clientRepository.persist(client);
         if (clientId.isSubsystem() && StringUtils.isNotEmpty(subsystemName)) {
             subsystemNameStatus.set(clientId, globalConfProvider.getSubsystemName(clientId), subsystemName);
         }
-        return persisted;
+        return client;
+    }
+
+    ClientEntity addClient(ClientId clientId, ServerConfEntity serverConfEntity, IsAuthentication isAuthentication, String status) {
+        ClientEntity client = new ClientEntity();
+        client.setIdentifier(identifierService.getOrPersistXroadIdEntity(XRoadIdMapper.get().toEntity(clientId)));
+        client.setConf(serverConfEntity);
+        client.setClientStatus(status);
+        client.setIsAuthentication(isAuthentication.name());
+        return clientRepository.persist(client);
     }
 
     /**
@@ -829,19 +841,6 @@ public class ClientService {
         Optional<String> match = globalConfService.getMemberClassesForThisInstance().stream()
                 .filter(mc -> mc.equals(memberClass)).findFirst();
         return match.isPresent();
-    }
-
-    /**
-     * If ClientId already exists in DB, return the managed instance.
-     * Otherwise return transient instance that was given as parameter
-     */
-    private ClientIdEntity getPossiblyManagedEntity(ClientId.Conf transientClientId) {
-        ClientIdEntity managedEntity = identifierRepository.getClientId(transientClientId);
-        if (managedEntity != null) {
-            return managedEntity;
-        } else {
-            return XRoadIdMapper.get().toEntity(transientClientId);
-        }
     }
 
     /**
@@ -879,6 +878,7 @@ public class ClientService {
         if (!serverConfEntity.getClients().remove(clientEntity)) {
             throw new RuntimeException("client to be deleted was somehow missing from server conf");
         }
+        clientRepository.remove(clientEntity);
         identifierRepository.remove(clientEntity.getIdentifier());
     }
 

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/IdentifierService.java
@@ -28,26 +28,19 @@
 package org.niis.xroad.securityserver.restapi.service;
 
 import ee.ria.xroad.common.identifier.XRoadId;
-import ee.ria.xroad.common.identifier.XRoadObjectType;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.niis.xroad.securityserver.restapi.repository.IdentifierRepository;
-import org.niis.xroad.serverconf.impl.entity.ClientEntity;
 import org.niis.xroad.serverconf.impl.entity.XRoadIdEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.groupingBy;
 
 /**
  * service class for handling identifiers
@@ -60,18 +53,17 @@ import static java.util.stream.Collectors.groupingBy;
 public class IdentifierService {
 
     private final IdentifierRepository identifierRepository;
-    private final LocalGroupService localGroupService;
-    private final GlobalConfService globalConfService;
 
     /**
      * Get the existing {@link XRoadId xRoadIds} from the local db and persist the not-existing ones
      * Useful method when changing identifier relations (such as adding access rights to services)
+     *
      * @param xRoadIds
-     * @return List of XRoadIds
+     * @return Set of XRoadIds
      */
-    Set<XRoadIdEntity> getOrPersistXroadIdEntities(Set<XRoadIdEntity> xRoadIds) {
-        Set<XRoadIdEntity> idsToPersist = new HashSet<>(xRoadIds);
-        Set<XRoadIdEntity> managedEntities = getXroadIdEntities(idsToPersist);
+    <T extends XRoadIdEntity> Set<T> getOrPersistXroadIdEntities(Set<T> xRoadIds) {
+        Set<T> idsToPersist = new HashSet<>(xRoadIds);
+        Set<T> managedEntities = getXroadIdEntities(idsToPersist);
         idsToPersist.removeAll(managedEntities); // remove the persistent ones
         identifierRepository.persist(idsToPersist); // persist the non-persisted
         managedEntities.addAll(idsToPersist); // add the newly persisted ids into the collection of already existing ids
@@ -80,66 +72,27 @@ public class IdentifierService {
 
     /**
      * Get the existing {@link XRoadId xRoadId} from the local db or persist it if it did not exist in db yet.
+     *
      * @param xRoadId
      * @return managed XRoadId which exists in IDENTIFIER table
      */
-    XRoadIdEntity getOrPersistXroadIdEntity(XRoadIdEntity xRoadId) {
-        return getOrPersistXroadIdEntities(new HashSet<>(Arrays.asList(xRoadId))).iterator().next();
+    <T extends XRoadIdEntity> T getOrPersistXroadIdEntity(T xRoadId) {
+        return getOrPersistXroadIdEntities(Set.of(xRoadId)).iterator().next();
     }
 
     /**
      * Get the existing {@link XRoadId xRoadIds} from the local db
+     *
      * @param xRoadIds
-     * @return List of XRoadIds
+     * @return Set of XRoadIds
      */
-    Set<XRoadIdEntity> getXroadIdEntities(Set<XRoadIdEntity> xRoadIds) {
-        Collection<XRoadIdEntity> allIdsFromDb = identifierRepository.getIdentifiers();
+    @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
+    <T extends XRoadIdEntity> Set<T> getXroadIdEntities(Set<T> xRoadIds) {
+        Collection<? extends XRoadIdEntity> allIdsFromDb = identifierRepository.getIdentifiers();
         return allIdsFromDb.stream()
                 .filter(xRoadIds::contains) // this works because of the XRoadId equals and hashCode overrides
+                .map(xRoadId -> (T) xRoadId)
                 .collect(Collectors.toSet());
     }
-
-    /**
-     * Verify that service client objects identified by given XRoadIds do exist.
-     * Criteria in detail:
-     * - subsystem is registered in global configuration
-     * - global group exists in global configuration
-     * - local group exists and belongs to given client
-     * @param clientEntity owner of (possible) local groups
-     * @param serviceClientIds service client ids to check
-     * @throws ServiceClientNotFoundException if some service client objects could not be found
-     */
-    public void verifyServiceClientObjectsExist(ClientEntity clientEntity, Set<XRoadIdEntity> serviceClientIds)
-            throws ServiceClientNotFoundException {
-        Map<XRoadObjectType, List<XRoadIdEntity>> idsPerType = serviceClientIds.stream()
-                .collect(groupingBy(XRoadIdEntity::getObjectType));
-        for (XRoadObjectType type : idsPerType.keySet()) {
-            if (!isValidServiceClientType(type)) {
-                throw new ServiceClientNotFoundException("Invalid service client subject object type " + type);
-            }
-        }
-        if (idsPerType.containsKey(XRoadObjectType.GLOBALGROUP)) {
-            if (!globalConfService.globalGroupsExist(idsPerType.get(XRoadObjectType.GLOBALGROUP))) {
-                throw new ServiceClientNotFoundException();
-            }
-        }
-        if (idsPerType.containsKey(XRoadObjectType.SUBSYSTEM)) {
-            if (!globalConfService.clientsExist(idsPerType.get(XRoadObjectType.SUBSYSTEM))) {
-                throw new ServiceClientNotFoundException();
-            }
-        }
-        if (idsPerType.containsKey(XRoadObjectType.LOCALGROUP)) {
-            if (!localGroupService.localGroupsExist(clientEntity, idsPerType.get(XRoadObjectType.LOCALGROUP))) {
-                throw new ServiceClientNotFoundException();
-            }
-        }
-    }
-
-    private boolean isValidServiceClientType(XRoadObjectType objectType) {
-        return objectType == XRoadObjectType.SUBSYSTEM
-                || objectType == XRoadObjectType.GLOBALGROUP
-                || objectType == XRoadObjectType.LOCALGROUP;
-    }
-
 
 }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InitializationService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/InitializationService.java
@@ -196,7 +196,6 @@ public class InitializationService {
                 + ownerClientId.getMemberCode() + "/" + serverConf.getServerCode();
         generateGPGKeyPair(keyRealName);
 
-        serverConfService.saveOrUpdate(serverConf);
     }
 
     /**
@@ -302,7 +301,7 @@ public class InitializationService {
      * @param securityServerCode securityServerCode
      * @return ServerConfEntity
      */
-    private ServerConfEntity createInitialServerConf(ClientIdEntity ownerClientId, String securityServerCode) {
+    ServerConfEntity createInitialServerConf(ClientIdEntity ownerClientId, String securityServerCode) {
         ServerConfEntity serverConfEntity = serverConfService.getOrCreateServerConfEntity();
 
         if (ObjectUtils.isEmpty(serverConfEntity.getServerCode())) {
@@ -310,11 +309,7 @@ public class InitializationService {
         }
 
         if (serverConfEntity.getOwner() == null) {
-            ClientEntity ownerClient = getInitialClient(ownerClientId);
-            ownerClient.setConf(serverConfEntity);
-            if (!serverConfEntity.getClients().contains(ownerClient)) {
-                serverConfEntity.getClients().add(ownerClient);
-            }
+            ClientEntity ownerClient = getInitialClient(ownerClientId, serverConfEntity);
             serverConfEntity.setOwner(ownerClient);
         }
         return serverConfEntity;
@@ -367,16 +362,15 @@ public class InitializationService {
 
     /**
      * Helper to create an initial client
+     *
      * @param clientId
+     * @param serverConf
      * @return
      */
-    private ClientEntity getInitialClient(ClientIdEntity clientId) {
+    private ClientEntity getInitialClient(ClientIdEntity clientId, ServerConfEntity serverConf) {
         ClientEntity localClient = clientService.getLocalClientEntity(clientId);
         if (localClient == null) {
-            localClient = new ClientEntity();
-            localClient.setIdentifier(clientId);
-            localClient.setClientStatus(Client.STATUS_SAVED);
-            localClient.setIsAuthentication(IsAuthentication.SSLAUTH.name());
+            localClient = clientService.addClient(clientId, serverConf, IsAuthentication.SSLAUTH, Client.STATUS_SAVED);
         }
         return localClient;
     }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/LocalGroupService.java
@@ -81,6 +81,7 @@ public class LocalGroupService {
     private final ClientRepository clientRepository;
     private final ClientService clientService;
     private final AuditDataHelper auditDataHelper;
+    private final IdentifierService identifierService;
 
     /**
      * Return local group.
@@ -187,14 +188,13 @@ public class LocalGroupService {
 
         auditLog(memberIds, localGroupEntity);
 
+        Set<ClientId> allClientIds = clientService.getAllClientIds();
         List<GroupMemberEntity> membersToBeAdded = new ArrayList<>(memberIds.size());
-        for (ClientId memberId : memberIds) {
-            Optional<ClientEntity> foundMember = clientService.findEntityByClientId(memberId);
-            if (!foundMember.isPresent()) {
+        for (ClientId clientIdToBeAdded : memberIds) {
+            if (!allClientIds.contains(clientIdToBeAdded)) {
                 throw new LocalGroupMemberNotFoundException(CLIENT_WITH_ID
-                        + memberId.toShortString() + NOT_FOUND);
+                        + clientIdToBeAdded.toShortString() + NOT_FOUND);
             }
-            ClientId clientIdToBeAdded = foundMember.get().getIdentifier();
             boolean isAdded = localGroupEntity.getGroupMembers().stream()
                     .anyMatch(groupMemberEntity -> groupMemberEntity.getGroupMemberId().toShortString().trim()
                             .equals(clientIdToBeAdded.toShortString().trim()));
@@ -203,7 +203,8 @@ public class LocalGroupService {
             }
             GroupMemberEntity groupMemberEntity = new GroupMemberEntity();
             groupMemberEntity.setAdded(new Date());
-            groupMemberEntity.setGroupMemberId(XRoadIdMapper.get().toEntity(clientIdToBeAdded));
+            groupMemberEntity.setGroupMemberId(
+                    identifierService.getOrPersistXroadIdEntity(XRoadIdMapper.get().toEntity(clientIdToBeAdded)));
             membersToBeAdded.add(groupMemberEntity);
         }
         // do not remove this saveOrUpdateAll - contrary to expectations hibernate does not cascade such
@@ -266,7 +267,7 @@ public class LocalGroupService {
                 .filter(member -> items.stream()
                         .anyMatch(item -> item.toShortString().trim()
                                 .equals(member.getGroupMemberId().toShortString().trim())))
-                .collect(Collectors.toList());
+                .toList();
 
         // do not remove members at all if even one of them was not found
         if (membersToBeRemoved.isEmpty() || items.size() != membersToBeRemoved.size()) {

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServerConfService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/service/ServerConfService.java
@@ -73,13 +73,13 @@ public class ServerConfService {
 
     /**
      * Get a server conf; an existing server conf will be returned if one exists. Otherwise
-     * a new transient instance is returned.
+     * a new managed instance is returned.
      * @return ServerConfEntity
      */
     ServerConfEntity getOrCreateServerConfEntity() {
         ServerConfEntity serverConfEntity = getServerConfGracefully();
         if (serverConfEntity == null) {
-            return new ServerConfEntity();
+            return serverConfRepository.saveOrUpdate(new ServerConfEntity());
         }
         return serverConfEntity;
     }
@@ -140,13 +140,6 @@ public class ServerConfService {
             return serverConfEntity.getOwner() != null;
         }
         return false;
-    }
-
-    /**
-     * Save or update ServerConf
-     */
-    public void saveOrUpdate(ServerConfEntity serverConfEntity) {
-        serverConfRepository.saveOrUpdate(serverConfEntity);
     }
 
     /**

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AccessRightServiceIntegrationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/service/AccessRightServiceIntegrationTest.java
@@ -82,6 +82,9 @@ public class AccessRightServiceIntegrationTest extends AbstractServiceIntegratio
     @Autowired
     EndpointService endpointService;
 
+    @Autowired
+    IdentifierService identifierService;
+
     private List<MemberInfo> memberInfos = new ArrayList<>(List.of(
             TestUtils.getMemberInfo(TestUtils.INSTANCE_FI, TestUtils.MEMBER_CLASS_GOV, TestUtils.MEMBER_CODE_M1, null),
             TestUtils.getMemberInfo(TestUtils.INSTANCE_EE, TestUtils.MEMBER_CLASS_GOV, TestUtils.MEMBER_CODE_M1, TestUtils.SUBSYSTEM1),
@@ -513,7 +516,7 @@ public class AccessRightServiceIntegrationTest extends AbstractServiceIntegratio
         ClientIdEntity subsystemId = TestUtils.getClientIdEntity(TestUtils.CLIENT_ID_SS5);
         LocalGroupIdEntity localGroupId = LocalGroupIdEntity.create("group2");
         GlobalGroupIdEntity globalGroupId = GlobalGroupIdEntity.create(TestUtils.INSTANCE_FI, TestUtils.DB_GLOBALGROUP_CODE);
-        Set<XRoadIdEntity> subjectIds = new HashSet<>(Arrays.asList(subsystemId, localGroupId, globalGroupId));
+        Set<XRoadIdEntity> subjectIds = identifierService.getOrPersistXroadIdEntities(Set.of(subsystemId, localGroupId, globalGroupId));
 
         ClientEntity ownerClient = clientRepository.getClient(serviceOwner);
 


### PR DESCRIPTION
Cascading persist operations caused duplicate records in identifier table. Cascading was removed from Client and XroadId references.

Refs: XRDDEV-2947