### PR TITLE
feat(dsp): align ds-identity-hub + ds-issuer-service with EDC 0.17

### DIFF
--- a/src/service/ds-identity-hub/ds-identity-hub-application/build.gradle.kts
+++ b/src/service/ds-identity-hub/ds-identity-hub-application/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   runtimeOnly(libs.edc.core.participantcontext.config)
 
   runtimeOnly(libs.edc.vault.hashicorp)
+  runtimeOnly(libs.edc.encryption.aes)
 
   runtimeOnly(project(":service:ds-identity-hub:ds-identity-hub-customization"))
 }

--- a/src/service/ds-identity-hub/ds-identity-hub-application/src/main/resources/application.yaml
+++ b/src/service/ds-identity-hub/ds-identity-hub-application/src/main/resources/application.yaml
@@ -19,6 +19,7 @@ quarkus:
         - xroad-logging.yaml
         - /etc/xroad/conf.d/local-tls.yaml
         - /etc/xroad/conf.d/local.yaml
+        - /etc/xroad/conf.d/local-ds-identity-hub.yaml
         - /etc/xroad/db.properties
     log:
       console:
@@ -50,9 +51,19 @@ edc:
     hashicorp:
       url: "${XROAD_SECRET_STORE_SCHEME:https}://${XROAD_SECRET_STORE_HOST:127.0.0.1}:${XROAD_SECRET_STORE_PORT:8200}"
       token: "${XROAD_SECRET_STORE_TOKEN}"
+      # KV v2 mount; see ds-control-plane application.yaml for rationale.
+      folder: ds
+      health:
+        check:
+          standby:
+            ok: true
       api:
         secret:
-          path: /v1/xrd-secret/ds
+          path: /v1/xrd-ds-secret
+  encryption:
+    aes:
+      key:
+        alias: ds-aes-key
   datasource:
     default:
       url: ${xroad.db.ds-identity-hub.hibernate.connection.url}

--- a/src/service/ds-identity-hub/ds-identity-hub-customization/src/main/java/org/niis/xroad/ds/identityhub/participantcontext/CustomIdentityHubParticipantContextService.java
+++ b/src/service/ds-identity-hub/ds-identity-hub-customization/src/main/java/org/niis/xroad/ds/identityhub/participantcontext/CustomIdentityHubParticipantContextService.java
@@ -40,25 +40,18 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
 import org.eclipse.edc.participantcontext.spi.config.service.ParticipantContextConfigService;
 import org.eclipse.edc.participantcontext.spi.store.ParticipantContextStore;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.edc.spi.result.ServiceResult.conflict;
