### PR TITLE
i18n(pt-BR): add missing translations for 'traffic' and 'diagnostics'

### DIFF
--- a/src/security-server/admin-service/ui/src/locales/pt-BR.json
+++ b/src/security-server/admin-service/ui/src/locales/pt-BR.json
@@ -304,6 +304,27 @@
         "UNKNOWN": "Desconhecido"
       },
       "title": "Carimbo de tempo"
+    },
+    "traffic": {
+      "period": "Período",
+      "periodInfo": "Selecione início e fim",
+      "date": "Data",
+      "time": "Hora",
+      "party": "Parte",
+      "partyInfo": "Serviço, subsistema, membro",
+      "client": "Cliente",
+      "service": "Serviço",
+      "exchangeRole": "Função de troca",
+      "exchangeRoleInfo": "Produtor ou Consumidor",
+      "producer": "Produtor",
+      "status": "Status",
+      "statusInfo": "Status da troca de mensagens",
+      "success": "Sucesso",
+      "failure": "Falha",
+      "successfulRequests": "Solicitações exitosas",
+      "failedRequests": "Solicitações falhas",
+      "disabledTitle": "Monitoramento de dados operacionais desativado",
+      "disabledMessage": "O monitoramento de dados operacionais está desativado para este Servidor de Segurança. Para ativá-lo, instale o complemento de monitoramento de dados operacionais (xroad-addon-opmonitoring)."
     }
   },
   "endpoints": {
@@ -948,6 +969,10 @@
     "settings": {
       "backupAndRestore": "Backup e Restauração",
       "systemParameters": "Parâmetros do Sistema"
+    },
+    "diagnostics": {
+      "overview": "Visão Geral",
+      "traffic": "Tráfego"
     }
   },
   "token": {


### PR DESCRIPTION
### Summary
This PR adds missing Portuguese (pt-BR) translations for the Traffic and Diagnostics sections.

### Details
- Added translations for traffic (period, status, success/failure, operational monitoring).
- Added translations for diagnostics (overview, traffic).

### Testing
- Checked JSON with `jq` to confirm validity.
- UI builds correctly with updated translations.

### Notes
This change only affects i18n. No core code is changed.
