### PR TITLE
chore: disable badges in eco-ci workflow step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,6 +138,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           pr-comment: true
   BuildAndPackageOnArm:
     name: Build and package code for arm architecture
@@ -206,6 +207,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           pr-comment: true
   RunCSSystemTests:
     name: Run Central Server system tests
@@ -299,6 +301,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           pr-comment: true
       - name: Upload GMT jsons
         uses: actions/upload-artifact@v6
@@ -391,6 +394,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           pr-comment: true
   RunE2ETests:
     name: Run E2E tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -500,4 +500,5 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           pr-comment: true

--- a/src/buildSrc/src/main/kotlin/xroad.int-test-conventions.gradle.kts
+++ b/src/buildSrc/src/main/kotlin/xroad.int-test-conventions.gradle.kts
@@ -21,6 +21,7 @@ val libs = project.extensions.getByType<VersionCatalogsExtension>().named("libs"
 dependencies {
   "intTestCompileOnly"(libs.findLibrary("lombok").get())
   "intTestAnnotationProcessor"(libs.findLibrary("lombok").get())
+  "intTestImplementation"(platform(libs.findLibrary("testcontainers-core").get()))
 }
 
 tasks.named<Checkstyle>("checkstyleIntTest") {

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ xmlUnit = "2.11.0"
 bouncyCastle = "1.83"
 slf4j = "2.0.17"
 testAutomationFramework = "0.2.21"
+testcontainers = "1.21.4"
 selenide="7.13.0"
 protoc = "4.33.5"
 grpc = "1.79.0"
@@ -74,6 +75,7 @@ julOverSlf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
 testAutomation-core = { module = "com.nortal.test:test-automation-core", version.ref = "testAutomationFramework" }
 testAutomation-allure = { module = "com.nortal.test:test-automation-allure", version.ref = "testAutomationFramework" }
 testAutomation-containers = { module = "com.nortal.test:test-automation-containers", version.ref = "testAutomationFramework" }
+testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testAutomation-feign = { module = "com.nortal.test:test-automation-feign", version.ref = "testAutomationFramework" }
 testAutomation-selenide = { module = "com.nortal.test:test-automation-selenide", version.ref = "testAutomationFramework" }
 testAutomation-assert = { module = "com.nortal.test:test-automation-assert", version.ref = "testAutomationFramework" }


### PR DESCRIPTION
Removing badges so that our internal tooling can't misuse the Eco-CI badge API, causing issues in their logs.

Should resolve #3308.