-import static org.eclipse.edc.spi.result.ServiceResult.fromFailure;
-import static org.eclipse.edc.spi.result.ServiceResult.notFound;
 import static org.eclipse.edc.spi.result.ServiceResult.success;
 
 /**
@@ -123,66 +116,6 @@ class CustomIdentityHubParticipantContextService extends IdentityHubParticipantC
         });
     }
 
-    @Override
-    public ServiceResult<IdentityHubParticipantContext> getParticipantContext(String participantContextId) {
-        return transactionContext.execute(() -> ServiceResult.from(participantContextStore.findById(participantContextId))
-                .map(this::convert));
-    }
-
-    @Override
-    public ServiceResult<Void> deleteParticipantContext(String participantContextId) {
-        return transactionContext.execute(() -> {
-            var participantContext = findByIdInternal(participantContextId);
-            if (participantContext == null) {
-                return ServiceResult.notFound("A ParticipantContext with ID '%s' does not exist.");
-            }
-            return updateParticipant(participantContextId, IdentityHubParticipantContext::deactivate)
-                    .compose(v -> {
-                        observable.invokeForEach(l -> l.deleting(participantContext));
-                        var res = participantContextStore.deleteById(participantContextId);
-                        vault.deleteSecret(participantContext.getParticipantContextId(), participantContext.getApiTokenAlias());
-                        if (res.failed()) {
-                            return fromFailure(res);
-                        }
-
-                        observable.invokeForEach(l -> l.deleted(participantContext));
-                        return ServiceResult.success();
-                    });
-        });
-    }
-
-    @Override
-    public ServiceResult<String> regenerateApiToken(String participantContextId) {
-        return transactionContext.execute(() -> {
-            var participantContext = getParticipantContext(participantContextId);
-            if (participantContext.failed()) {
-                return participantContext.map(pc -> null);
-            }
-            return createTokenAndStoreInVault(participantContext.getContent());
-        });
-    }
-
-    @Override
-    public ServiceResult<Void> updateParticipant(String participantContextId, Consumer<IdentityHubParticipantContext> modificationFunction) {
-        return transactionContext.execute(() -> {
-            var participant = findByIdInternal(participantContextId);
-            if (participant == null) {
-                return notFound("ParticipantContext with ID '%s' not found.".formatted(participantContextId));
-            }
-            modificationFunction.accept(participant);
-            var res = participantContextStore.update(participant)
-                    .onSuccess(u -> observable.invokeForEach(l -> l.updated(participant)));
-            return res.succeeded() ? success() : fromFailure(res);
-        });
-    }
-
-    @Override
-    public ServiceResult<Collection<IdentityHubParticipantContext>> query(QuerySpec querySpec) {
-        return transactionContext.execute(() -> ServiceResult.from(participantContextStore.query(querySpec))
-                .map(participantContexts -> participantContexts.stream().map(this::convert)
-                        .collect(Collectors.toList())));
-    }
-
     private ServiceResult<String> createTokenAndStoreInVault(IdentityHubParticipantContext participantContext) {
         var alias = participantContext.getApiTokenAlias();
         var newToken = tokenGenerator.generate(participantContext.getParticipantContextId());
@@ -214,12 +147,6 @@ class CustomIdentityHubParticipantContextService extends IdentityHubParticipantC
         return configResult.compose(u -> ServiceResult.from(result).map(it -> context));
     }
 
-    private IdentityHubParticipantContext findByIdInternal(String participantContextId) {
-        var resultStream = participantContextStore.findById(participantContextId)
-                .map(this::convert);
-        return resultStream.orElse(f -> null);
-    }
-
     private IdentityHubParticipantContext convert(ParticipantManifest manifest) {
         var apiKeyAlias = ofNullable(manifest.getApiKeyAlias()).orElse("%s-%s".formatted(manifest.getParticipantContextId(), API_KEY_ALIAS_SUFFIX));
         var context = IdentityHubParticipantContext.Builder.newInstance()
@@ -235,16 +162,5 @@ class CustomIdentityHubParticipantContextService extends IdentityHubParticipantC
         }
 
         return context.build();
-    }
-
-    private IdentityHubParticipantContext convert(ParticipantContext participantContext) {
-        return IdentityHubParticipantContext.Builder.newInstance()
-                .participantContextId(participantContext.getParticipantContextId())
-                .did(participantContext.getIdentity())
-                .state(participantContext.getStateAsEnum())
-                .createdAt(participantContext.getCreatedAt())
-                .lastModified(participantContext.getLastModified())
-                .properties(participantContext.getProperties())
-                .build();
     }
 }

--- a/src/service/ds-issuer-service/ds-issuer-service-application/build.gradle.kts
+++ b/src/service/ds-issuer-service/ds-issuer-service-application/build.gradle.kts
@@ -17,5 +17,8 @@ dependencies {
 
   runtimeOnly(libs.edc.core.sql.bootstrapper)
 
+  runtimeOnly(libs.edc.vault.hashicorp)
+  runtimeOnly(libs.edc.encryption.aes)
+
   runtimeOnly(project(":service:ds-identity-hub:ds-identity-hub-customization"))
 }

--- a/src/service/ds-issuer-service/ds-issuer-service-application/src/main/resources/application.yaml
+++ b/src/service/ds-issuer-service/ds-issuer-service-application/src/main/resources/application.yaml
@@ -19,6 +19,7 @@ quarkus:
         - xroad-logging.yaml
         - /etc/xroad/conf.d/local-tls.yaml
         - /etc/xroad/conf.d/local.yaml
+        - /etc/xroad/conf.d/local-ds-issuer-service.yaml
         - /etc/xroad/db.properties
     log:
       console:
@@ -52,6 +53,24 @@ web:
 
 edc:
   hostname: ${HOSTNAME}
+  vault:
+    hashicorp:
+      url: "${XROAD_SECRET_STORE_SCHEME:https}://${XROAD_SECRET_STORE_HOST:127.0.0.1}:${XROAD_SECRET_STORE_PORT:8200}"
+      token: "${XROAD_SECRET_STORE_TOKEN}"
+      # KV v2 mount xrd-ds-secret; provisioned by secret-store-init.sh.
+      # See ds-control-plane application.yaml for path-construction rationale.
+      folder: ds
+      health:
+        check:
+          standby:
+            ok: true
+      api:
+        secret:
+          path: /v1/xrd-ds-secret
+  encryption:
+    aes:
+      key:
+        alias: ds-aes-key
   datasource:
     default:
       url: ${xroad.db.ds-issuer-service.hibernate.connection.url}


### PR DESCRIPTION
Updates application config for both federation participants (application.yaml, build.gradle.kts) and trims
CustomIdentityHubParticipantContextService to match the EDC 0.17 participant-context lifecycle — drops the bespoke ParticipantContext fetch/upsert path now covered by the upstream provisioner. No proxy hot-path change. proxy-application still does not depend on proxy-dsp-core.