### PR TITLE
chore: pin github actions to specific hashes

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -40,20 +40,20 @@ runs:
 
     - name: Free Disk Space (Ubuntu)
       if: inputs.free-disk-space == 'true' && runner.os == 'Linux'
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         android: true
         dotnet: true
         haskell: true
 
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6
       with:
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         gradle-home-cache-cleanup: true
@@ -65,7 +65,7 @@ runs:
 
     - name: Set up Docker Buildx
       if: inputs.setup-docker-buildx == 'true'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       with:
         driver-opts: network=host
 

--- a/.github/workflows/_build-and-package.yml
+++ b/.github/workflows/_build-and-package.yml
@@ -30,12 +30,12 @@ jobs:
       service_image_tag: ${{ steps.build-config.outputs.service_image_tag }}
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'Build, unit tests and packaging'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0  # SonarCloud: Shallow clones should be disabled for a better relevancy of analysis
@@ -49,20 +49,20 @@ jobs:
           free-disk-space: false
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Build, test and package code setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'Build environment setup'
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -156,63 +156,63 @@ jobs:
           ./build-images.sh --platforms linux/amd64,linux/arm64 --push
 
       - name: Upload signer-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: signer-int-test-jar
           path: src/service/signer/signer-int-test/build/libs/signer-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload confproxy-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: confproxy-int-test-jar
           path: src/service/configuration-proxy/configuration-proxy-int-test/build/libs/confproxy-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload softtoken-signer-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: softtoken-signer-int-test-jar
           path: src/service/softtoken-signer/softtoken-signer-int-test/build/libs/softtoken-signer-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload opmonitor-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: opmonitor-int-test-jar
           path: src/service/op-monitor/op-monitor-int-test/build/libs/opmonitor-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload cs-admin-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cs-admin-int-test-jar
           path: src/central-server/admin-service/int-test/build/libs/central-server-admin-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload cs-management-int-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cs-management-int-test-jar
           path: src/central-server/management-service/int-test/build/libs/central-server-management-int-test-1.0.jar
           compression-level: '0'
 
       - name: Upload ss-system-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ss-system-test-jar
           path: src/security-server/system-test/build/libs/security-server-system-test-1.0.jar
           compression-level: '0'
 
       - name: Upload cs-system-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cs-system-test-jar
           path: src/central-server/admin-service/ui-system-test/build/libs/central-server-system-test-1.0.jar
           compression-level: '0'
 
       - name: Upload e2e-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: e2e-test-jar
           path: src/security-server/e2e-test/build/libs/e2e-test-1.0.jar
@@ -228,7 +228,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: Unit and integration tests
@@ -238,7 +238,7 @@ jobs:
           list-tests: 'failed'
 
       - name: Build, test and package code execution measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'Build, unit tests and packaging'
@@ -310,13 +310,13 @@ jobs:
           show-packages: 'true'
 
       - name: Packaging and upload artifacts measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'Packaging and upload artifacts'
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false

--- a/.github/workflows/_test-central-server.yml
+++ b/.github/workflows/_test-central-server.yml
@@ -27,35 +27,35 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'cs-system-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download cs-system-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: cs-system-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-system-test setup'
@@ -70,7 +70,7 @@ jobs:
           label: 'cs-system-test storage'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-system-test'
@@ -78,7 +78,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: cs-system-test
@@ -86,7 +86,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload cs-system-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: cs-system-test-report-${{ github.run_number }}
@@ -96,7 +96,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -104,7 +104,7 @@ jobs:
           pr-comment: true
 
       - name: Upload GMT jsons
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: cs-system-test-gmt
           path: |

--- a/.github/workflows/_test-e2e.yml
+++ b/.github/workflows/_test-e2e.yml
@@ -27,35 +27,35 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'e2e-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download e2e-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: e2e-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'e2e-test setup'
@@ -73,7 +73,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'e2e-test'
@@ -81,7 +81,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: e2e-test
@@ -89,7 +89,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload e2e-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: e2e-test-report-${{ github.run_number }}
@@ -99,7 +99,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false

