### PR TITLE
fix: Missing logging when openbao certificate fetch is failing

### DIFF
--- a/src/common/common-rpc/src/main/java/org/niis/xroad/common/rpc/server/ManagedRpcServer.java
+++ b/src/common/common-rpc/src/main/java/org/niis/xroad/common/rpc/server/ManagedRpcServer.java
@@ -68,6 +68,7 @@ public abstract class ManagedRpcServer {
     }
 
     private RpcServer createServer() {
+        log.info("RPC server is being initialized..");
         return new RpcServer(
                 rpcServerProperties.listenAddress(),
                 rpcServerProperties.port(),

--- a/src/common/common-rpc/src/main/java/org/niis/xroad/common/rpc/vault/ReloadableVaultKeyManager.java
+++ b/src/common/common-rpc/src/main/java/org/niis/xroad/common/rpc/vault/ReloadableVaultKeyManager.java
@@ -74,7 +74,10 @@ public class ReloadableVaultKeyManager implements VaultKeyProvider {
 
     @Override
     public void init() {
+        var startTime = System.currentTimeMillis();
+        log.info("Initializing reloadable vault key manager..");
         reload();
+        log.info("Reloadable vault key manager initialized in {} ms", System.currentTimeMillis() - startTime);
     }
 
     @Override
@@ -135,7 +138,10 @@ public class ReloadableVaultKeyManager implements VaultKeyProvider {
         var keyManager = new AdvancedTlsX509KeyManager();
 
         var scheduler = Executors.newScheduledThreadPool(1, Thread.ofVirtual().factory());
+
         var retryInstance = createRetryInstance(certificateProvisionProperties);
+        retryInstance.getEventPublisher().onRetry(event ->
+                log.warn("Retrying provision certificates from secret store. Event: {}", event));
 
         return new ReloadableVaultKeyManager(certificateProvisionProperties, vaultKeyClient,
                 trustStore, keyManager, scheduler, retryInstance);


### PR DESCRIPTION
This change adds retry logging with a detailed status. For example:

> 2025-10-14 12:09:25,309 WARN  [org.nii.xro.com.rpc.vau.ReloadableVaultKeyManager] (main) Retrying provision certificates from secret store. Event: 2025-10-14T12:09:25.308191806Z[Etc/UTC]: Retry 'vaultReloadRetry', waiting PT11.25S until attempt '3'. Last attempt failed with exception 'VaultClientException{operationName='VAULT [SECRETS (pki)] Issue', requestPath='http://openbao:8200/v1/xrd-pki/issue/xrd-internal', status=404, errors=[no handler for route "xrd-pki/issue/xrd-internal". route entry not found.]}'.

> 2025-10-14T12:09:36.572154938Z 2025-10-14 12:09:36,571 WARN  [org.nii.xro.com.rpc.vau.ReloadableVaultKeyManager] (main) Retrying provision certificates from secret store. Event: 2025-10-14T12:09:36.571204724Z[Etc/UTC]: Retry 'vaultReloadRetry', waiting PT16.875S until attempt '4'. Last attempt failed with exception 'VaultClientException{operationName='VAULT [SECRETS (pki)] Issue', requestPath='http://openbao:8200/v1/xrd-pki/issue/xrd-internal', status=404, errors=[no handler for route "xrd-pki/issue/xrd-internal". route entry not found.]}'.
