### PR TITLE
chore: update default TLS cipher suites for SS↔SS and IS↔SS (prefer GCM, remove deprecated DHE-RSA CBC from SS↔SS)

### DIFF
--- a/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
+++ b/src/common/common-core/src/main/java/ee/ria/xroad/common/SystemProperties.java
@@ -1690,13 +1690,13 @@ public final class SystemProperties {
     }
 
     private static final String DEFAULT_CLIENT_SSL_CIPHER_SUITES = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"
-            + "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,"
             + "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
+            + "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,"
             + "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,"
             + "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,"
+            + "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,"
             + "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,"
-            + "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,"
-            + "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384";
+            + "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256";
 
     /**
      * Get proxy client's accepted TLS cipher suites (between is and ss).
@@ -1707,9 +1707,10 @@ public final class SystemProperties {
         return System.getProperty(PROXY_CLIENT_TLS_CIPHERS, DEFAULT_CLIENT_SSL_CIPHER_SUITES).trim().split(COMMA_SPLIT);
     }
 
-    private static final String DEFAULT_XROAD_SSL_CIPHER_SUITES = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,"
-            + "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,"
-            + "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384";
+    private static final String DEFAULT_XROAD_SSL_CIPHER_SUITES = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,"
+                    + "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
+                    + "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,"
+                    + "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384";
 
     /**
      * Get X-Road accepted TLS cipher suites (between ss and ss).

--- a/src/packages/src/xroad/default-configuration/override-securityserver-fi.ini
+++ b/src/packages/src/xroad/default-configuration/override-securityserver-fi.ini
@@ -12,7 +12,7 @@ csr-signature-digest-algorithm=SHA-256
 ; Client-side enabled TLS protocols and cipher suites. User by client side listerers and connectors.
 ; See https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider for possible values
 client-tls-protocols=TLSv1.2
-client-tls-ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+client-tls-ciphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
 server-connector-max-idle-time=120000
 server-support-clients-pooled-connections=true
 pool-enable-connection-reuse=true


### PR DESCRIPTION

Refs: XRDDEV-3116