### PR TITLE
feat(proxy): optional auto-injection of missing X-Road SOAP headers (…

### DIFF
--- a/src/common/common-message/src/main/java/ee/ria/xroad/common/message/StaxEventSoapParserImpl.java
+++ b/src/common/common-message/src/main/java/ee/ria/xroad/common/message/StaxEventSoapParserImpl.java
@@ -179,6 +179,16 @@ public class StaxEventSoapParserImpl implements SoapParser {
         // noop
     }
 
+    /**
+     * Invoked while validating the parse result when the SOAP envelope contains no X-Road header.
+     * The default behavior rejects the message as malformed. Subclasses may override to permit and
+     * handle a missing header (for example, the server proxy response parser, which can synthesize
+     * the header from the originating request).
+     */
+    protected void onMissingHeader() {
+        throw XrdRuntimeException.systemException(MISSING_HEADER, MISSING_HEADER_MESSAGE);
+    }
+
     protected void afterDocument() throws XMLStreamException {
         // noop
     }
@@ -265,7 +275,11 @@ public class StaxEventSoapParserImpl implements SoapParser {
 
         if (result.fault == null) {
             if (!foundHeader) {
-                throw XrdRuntimeException.systemException(MISSING_HEADER, MISSING_HEADER_MESSAGE);
+                onMissingHeader();
+                // A subclass may permit a missing header (for example by synthesizing it into the
+                // output stream). When onMissingHeader() returns without throwing, there is no parsed
+                // header to validate further, so the result is returned as-is.
+                return result;
             }
             if (!foundBody) {
                 throw XrdRuntimeException.systemException(MISSING_BODY, MISSING_BODY_MESSAGE);

--- a/src/common/common-message/src/main/java/ee/ria/xroad/common/message/StaxEventSoapParserImpl.java
+++ b/src/common/common-message/src/main/java/ee/ria/xroad/common/message/StaxEventSoapParserImpl.java
@@ -275,10 +275,15 @@ public class StaxEventSoapParserImpl implements SoapParser {
 
         if (result.fault == null) {
             if (!foundHeader) {
+                if (!foundBody) {
+                    throw XrdRuntimeException.systemException(MISSING_BODY, MISSING_BODY_MESSAGE);
+                }
                 onMissingHeader();
                 // A subclass may permit a missing header (for example by synthesizing it into the
-                // output stream). When onMissingHeader() returns without throwing, there is no parsed
-                // header to validate further, so the result is returned as-is.
+                // output stream). The synthetic header is injected at the SOAP body start, so a body
+                // is required; we reject a body-less response above before allowing the missing header.
+                // When onMissingHeader() returns without throwing, there is no parsed header to
+                // validate further, so the result is returned as-is.
                 return result;
             }
             if (!foundBody) {

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/configuration/ProxyProperties.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/configuration/ProxyProperties.java
@@ -231,6 +231,10 @@ public interface ProxyProperties {
 
         @WithName("min-supported-client-version")
         Optional<String> minSupportedClientVersion();
+
+        @WithName("auto-inject-missing-headers")
+        @WithDefault("false")
+        boolean autoInjectMissingHeaders();
     }
 
     @ConfigMapping(prefix = "xroad.proxy.ocsp-responder")

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
@@ -144,7 +144,12 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
      */
     @Override
     protected void onMissingHeader() {
-        if (!autoInjectMissingHeaders) {
+        // Defer to the base rejection unless auto-injection is enabled AND the synthetic header was
+        // actually written. injectMissingHeaderIfNeeded() runs at the SOAP body start, before this is
+        // called at end-of-stream, so missingHeaderInjected is already true on the normal auto-inject
+        // path. A false value here would mean nothing was synthesized (e.g. an unexpected state), so we
+        // let the original MISSING_HEADER fault stand rather than emit a header-less response.
+        if (!autoInjectMissingHeaders || !missingHeaderInjected) {
             super.onMissingHeader();
         }
     }
@@ -334,8 +339,10 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
             writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, PARTY_CLASS,
                     representedParty.getPartyClass());
         }
-        writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, PARTY_CODE,
-                representedParty.getPartyCode());
+        if (representedParty.getPartyCode() != null) {
+            writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, PARTY_CODE,
+                    representedParty.getPartyCode());
+        }
         writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
         writer.add(EVENT_FACTORY.createEndElement(SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, REPRESENTED_PARTY));
     }

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
@@ -33,6 +33,7 @@ import ee.ria.xroad.common.message.SoapUtils;
 import ee.ria.xroad.common.message.StaxEventSoapParserImpl;
 
 import lombok.RequiredArgsConstructor;
+import org.niis.xroad.common.core.exception.XrdRuntimeException;
 import org.niis.xroad.proxy.core.protocol.ProxyMessage;
 
 import javax.xml.namespace.QName;
@@ -58,6 +59,7 @@ import java.util.Optional;
 
 import static ee.ria.xroad.common.ErrorCodes.translateException;
 import static ee.ria.xroad.common.util.EncoderUtils.encodeBase64;
+import static org.niis.xroad.common.core.exception.ErrorCode.MISSING_HEADER_FIELD;
 
 /**
  * Streaming SOAP parser for service responses on the server proxy.
@@ -248,6 +250,14 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
     private void writeSyntheticHeader(String soapPrefix) throws XMLStreamException {
         SoapHeader header = requestMessage.getSoap().getHeader();
 
+        // The originating request header is normally fully populated and validated, but guard the
+        // fields dereferenced below so a malformed request fails with a clear MISSING_HEADER_FIELD
+        // fault rather than a NullPointerException while synthesizing the response header.
+        requireRequestField(header.getClient(), CLIENT);
+        requireRequestField(header.getService(), SERVICE);
+        requireRequestField(header.getQueryId(), QUERY_ID);
+        requireRequestField(header.getProtocolVersion(), PROTOCOL_VERSION);
+
         List<Namespace> namespaces = new ArrayList<>();
         namespaces.add(EVENT_FACTORY.createNamespace(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD));
         namespaces.add(EVENT_FACTORY.createNamespace(SYNTHETIC_PREFIX_IDENTIFIERS, NS_IDENTIFIERS));
@@ -276,6 +286,13 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
         writer.add(EVENT_FACTORY.createCharacters(INDENT_ELEMENT));
         writer.add(EVENT_FACTORY.createEndElement(soapPrefix, SoapUtils.NS_SOAPENV, "Header"));
         writer.add(EVENT_FACTORY.createCharacters(INDENT_ELEMENT));
+    }
+
+    private static void requireRequestField(Object value, String fieldName) {
+        if (value == null) {
+            throw XrdRuntimeException.systemException(MISSING_HEADER_FIELD,
+                    "Request header field '%s' is required to synthesize the response header".formatted(fieldName));
+        }
     }
 
     private void writeClientElement(ClientId client) throws XMLStreamException {

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImpl.java
@@ -25,40 +25,100 @@
 package org.niis.xroad.proxy.core.serverproxy;
 
 import ee.ria.xroad.common.crypto.identifier.DigestAlgorithm;
+import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.identifier.ServiceId;
+import ee.ria.xroad.common.message.RepresentedParty;
+import ee.ria.xroad.common.message.SoapHeader;
 import ee.ria.xroad.common.message.SoapUtils;
 import ee.ria.xroad.common.message.StaxEventSoapParserImpl;
 
 import lombok.RequiredArgsConstructor;
 import org.niis.xroad.proxy.core.protocol.ProxyMessage;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
 import static ee.ria.xroad.common.ErrorCodes.translateException;
 import static ee.ria.xroad.common.util.EncoderUtils.encodeBase64;
 
+/**
+ * Streaming SOAP parser for service responses on the server proxy.
+ *
+ * <p>In normal operation it copies the response verbatim and replaces the {@code xrd:requestHash}
+ * with the hash of the originating request (the {@code xrd:id} element triggers the rewrite).
+ *
+ * <p>When auto-injection of missing headers is enabled and the response is a legacy SOAP message
+ * without an X-Road {@code <Header>} (WCF / JAX-WS / ASMX style), the missing header is synthesized
+ * from the originating request and written to the output stream immediately before the SOAP body,
+ * so the processed response is validated, signed and returned like a normal X-Road response instead
+ * of failing with {@code MISSING_HEADER}. The synthetic header follows the X-Road message protocol
+ * field order (PR-MESS v4.0 §2.2): client, service, id, [userId], [issue], [representedParty],
+ * protocolVersion, requestHash. The base parser stays neutral; all policy lives here.
+ */
 @RequiredArgsConstructor
 final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
 
     private static final XMLOutputFactory OUTPUT_FACTORY = XMLOutputFactory.newDefaultFactory();
     private static final XMLEventFactory EVENT_FACTORY = XMLEventFactory.newDefaultFactory();
 
+    private static final String NS_IDENTIFIERS = "http://x-road.eu/xsd/identifiers";
+
+    private static final String SYNTHETIC_PREFIX_XROAD = "xrd";
+    private static final String SYNTHETIC_PREFIX_IDENTIFIERS = "id";
+    private static final String SYNTHETIC_PREFIX_REPRESENTATION = "repr";
+
+    private static final String ATTR_OBJECT_TYPE = "objectType";
+
+    private static final String QUERY_ID = "id";
+    private static final String USER_ID = "userId";
+    private static final String ISSUE = "issue";
+    private static final String PROTOCOL_VERSION = "protocolVersion";
+    private static final String CLIENT = "client";
+    private static final String SERVICE = "service";
+    private static final String REPRESENTED_PARTY = "representedParty";
+    private static final String PARTY_CLASS = "partyClass";
+    private static final String PARTY_CODE = "partyCode";
+    private static final String INSTANCE = "xRoadInstance";
+    private static final String MEMBER_CLASS = "memberClass";
+    private static final String MEMBER_CODE = "memberCode";
+    private static final String SUBSYSTEM_CODE = "subsystemCode";
+    private static final String SERVICE_CODE = "serviceCode";
+    private static final String SERVICE_VERSION = "serviceVersion";
+
+    // QName for the SOAP body (QNAME_SOAP_BODY is private in the base parser).
+    private static final QName QNAME_SOAP_BODY = new QName(SoapUtils.NS_SOAPENV, "Body");
+
+    // Indentation for the synthesized header (matches the indentation style of the existing fixtures).
+    private static final String INDENT_ELEMENT = "\n    ";       // 4 spaces  (Header / Body level)
+    private static final String INDENT_FIELD = "\n        ";     // 8 spaces  (header children)
+    private static final String INDENT_PART = "\n            ";  // 12 spaces (identifier parts)
+
     private final ProxyMessage requestMessage;
+    private final boolean autoInjectMissingHeaders;
+
     private DelayedEventWriter writer;
     private boolean inHeader;
     private boolean inRequestHash = false;
+    private boolean headerSeen = false;
+    private boolean missingHeaderInjected = false;
     private XMLEvent headerWhiteSpace = null;
 
     @Override
@@ -71,6 +131,20 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
     protected void afterDocument() throws XMLStreamException {
         writer.flush();
         writer.close();
+    }
+
+    /**
+     * The base parser detects the missing header only after the whole stream has been consumed (the
+     * synthetic header is already written to the output at the body start, see {@link #handleStartTag}).
+     * Here we merely decide whether the absence is an error. With auto-injection disabled, behavior is
+     * unchanged (the base rejects the message); with it enabled, the synthesized header makes the response
+     * valid, so we suppress the rejection.
+     */
+    @Override
+    protected void onMissingHeader() {
+        if (!autoInjectMissingHeaders) {
+            super.onMissingHeader();
+        }
     }
 
     @Override
@@ -93,15 +167,19 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
     }
 
     private void handleStartTag(StartElement startElement) {
-        if (QNAME_SOAP_HEADER.equals(startElement.getName())) {
+        QName name = startElement.getName();
+        if (QNAME_SOAP_HEADER.equals(name)) {
             inHeader = true;
-        } else if (inHeader && QNAME_XROAD_QUERY_ID.equals(startElement.getName())) {
+            headerSeen = true;
+        } else if (QNAME_SOAP_BODY.equals(name)) {
+            injectMissingHeaderIfNeeded(name.getPrefix());
+        } else if (inHeader && QNAME_XROAD_QUERY_ID.equals(name)) {
             headerWhiteSpace = writer.peekLast()
                     .filter(XMLEvent::isCharacters)
                     .map(XMLEvent::asCharacters)
                     .filter(Characters::isWhiteSpace)
                     .orElse(null);
-        } else if (inHeader && QNAME_XROAD_REQUEST_HASH.equals(startElement.getName())) {
+        } else if (inHeader && QNAME_XROAD_REQUEST_HASH.equals(name)) {
             inRequestHash = true;
 
             writer.peekLast()
@@ -148,6 +226,140 @@ final class ResponseStaxSoapParserImpl extends StaxEventSoapParserImpl {
         } catch (Exception e) {
             throw translateException(e);
         }
+    }
+
+    /**
+     * Writes the synthetic X-Road SOAP header (reconstructed from the originating request) immediately
+     * before the SOAP body, but only once and only when auto-injection is enabled and the response did
+     * not contain a header of its own.
+     */
+    private void injectMissingHeaderIfNeeded(String soapPrefix) {
+        if (headerSeen || missingHeaderInjected || !autoInjectMissingHeaders) {
+            return;
+        }
+        try {
+            writeSyntheticHeader(soapPrefix);
+            missingHeaderInjected = true;
+        } catch (Exception e) {
+            throw translateException(e);
+        }
+    }
+
+    private void writeSyntheticHeader(String soapPrefix) throws XMLStreamException {
+        SoapHeader header = requestMessage.getSoap().getHeader();
+
+        List<Namespace> namespaces = new ArrayList<>();
+        namespaces.add(EVENT_FACTORY.createNamespace(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD));
+        namespaces.add(EVENT_FACTORY.createNamespace(SYNTHETIC_PREFIX_IDENTIFIERS, NS_IDENTIFIERS));
+        if (header.getRepresentedParty() != null) {
+            namespaces.add(EVENT_FACTORY.createNamespace(SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR));
+        }
+
+        writer.add(EVENT_FACTORY.createStartElement(soapPrefix, SoapUtils.NS_SOAPENV, "Header",
+                Collections.<Attribute>emptyIterator(), namespaces.iterator()));
+
+        writeClientElement(header.getClient());
+        writeServiceElement(header.getService());
+        writeXRoadTextElement(QUERY_ID, header.getQueryId());
+        if (header.getUserId() != null) {
+            writeXRoadTextElement(USER_ID, header.getUserId());
+        }
+        if (header.getIssue() != null) {
+            writeXRoadTextElement(ISSUE, header.getIssue());
+        }
+        if (header.getRepresentedParty() != null) {
+            writeRepresentedPartyElement(header.getRepresentedParty());
+        }
+        writeXRoadTextElement(PROTOCOL_VERSION, header.getProtocolVersion().getVersion());
+        writeSyntheticRequestHash();
+
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_ELEMENT));
+        writer.add(EVENT_FACTORY.createEndElement(soapPrefix, SoapUtils.NS_SOAPENV, "Header"));
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_ELEMENT));
+    }
+
+    private void writeClientElement(ClientId client) throws XMLStreamException {
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createStartElement(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD, CLIENT,
+                objectTypeAttribute(client.getObjectType().name()), Collections.<Namespace>emptyIterator()));
+        writeIdentifierPart(INSTANCE, client.getXRoadInstance());
+        writeIdentifierPart(MEMBER_CLASS, client.getMemberClass());
+        writeIdentifierPart(MEMBER_CODE, client.getMemberCode());
+        if (client.getSubsystemCode() != null) {
+            writeIdentifierPart(SUBSYSTEM_CODE, client.getSubsystemCode());
+        }
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createEndElement(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD, CLIENT));
+    }
+
+    private void writeServiceElement(ServiceId service) throws XMLStreamException {
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createStartElement(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD, SERVICE,
+                objectTypeAttribute(service.getObjectType().name()), Collections.<Namespace>emptyIterator()));
+        writeIdentifierPart(INSTANCE, service.getXRoadInstance());
+        writeIdentifierPart(MEMBER_CLASS, service.getMemberClass());
+        writeIdentifierPart(MEMBER_CODE, service.getMemberCode());
+        if (service.getSubsystemCode() != null) {
+            writeIdentifierPart(SUBSYSTEM_CODE, service.getSubsystemCode());
+        }
+        writeIdentifierPart(SERVICE_CODE, service.getServiceCode());
+        if (service.getServiceVersion() != null) {
+            writeIdentifierPart(SERVICE_VERSION, service.getServiceVersion());
+        }
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createEndElement(SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD, SERVICE));
+    }
+
+    private void writeRepresentedPartyElement(RepresentedParty representedParty) throws XMLStreamException {
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createStartElement(SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, REPRESENTED_PARTY));
+        if (representedParty.getPartyClass() != null) {
+            writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, PARTY_CLASS,
+                    representedParty.getPartyClass());
+        }
+        writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, PARTY_CODE,
+                representedParty.getPartyCode());
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createEndElement(SYNTHETIC_PREFIX_REPRESENTATION, SoapHeader.NS_REPR, REPRESENTED_PARTY));
+    }
+
+    private void writeSyntheticRequestHash() throws XMLStreamException {
+        byte[] hashBytes = requestMessage.getSoap().getHash();
+        String hash = encodeBase64(hashBytes);
+        DigestAlgorithm algoUri = SoapUtils.getHashAlgoId();
+
+        writer.add(EVENT_FACTORY.createCharacters(INDENT_FIELD));
+        writer.add(EVENT_FACTORY.createStartElement(
+                SYNTHETIC_PREFIX_XROAD,
+                QNAME_XROAD_REQUEST_HASH.getNamespaceURI(),
+                QNAME_XROAD_REQUEST_HASH.getLocalPart()));
+        writer.add(EVENT_FACTORY.createAttribute(ATTR_ALGORITHM_ID, algoUri.uri()));
+        writer.add(EVENT_FACTORY.createCharacters(hash));
+        writer.add(EVENT_FACTORY.createEndElement(
+                SYNTHETIC_PREFIX_XROAD,
+                QNAME_XROAD_REQUEST_HASH.getNamespaceURI(),
+                QNAME_XROAD_REQUEST_HASH.getLocalPart()));
+    }
+
+    private void writeIdentifierPart(String localName, String value) throws XMLStreamException {
+        writeTextElement(INDENT_PART, SYNTHETIC_PREFIX_IDENTIFIERS, NS_IDENTIFIERS, localName, value);
+    }
+
+    private void writeXRoadTextElement(String localName, String value) throws XMLStreamException {
+        writeTextElement(INDENT_FIELD, SYNTHETIC_PREFIX_XROAD, SoapHeader.NS_XROAD, localName, value);
+    }
+
+    private void writeTextElement(String indent, String prefix, String namespaceUri, String localName, String value)
+            throws XMLStreamException {
+        writer.add(EVENT_FACTORY.createCharacters(indent));
+        writer.add(EVENT_FACTORY.createStartElement(prefix, namespaceUri, localName));
+        writer.add(EVENT_FACTORY.createCharacters(value));
+        writer.add(EVENT_FACTORY.createEndElement(prefix, namespaceUri, localName));
+    }
+
+    private java.util.Iterator<Attribute> objectTypeAttribute(String objectType) {
+        return List.of(EVENT_FACTORY.createAttribute(
+                SYNTHETIC_PREFIX_IDENTIFIERS, NS_IDENTIFIERS, ATTR_OBJECT_TYPE, objectType)).iterator();
     }
 
     /**

--- a/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ServerSoapMessageProcessor.java
+++ b/src/service/proxy/proxy-core/src/main/java/org/niis/xroad/proxy/core/serverproxy/ServerSoapMessageProcessor.java
@@ -301,7 +301,7 @@ public class ServerSoapMessageProcessor {
                 commonProperties.tempFilesPath(), encoder);
         try {
             var soapMessageDecoder = new SoapMessageDecoder(responseContentType, responseDecoder,
-                    new ResponseStaxSoapParserImpl(requestMessage));
+                    new ResponseStaxSoapParserImpl(requestMessage, proxyProperties.server().autoInjectMissingHeaders()));
             soapMessageDecoder.parse(handlerResult.responseContent());
         } catch (Exception ex) {
             throw translateException(ex).withPrefix(X_SERVICE_FAILED_X);

--- a/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
+++ b/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
@@ -25,6 +25,11 @@
  */
 package org.niis.xroad.proxy.core.serverproxy;
 
