### PR TITLE
chore: fix incorrect template attribute on Sign and Auth keys tab

### DIFF
--- a/src/security-server/admin-service/ui/src/views/KeysAndCertificates/SignAndAuthKeys/SignAndAuthKeys.vue
+++ b/src/security-server/admin-service/ui/src/views/KeysAndCertificates/SignAndAuthKeys/SignAndAuthKeys.vue
@@ -25,7 +25,7 @@
  -->
 <template>
   <XrdTitledView title-key="tab.keys.signAndAuthKeys">
-    <template #appendTitle>
+    <template #append-title>
       <help-button
         :help-image="helpImage"
         help-title="keys.helpTitleKeys"


### PR DESCRIPTION
Fixes the incorrect template attribute, which caused the auth and sign keys tab header to not show help and search functionality.