### PR TITLE
chore: migrate 7.x Eco CI badge change to 8.x build scripts

### DIFF
--- a/.github/workflows/_build-and-package.yml
+++ b/.github/workflows/_build-and-package.yml
@@ -312,6 +312,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 

--- a/.github/workflows/_test-central-server.yml
+++ b/.github/workflows/_test-central-server.yml
@@ -99,6 +99,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 

--- a/.github/workflows/_test-e2e.yml
+++ b/.github/workflows/_test-e2e.yml
@@ -102,5 +102,6 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true

--- a/.github/workflows/_test-security-server.yml
+++ b/.github/workflows/_test-security-server.yml
@@ -101,5 +101,6 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true

--- a/.github/workflows/_test-services.yml
+++ b/.github/workflows/_test-services.yml
@@ -100,6 +100,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 
@@ -182,6 +183,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 
@@ -264,6 +266,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 
@@ -339,6 +342,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true
 
@@ -414,5 +418,6 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
         with:
           task: display-results
+          display-badge: false
           display-table: false
           pr-comment: true


### PR DESCRIPTION
Looks like these changes were missed during the backmerge.