### PR TITLE
chore: use "cert" request param in CertHashBasedOcspResponderClient

### DIFF
--- a/deployment/security-server/images/base-images/baseline/Dockerfile
+++ b/deployment/security-server/images/base-images/baseline/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=localhost:5555
 ARG DOCKER_REGISTRY=""
-FROM ${DOCKER_REGISTRY}eclipse-temurin:25-jre-noble
+FROM ${DOCKER_REGISTRY}eclipse-temurin:25-jre
 
 RUN groupadd --system --gid 999 xroad && \
     useradd --system  \

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClient.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClient.java
@@ -42,7 +42,6 @@ import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPResp;
-import org.bouncycastle.operator.OperatorCreationException;
 import org.niis.xroad.proxy.core.configuration.ProxyProperties;
 
 import java.io.IOException;
@@ -83,7 +82,7 @@ public final class CertHashBasedOcspResponderClient {
      * @return list of OCSP response objects
      */
     public List<OCSPResp> getOcspResponsesFromServer(String providerAddress, List<X509Certificate> certificates)
-            throws CertificateEncodingException, URISyntaxException, IOException, OperatorCreationException, OCSPException {
+            throws CertificateEncodingException, URISyntaxException, IOException, OCSPException {
         URL url = createUrl(providerAddress, certificates);
         return getOcspResponsesFromServer(url);
     }
@@ -140,8 +139,8 @@ public final class CertHashBasedOcspResponderClient {
         return responses;
     }
 
-    private URL createUrl(String providerAddress, List<X509Certificate> certificates)
-            throws URISyntaxException, IOException, CertificateEncodingException, OperatorCreationException {
+    URL createUrl(String providerAddress, List<X509Certificate> certificates)
+            throws URISyntaxException, IOException, CertificateEncodingException {
         String[] sha256Hashes = CertUtils.getHashes(certificates);
         String[] sha1Hashes = getSha1Hashes(certificates);
 

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClient.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClient.java
@@ -25,6 +25,8 @@
  */
 package org.niis.xroad.proxy.core.util;
 
+import ee.ria.xroad.common.crypto.Digests;
+import ee.ria.xroad.common.crypto.identifier.DigestAlgorithm;
 import ee.ria.xroad.common.util.CertUtils;
 import ee.ria.xroad.common.util.MimeTypes;
 
@@ -63,6 +65,9 @@ import java.util.List;
 public final class CertHashBasedOcspResponderClient {
 
     public static final String SHA_256_CERT_PARAM = "cert_hash";
+    // Legacy SHA-1 hash parameter, kept so X-Road 8.x clients can fetch OCSP responses from 7.x security servers
+    // whose responder only recognises this parameter name. Remove once 7.x interop is no longer required.
+    static final String SHA_1_CERT_PARAM = "cert";
     private static final String METHOD = "GET";
 
     private static final List<Integer> VALID_RESPONSE_CODES = Arrays.asList(
@@ -76,7 +81,6 @@ public final class CertHashBasedOcspResponderClient {
      * @param providerAddress URL of the OCSP response provider
      * @param certificates    certificates for which to get the responses
      * @return list of OCSP response objects
-     * @throws Exception if I/O errors occurred
      */
     public List<OCSPResp> getOcspResponsesFromServer(String providerAddress, List<X509Certificate> certificates)
             throws CertificateEncodingException, URISyntaxException, IOException, OperatorCreationException, OCSPException {
@@ -139,13 +143,25 @@ public final class CertHashBasedOcspResponderClient {
     private URL createUrl(String providerAddress, List<X509Certificate> certificates)
             throws URISyntaxException, IOException, CertificateEncodingException, OperatorCreationException {
         String[] sha256Hashes = CertUtils.getHashes(certificates);
+        String[] sha1Hashes = getSha1Hashes(certificates);
 
         var uriBuilder = new URIBuilder().setScheme("http").setHost(providerAddress).setPort(ocspResponderProperties.port());
+        // Send both parameter names so 7.x responders (only recognise "cert") and 8.x responders
+        // (recognise "cert_hash") can both serve the request. Drop the SHA-1 parameter once 7.x interop is gone.
+        Arrays.stream(sha1Hashes).forEach(hash -> uriBuilder.addParameter(SHA_1_CERT_PARAM, hash));
         Arrays.stream(sha256Hashes).forEach(hash -> uriBuilder.addParameter(SHA_256_CERT_PARAM, hash));
         var uri = uriBuilder.build();
 
         log.debug("Getting OCSP responses for hashes ({}) from: {}", Arrays.toString(sha256Hashes), uri.getHost());
 
         return uri.toURL();
+    }
+
+    private static String[] getSha1Hashes(List<X509Certificate> certs) throws CertificateEncodingException, IOException {
+        String[] hashes = new String[certs.size()];
+        for (int i = 0; i < certs.size(); i++) {
+            hashes[i] = Digests.hexDigest(DigestAlgorithm.SHA1, certs.get(i).getEncoded());
+        }
+        return hashes;
     }
 }

--- a/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClientTest.java
+++ b/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/util/CertHashBasedOcspResponderClientTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.proxy.core.util;
+
+import ee.ria.xroad.common.TestCertUtil;
+import ee.ria.xroad.common.crypto.Digests;
+import ee.ria.xroad.common.crypto.identifier.DigestAlgorithm;
+import ee.ria.xroad.common.util.CertUtils;
+
+import org.junit.jupiter.api.Test;
+import org.niis.xroad.common.properties.ConfigUtils;
+import org.niis.xroad.proxy.core.configuration.ProxyProperties;
+
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CertHashBasedOcspResponderClientTest {
+
+    private static final ProxyProperties.OcspResponderProperties PROPS =
+            ConfigUtils.defaultConfiguration(ProxyProperties.OcspResponderProperties.class);
+
+    /**
+     * Regression guard for X-Road 7.x interoperability.
+     *
+     * <p>A 7.x security server's cert-hash OCSP responder only recognises the legacy
+     * {@code cert=<sha1>} URL parameter. An 8.x security server's responder uses
+     * {@code cert_hash=<sha256>}. During the mixed-version upgrade window an 8.x client
+     * must send <b>both</b> parameters so it can fetch OCSP responses from either peer.
+     */
+    @Test
+    void buildsUrlWithBothSha1AndSha256ParamsForXroad7Interoperability() throws Exception {
+        var client = new CertHashBasedOcspResponderClient(PROPS);
+        X509Certificate cert = TestCertUtil.getCaCert();
+
+        URL url = client.createUrl("ocsp.example.test", List.of(cert));
+
+        String expectedSha1 = Digests.hexDigest(DigestAlgorithm.SHA1, cert.getEncoded());
+        String expectedSha256 = CertUtils.getHashes(List.of(cert))[0];
+        String query = url.getQuery();
+
+        assertThat(query)
+                .as("8.x→7.x interop: legacy SHA-1 'cert' parameter must be present alongside 'cert_hash'")
+                .contains(CertHashBasedOcspResponderClient.SHA_1_CERT_PARAM + "=" + expectedSha1)
+                .contains(CertHashBasedOcspResponderClient.SHA_256_CERT_PARAM + "=" + expectedSha256);
+    }
+}


### PR DESCRIPTION
use "cert" request param in CertHashBasedOcspResponderClient to work with xrd 7 responder. Required for X-Road 8 proxy work with v7.

Refs: XRDDEV-3183