--- a/.github/workflows/_test-security-server.yml
+++ b/.github/workflows/_test-security-server.yml
@@ -27,35 +27,35 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'ss-system-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download ss-system-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ss-system-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'ss-system-test setup'
@@ -71,7 +71,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'ss-system-test'
@@ -79,7 +79,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: ss-system-test
@@ -87,7 +87,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload ss-system-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: ss-system-test-report-${{ github.run_number }}
@@ -98,7 +98,7 @@ jobs:
             test-framework-working-dir/selenide-failures/*.png
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false

--- a/.github/workflows/_test-services.yml
+++ b/.github/workflows/_test-services.yml
@@ -27,35 +27,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'signer-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download signer-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: signer-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'signer-int-test setup'
@@ -71,7 +71,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'signer-int-test'
@@ -79,7 +79,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: signer-int-test
@@ -87,7 +87,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload signer-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: signer-int-test-report-${{ github.run_number }}
@@ -97,7 +97,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -110,35 +110,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'softtoken-signer-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download softtoken-signer-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: softtoken-signer-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'softtoken-signer-int-test setup'
@@ -154,7 +154,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'softtoken-signer-int-test'
@@ -162,7 +162,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: softtoken-signer-int-test
@@ -170,7 +170,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload softtoken-signer-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: softtoken-signer-int-test-report-${{ github.run_number }}
@@ -180,7 +180,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -193,35 +193,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'confproxy-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download confproxy-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: confproxy-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'confproxy-int-test setup'
@@ -237,7 +237,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'confproxy-int-test'
@@ -245,7 +245,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: confproxy-int-test
@@ -253,7 +253,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload confproxy-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: confproxy-int-test-report-${{ github.run_number }}
@@ -263,7 +263,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -275,35 +275,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'opmonitor-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download opmonitor-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: opmonitor-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'opmonitor-int-test setup'
@@ -319,7 +319,7 @@ jobs:
           show-docker-images: 'true'
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'opmonitor-int-test'
@@ -327,7 +327,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: opmonitor-int-test
@@ -335,7 +335,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload opmonitor-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: opmonitor-int-test-report-${{ github.run_number }}
@@ -345,7 +345,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -358,35 +358,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'cs-admin-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download cs-admin-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: cs-admin-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-admin-int-test setup'
@@ -395,7 +395,7 @@ jobs:
         run: java -jar central-server-admin-int-test-1.0.jar
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-admin-int-test'
@@ -403,7 +403,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: cs-admin-int-test
@@ -411,7 +411,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload cs-admin-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: cs-admin-int-test-report-${{ github.run_number }}
@@ -421,7 +421,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false
@@ -434,35 +434,35 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Start Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: start-measurement
           label: 'cs-management-int-test'
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Download cs-management-int-test
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: cs-management-int-test-jar
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-management-int-test setup'
@@ -471,7 +471,7 @@ jobs:
         run: java -jar central-server-management-int-test-1.0.jar
 
       - name: Test measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: get-measurement
           label: 'cs-management-int-test'
@@ -479,7 +479,7 @@ jobs:
       - name: Test report
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         if: success() || failure()
         with:
           name: cs-management-int-test
@@ -487,7 +487,7 @@ jobs:
           reporter: java-junit
 
       - name: Upload cs-management-int-test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: cs-management-int-test-report-${{ github.run_number }}
@@ -497,7 +497,7 @@ jobs:
             test-framework-working-dir/test-automation-exec.log
 
       - name: Show Energy Results
-        uses: green-coding-solutions/eco-ci-energy-estimation@v5.2
+        uses: green-coding-solutions/eco-ci-energy-estimation@9fcdc7c7225cc2cbeead14d114a61a461bd37e66 # v5.2
         with:
           task: display-results
           display-badge: false

--- a/.github/workflows/build-package-builder-images.yaml
+++ b/.github/workflows/build-package-builder-images.yaml
@@ -32,7 +32,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Read version from gradle.properties
         id: version
@@ -45,7 +45,7 @@ jobs:
           echo "Using tag: ${IMAGE_TAG}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Read version from gradle.properties
         id: version
@@ -80,7 +80,7 @@ jobs:
           echo "Using tag: ${IMAGE_TAG}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -103,13 +103,13 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/cleanup-snapshots.yaml
+++ b/.github/workflows/cleanup-snapshots.yaml
@@ -72,7 +72,7 @@ jobs:
     #          - x-road/package-builder-rpm-el9
     steps:
       - name: Cleanup old snapshot images (${{ matrix.package }})
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
         with:
           package: ${{ matrix.package }}
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -10,10 +10,11 @@ jobs:
     steps:
       # 0. Checkout repository (Required to read the config file)
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       # 1. Install the ORT Server Client (OSC) and Authenticate
       - name: Setup Double Open CLI
+        # Looks like they don't use releases, so not pinning this to a release commit for now
         uses: eclipse-apoapsis/actions/setup-osc@main
         with:
           url: https://ort-api.scw.doubleopen.io
@@ -41,7 +42,7 @@ jobs:
       # Run this step even if previous steps failed
       - name: Upload Artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: compliance-reports
           path: reports/

--- a/.github/workflows/publish_testca.yaml
+++ b/.github/workflows/publish_testca.yaml
@@ -11,37 +11,35 @@ env:
   REGISTRY: ghcr.io
   XROAD_HOME: ${{ github.workspace }}
 jobs:
-  PublishCS:
+  PublishCA:
     name: Publish test CA image
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Initialize docker setup
         working-directory: ./development/docker/testca
         run: ./init_context.sh
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ github.workspace }}/development/docker/testca
           push: true
           tags: ghcr.io/nordic-institute/xrddev-testca:latest
       - name: Clean old CA images
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:
           image-names: xrddev-testca
-          cut-off: 1 week ago UTC
+          cut-off: 1w
           timestamp-to-use: created_at
-          account-type: org
-          org-name: nordic-institute
-          keep-at-least: 1
-          token-type: github-token
+          account: nordic-institute
+          keep-n-most-recent: 1
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins GitHub actions to specific release hashes for added security.

There were also two larger version upgrades:

- gradle/actions/setup-gradle v4 -> v6: Doesn't appear to have any functional changes that affect us.
- snok/container-retention-policy v2 -> v3: This had breaking changes that required updating inputs, see https://github.com/snok/container-retention-policy/releases/tag/v3.0.0