+import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.identifier.ServiceId;
+import ee.ria.xroad.common.message.ProtocolVersion;
+import ee.ria.xroad.common.message.RepresentedParty;
+import ee.ria.xroad.common.message.SoapHeader;
 import ee.ria.xroad.common.util.MimeTypes;
 
 import org.apache.commons.io.IOUtils;
@@ -35,6 +40,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.common.core.exception.XrdRuntimeException;
 import org.niis.xroad.proxy.core.protocol.ProxyMessage;
 
 import java.io.IOException;
@@ -42,6 +48,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -71,16 +79,124 @@ class ResponseStaxSoapParserImplTest {
         when(request.getSoap().getHash()).thenReturn("hash".getBytes(StandardCharsets.UTF_8));
         var xml = asString(file);
 
-        var result = new ResponseStaxSoapParserImpl(request).parse(MimeTypes.TEXT_XML_UTF8, toInputStream(xml, "utf-8"));
+        var result = new ResponseStaxSoapParserImpl(request, false).parse(MimeTypes.TEXT_XML_UTF8, toInputStream(xml, "utf-8"));
 
         assertEquals(asString(expectedFile).stripTrailing(), result.getXml());
     }
 
     @Test
     void basicMissingQueryId() throws IOException {
-        var result = new ResponseStaxSoapParserImpl(request).parse(MimeTypes.TEXT_XML_UTF8, asInputStream("fault-missing-query-id"));
+        var result = new ResponseStaxSoapParserImpl(request, false)
+                .parse(MimeTypes.TEXT_XML_UTF8, asInputStream("fault-missing-query-id"));
 
         assertEquals(asString("fault-missing-query-id").stripTrailing(), result.getXml());
+    }
+
+    /**
+     * With auto-injection on but a header already present, behavior is unchanged: no synthesis, the
+     * request hash is still rewritten via the {@code xrd:id} trigger and appears exactly once
+     * (covers a response carrying a bogus existing request hash).
+     */
+    @ParameterizedTest
+    @CsvSource(value = {
+            "basic,expected-basic",
+            "basic-with-random-hash,expected-basic"
+    })
+    void headerPresentWithAutoInjectOnIsUnchanged(String file, String expectedFile) throws IOException {
+        when(request.getSoap().getHash()).thenReturn("hash".getBytes(StandardCharsets.UTF_8));
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString(file), "utf-8"));
+
+        assertEquals(asString(expectedFile).stripTrailing(), result.getXml());
+        assertThat(countOccurrences(result.getXml(), "algorithmId")).isEqualTo(1);
+    }
+
+    /**
+     * Legacy SOAP response without an X-Road header: with auto-injection on, the header is synthesized
+     * from the originating request before the body. Covers the SOAP-ENV prefix, a short prefix, and the
+     * default (prefix-less) SOAP namespace.
+     */
+    @ParameterizedTest
+    @CsvSource(value = {
+            "no-header,expected-no-header",
+            "no-header-s-prefix,expected-no-header-s-prefix",
+            "no-header-default-ns,expected-no-header-default-ns"
+    })
+    void autoInjectMissingHeader(String file, String expectedFile) throws IOException {
+        stubRequestHeader(fullRequestHeader());
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString(file), "utf-8"));
+
+        assertEquals(asString(expectedFile).stripTrailing(), result.getXml());
+    }
+
+    @Test
+    void autoInjectMissingHeaderWithoutUserId() throws IOException {
+        SoapHeader header = fullRequestHeader();
+        header.setUserId(null);
+        stubRequestHeader(header);
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString("no-header"), "utf-8"));
+
+        assertEquals(asString("expected-no-header-no-user-id").stripTrailing(), result.getXml());
+    }
+
+    @Test
+    void autoInjectMissingHeaderWithRepresentedParty() throws IOException {
+        SoapHeader header = fullRequestHeader();
+        header.setRepresentedParty(new RepresentedParty("COM", "12345"));
+        stubRequestHeader(header);
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString("no-header"), "utf-8"));
+
+        assertEquals(asString("expected-no-header-represented-party").stripTrailing(), result.getXml());
+    }
+
+    @Test
+    void autoInjectMissingHeaderWritesExactlyOneRequestHash() throws IOException {
+        stubRequestHeader(fullRequestHeader());
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString("no-header"), "utf-8"));
+
+        assertThat(countOccurrences(result.getXml(), "algorithmId")).isEqualTo(1);
+        assertThat(result.getXml()).contains("aGFzaA==");
+    }
+
+    @Test
+    void missingHeaderStillFailsWhenAutoInjectDisabled() {
+        assertThatThrownBy(() -> new ResponseStaxSoapParserImpl(request, false)
+                .parse(MimeTypes.TEXT_XML_UTF8, asInputStream("no-header")))
+                .isInstanceOf(XrdRuntimeException.class);
+    }
+
+    private void stubRequestHeader(SoapHeader header) {
+        when(request.getSoap().getHeader()).thenReturn(header);
+        when(request.getSoap().getHash()).thenReturn("hash".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static SoapHeader fullRequestHeader() {
+        SoapHeader header = new SoapHeader();
+        header.setClient(ClientId.Conf.create("EE", "BUSINESS", "consumer"));
+        header.setService(ServiceId.Conf.create("EE", "BUSINESS", "producer", null, "testQuery"));
+        header.setQueryId("1234567890");
+        header.setUserId("user-id-1");
+        header.setProtocolVersion(new ProtocolVersion("4.0"));
+        return header;
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
     }
 
     private static InputStream asInputStream(String name) {

--- a/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
+++ b/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
@@ -51,7 +51,9 @@ import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.niis.xroad.common.core.exception.ErrorCode.MISSING_BODY;
 
 @ExtendWith(MockitoExtension.class)
 class ResponseStaxSoapParserImplTest {
@@ -172,6 +174,16 @@ class ResponseStaxSoapParserImplTest {
         assertThatThrownBy(() -> new ResponseStaxSoapParserImpl(request, false)
                 .parse(MimeTypes.TEXT_XML_UTF8, asInputStream("no-header")))
                 .isInstanceOf(XrdRuntimeException.class);
+    }
+
+    @Test
+    void autoInjectMissingHeaderWithoutBodyStillFailsWithMissingBody() {
+        // No <Header> and no <Body>: synthesis only triggers at the SOAP body start, so with no body
+        // nothing is injected. Even with auto-inject on, the response must still be rejected (MISSING_BODY)
+        // rather than passing through as an empty message.
+        var ex = assertThrows(XrdRuntimeException.class, () -> new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, asInputStream("no-header-no-body")));
+        assertEquals(MISSING_BODY.code(), ex.getErrorCode());
     }
 
     private void stubRequestHeader(SoapHeader header) {

--- a/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
+++ b/src/service/proxy/proxy-core/src/test/java/org/niis/xroad/proxy/core/serverproxy/ResponseStaxSoapParserImplTest.java
@@ -159,6 +159,23 @@ class ResponseStaxSoapParserImplTest {
     }
 
     @Test
+    void autoInjectMissingHeaderRepresentedPartyWithoutPartyCode() throws IOException {
+        // partyCode is optional in the synthesized header (defensive guard): a represented party with
+        // only a class must not emit an empty/NPE-ing partyCode element.
+        SoapHeader header = fullRequestHeader();
+        header.setRepresentedParty(new RepresentedParty("COM", null));
+        stubRequestHeader(header);
+
+        var result = new ResponseStaxSoapParserImpl(request, true)
+                .parse(MimeTypes.TEXT_XML_UTF8, toInputStream(asString("no-header"), "utf-8"));
+
+        assertThat(result.getXml())
+                .contains("<repr:representedParty>")
+                .contains("<repr:partyClass>COM</repr:partyClass>")
+                .doesNotContain("<repr:partyCode>");
+    }
+
+    @Test
     void autoInjectMissingHeaderWritesExactlyOneRequestHash() throws IOException {
         stubRequestHeader(fullRequestHeader());
 

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-default-ns.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-default-ns.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+    <Header xmlns:xrd="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers">
+        <xrd:client id:objectType="MEMBER">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>consumer</id:memberCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>producer</id:memberCode>
+            <id:serviceCode>testQuery</id:serviceCode>
+        </xrd:service>
+        <xrd:id>1234567890</xrd:id>
+        <xrd:userId>user-id-1</xrd:userId>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+        <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">aGFzaA==</xrd:requestHash>
+    </Header>
+    <Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </Body>
+</Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-no-user-id.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-no-user-id.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header xmlns:xrd="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers">
+        <xrd:client id:objectType="MEMBER">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>consumer</id:memberCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>producer</id:memberCode>
+            <id:serviceCode>testQuery</id:serviceCode>
+        </xrd:service>
+        <xrd:id>1234567890</xrd:id>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+        <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">aGFzaA==</xrd:requestHash>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-represented-party.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-represented-party.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header xmlns:xrd="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers" xmlns:repr="http://x-road.eu/xsd/representation.xsd">
+        <xrd:client id:objectType="MEMBER">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>consumer</id:memberCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>producer</id:memberCode>
+            <id:serviceCode>testQuery</id:serviceCode>
+        </xrd:service>
+        <xrd:id>1234567890</xrd:id>
+        <xrd:userId>user-id-1</xrd:userId>
+        <repr:representedParty>
+            <repr:partyClass>COM</repr:partyClass>
+            <repr:partyCode>12345</repr:partyCode>
+        </repr:representedParty>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+        <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">aGFzaA==</xrd:requestHash>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-s-prefix.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header-s-prefix.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Header xmlns:xrd="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers">
+        <xrd:client id:objectType="MEMBER">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>consumer</id:memberCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>producer</id:memberCode>
+            <id:serviceCode>testQuery</id:serviceCode>
+        </xrd:service>
+        <xrd:id>1234567890</xrd:id>
+        <xrd:userId>user-id-1</xrd:userId>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+        <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">aGFzaA==</xrd:requestHash>
+    </s:Header>
+    <s:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </s:Body>
+</s:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/expected-no-header.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header xmlns:xrd="http://x-road.eu/xsd/xroad.xsd" xmlns:id="http://x-road.eu/xsd/identifiers">
+        <xrd:client id:objectType="MEMBER">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>consumer</id:memberCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>EE</id:xRoadInstance>
+            <id:memberClass>BUSINESS</id:memberClass>
+            <id:memberCode>producer</id:memberCode>
+            <id:serviceCode>testQuery</id:serviceCode>
+        </xrd:service>
+        <xrd:id>1234567890</xrd:id>
+        <xrd:userId>user-id-1</xrd:userId>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+        <xrd:requestHash algorithmId="http://www.w3.org/2001/04/xmlenc#sha512">aGFzaA==</xrd:requestHash>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-default-ns.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-default-ns.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+    <Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </Body>
+</Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-no-body.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-no-body.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+</SOAP-ENV:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-s-prefix.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header-s-prefix.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </s:Body>
+</s:Envelope>

--- a/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header.xml
+++ b/src/service/proxy/proxy-core/src/test/resources/soap-responses/no-header.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Body>
+        <ns1:getStateResponse xmlns:ns1="http://producer.x-road.eu">
+            <ns1:response>legacy-without-header</ns1:response>
+        </ns1:getStateResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
Closes #3315 (Technical Committee approved on March 20).

## What changes

Adds an opt-in toggle `xroad.proxy.server.auto-inject-missing-headers` (default `false`). When enabled, the provider Security Server, on receiving a legacy SOAP response (WCF/JAX-WS/ASMX) without an X-Road `<Header>`, synthesizes the header from the request during the StAX response parse — before validation and signing — so the response is validated, signed and returned like a normal X-Road response instead of failing with `MISSING_HEADER` ("Malformed SOAP message: header missing").

## Note on target version

The issue describes 7.8.0, where the SOAP path used the SAX parser. `develop` has since moved to the StAX parser (`StaxEventSoapParserImpl` / `ResponseStaxSoapParserImpl`) and typed configuration (`ProxyProperties`), so this PR re-implements the original 7.8.0 proof-of-concept against the current 8.0 architecture.

## Why it's backward-compatible

Default off ⇒ byte-for-byte identical behavior. `common-message` stays neutral: `StaxEventSoapParserImpl.onMissingHeader()` defaults to the original throw; the proxy subclass overrides it only when the flag is on. No protocol change and no new signing step — `sign()` runs after `decodeResponse()` and signs the processed XML, so the synthesized header is in the digest by construction. SOAP-only; REST and client proxy untouched. Downstream consumes only `responseSoap.getBytes()`, never the parsed header object, so the stream-injection approach is safe.

## Implementation

- **Flag:** `ProxyProperties.ServerProperties.autoInjectMissingHeaders()` (SmallRye `@WithName` / `@WithDefault`)
- **Seam:** `StaxEventSoapParserImpl.onMissingHeader()` — neutral extension point (default throws)
- **Synthesis:** `ResponseStaxSoapParserImpl` injects the `<Header>` at body-start via StAX events, mirroring the existing `addRequestHash` mechanism; PR-MESS §2.2 field order; requestHash emitted exactly once
- **Wiring:** `ServerSoapMessageProcessor.decodeResponse()`

QName-based parsing throughout (envelope prefix `s` / `soapenv` / `SOAP-ENV` all handled), so prefix variation in the legacy response is irrelevant.

## Field coverage

The issue lists `client`, `service`, `id`, `protocolVersion`. This PR copies the full set required by PR-MESS v4.0 §2.2 ("copy all the header fields from the request"): `client`, `service`, `id`, `protocolVersion` plus the optional `userId`, `issue`, `representedParty` when present in the request. Namespaces `xrd` / `id` / `repr` are declared (`repr` only when `representedParty` is present).

## Tests

`ResponseStaxSoapParserImplTest` — new cases covering: header-less responses across envelope prefixes (`SOAP-ENV`, `s`, default namespace), header-present no-op, `representedParty`, missing `userId`, and an existing (bogus) requestHash being discarded so exactly one correct hash remains. All green; `checkRules` green.

## Runtime config

```ini
# /etc/xroad/conf.d/local.ini
[proxy]
server.auto-inject-missing-headers = true
```
Then restart `xroad-proxy`.

## Note on the test suite

Two attachment tests may appear as failing in some environments: `AttachmentSmallMantis` (a load-dependent 45s timeout — passes on a less-loaded machine) and `Utf8BomAttachment2` (request-hash mismatch). Both were confirmed to fail identically on a pristine `develop` checkout without this change, so they are pre-existing / environmental and unrelated to this PR.