### PR TITLE
feat: Provide admin password to sidecar as hash

### DIFF
--- a/doc/Sidecar/security_server_sidecar_user_guide.md
+++ b/doc/Sidecar/security_server_sidecar_user_guide.md
@@ -172,6 +172,8 @@ docker run --detach \
   -e XROAD_TOKEN_PIN=<token pin> \
   -e XROAD_ADMIN_USER=<admin user> \
   -e XROAD_ADMIN_PASSWORD=<admin password> \
+  # Alternatively a password hash for admin can be used
+  # -e XROAD_ADMIN_PWD_HASH=<admin password hash>
   # Optional parameters - BEGIN
   -v <config-volume>:/etc/xroad \
   -v <archive-volume>:/var/lib/xroad \
@@ -183,6 +185,9 @@ docker run --detach \
   # Optional parameters - END
   niis/xroad-security-server-sidecar:<version[-type[-variant]]>
 ```
+
+Hash for admin user can be generated with multiple tools. Note that yescrypt ( `$y$xxxx` ) hash is not supported in older xroad images.
+A SHA512 hash can be generated with `mkpasswd -m SHA-512` or with docker command `docker run --rm -it docker.io/serversideup/mkpasswd -m SHA-512`
 
 Note! This command persists all configuration inside the Sidecar container which means that state is lost when the container is destroyed.
 In production use, either persistent volumes should be used. Using a separate database is recommended.

--- a/sidecar/files/_entrypoint_common.sh
+++ b/sidecar/files/_entrypoint_common.sh
@@ -86,12 +86,17 @@ chown xroad:xroad /etc/xroad /var/lib/xroad /var/tmp/xroad
 if [[ -n "$XROAD_ADMIN_USER" ]] && ! getent passwd "$XROAD_ADMIN_USER" &>/dev/null; then
   # Configure admin user with user-supplied username and password
   log "Creating admin user with user-supplied credentials"
-  useradd -m "${XROAD_ADMIN_USER}" -s /usr/sbin/nologin
-  echo "${XROAD_ADMIN_USER}:${XROAD_ADMIN_PASSWORD}" | chpasswd
+  if [[ -n "$XROAD_ADMIN_PWD_HASH" ]]; then
+    useradd -m "${XROAD_ADMIN_USER}" -s /usr/sbin/nologin -p "$XROAD_ADMIN_PWD_HASH"
+  else
+    useradd -m "${XROAD_ADMIN_USER}" -s /usr/sbin/nologin
+    echo "${XROAD_ADMIN_USER}:${XROAD_ADMIN_PASSWORD}" | chpasswd
+  fi
   echo "xroad-proxy xroad-common/username string ${XROAD_ADMIN_USER}" | debconf-set-selections
 fi
 XROAD_ADMIN_USER=
 XROAD_ADMIN_PASSWORD=
+XROAD_ADMIN_PWD_HASH=
 
 if [ "$INSTALLED_VERSION" == "$PACKAGED_VERSION" ]; then
   if [ -f /etc/xroad/VERSION ]; then


### PR DESCRIPTION
Admin password can and most likely should be provided to the container as a hash, instead of plaintext password.

This commit adds a new environment variable 'XROAD_ADMIN_PWD_HASH', which can be used to supply a hash to sidecar container instead of hashing the plaintext password on container start. If 'XROAD_ADMIN_PWD_HASH' variable is not supplied, old behaviour is preserved.