### PR TITLE
feat: Cache ServerConf-backed EDC catalog store reads

### DIFF
--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/AssetIndexServerConfStore.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/AssetIndexServerConfStore.java
@@ -61,6 +61,7 @@ class AssetIndexServerConfStore implements AssetIndex {
     private final String participantContextId;
     private final String managementParticipantContextId;
     private final BuiltinServiceCatalog builtinServiceCatalog;
+    private final StoreEnumerationCache<Asset> cache;
     private final QueryEvaluator<Asset> queryEvaluator = new QueryEvaluator<>(Asset::getId, Asset::getParticipantContextId);
 
     /** MANAGEMENT subsystem uses a distinct DSP identity to avoid self-negotiation constraint violations. */
@@ -86,6 +87,14 @@ class AssetIndexServerConfStore implements AssetIndex {
             log.trace("queryAssets criteria={} offset={} limit={}",
                     querySpec.getFilterExpression(), querySpec.getOffset(), querySpec.getLimit());
         }
+        var snapshot = cache.getEnumeration(this::buildAssetList);
+        if (log.isTraceEnabled()) {
+            log.trace("queryAssets collected={} assets before filtering", snapshot.size());
+        }
+        return queryEvaluator.evaluate(snapshot.stream(), querySpec);
+    }
+
+    private List<Asset> buildAssetList() {
         var assets = new ArrayList<Asset>();
         for (var member : serverConfProvider.getMembers()) {
             for (var serviceId : serverConfProvider.getAllServices(member)) {
@@ -100,15 +109,17 @@ class AssetIndexServerConfStore implements AssetIndex {
         }
         ManagementServiceCatalog.resolveSyntheticServices(globalConfProvider, serverConfProvider)
                 .forEach(serviceId -> assets.add(AssetMapper.toAsset(serviceId, managementParticipantContextId)));
-        if (log.isTraceEnabled()) {
-            log.trace("queryAssets collected={} assets before filtering", assets.size());
-        }
-        return queryEvaluator.evaluate(assets.stream(), querySpec);
+        return assets;
     }
 
     @Override
     @Nullable
     public Asset findById(String assetId) {
+        return cache.findById(assetId, () -> findByIdInternal(assetId));
+    }
+
+    @Nullable
+    private Asset findByIdInternal(String assetId) {
         log.trace("findById assetId={}", assetId);
         var builtinServiceId = builtinServiceCatalog.findServiceId(assetId);
         if (builtinServiceId != null) {
@@ -159,6 +170,17 @@ class AssetIndexServerConfStore implements AssetIndex {
             log.trace("resolveForAsset assetId={} matched builtin, baseUrl={}", assetId, builtinServiceCatalog.serverProxyUrl());
             return buildHttpDataAddress(builtinServiceCatalog.serverProxyUrl());
         }
+        var cached = cache.getDataAddress(assetId);
+        if (cached != null) {
+            return cached;
+        }
+        var result = resolveForAssetInternal(assetId);
+        cache.cacheDataAddress(assetId, result);
+        return result;
+    }
+
+    @Nullable
+    private DataAddress resolveForAssetInternal(String assetId) {
         var serviceId = AssetMapper.decodeAssetId(assetId);
         if (serviceId == null) {
             log.trace("resolveForAsset assetId={} decode failed, returning null", assetId);

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/ContractDefinitionServerConfStore.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/ContractDefinitionServerConfStore.java
@@ -63,6 +63,7 @@ class ContractDefinitionServerConfStore implements ContractDefinitionStore {
     private final String participantContextId;
     private final String managementParticipantContextId;
     private final BuiltinServiceCatalog builtinServiceCatalog;
+    private final StoreEnumerationCache<ContractDefinition> cache;
     private final QueryEvaluator<ContractDefinition> queryEvaluator =
             new QueryEvaluator<>(ContractDefinition::getId, ContractDefinition::getParticipantContextId);
 
@@ -77,6 +78,11 @@ class ContractDefinitionServerConfStore implements ContractDefinitionStore {
     @Override
     @Nullable
     public ContractDefinition findById(String definitionId) {
+        return cache.findById(definitionId, () -> findByIdInternal(definitionId));
+    }
+
+    @Nullable
+    private ContractDefinition findByIdInternal(String definitionId) {
         log.trace("findById definitionId={}", definitionId);
         if (definitionId == null || definitionId.isBlank()) {
             log.trace("findById definitionId blank, returning null");
@@ -135,8 +141,15 @@ class ContractDefinitionServerConfStore implements ContractDefinitionStore {
             log.trace("findAll criteria={} offset={} limit={}",
                     spec.getFilterExpression(), spec.getOffset(), spec.getLimit());
         }
-        var definitions = new ArrayList<ContractDefinition>();
+        var snapshot = cache.getEnumeration(this::buildContractDefinitionList);
+        if (log.isTraceEnabled()) {
+            log.trace("findAll collected={} definitions before filtering", snapshot.size());
+        }
+        return queryEvaluator.evaluate(snapshot.stream(), spec);
+    }
 
+    private List<ContractDefinition> buildContractDefinitionList() {
+        var definitions = new ArrayList<ContractDefinition>();
         for (var member : serverConfProvider.getMembers()) {
             for (var serviceId : serverConfProvider.getAllServices(member)) {
                 collectContractDefinitionsForService(serviceId, definitions);
@@ -148,11 +161,7 @@ class ContractDefinitionServerConfStore implements ContractDefinitionStore {
         ManagementServiceCatalog.resolveSyntheticServices(globalConfProvider, serverConfProvider)
                 .forEach(serviceId -> definitions.add(ContractDefinitionMapper.toOwnerOnlyContractDefinition(
                         serviceId, managementParticipantContextId)));
-
-        if (log.isTraceEnabled()) {
-            log.trace("findAll collected={} definitions before filtering", definitions.size());
-        }
-        return queryEvaluator.evaluate(definitions.stream(), spec);
+        return definitions;
     }
 
     @Override

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/PolicyDefinitionServerConfStore.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/PolicyDefinitionServerConfStore.java
@@ -66,6 +66,7 @@ class PolicyDefinitionServerConfStore implements PolicyDefinitionStore {
     private final String participantContextId;
     private final String managementParticipantContextId;
     private final BuiltinServiceCatalog builtinServiceCatalog;
+    private final StoreEnumerationCache<PolicyDefinition> cache;
     private final QueryEvaluator<PolicyDefinition> queryEvaluator =
             new QueryEvaluator<>(PolicyDefinition::getId, PolicyDefinition::getParticipantContextId);
 
@@ -81,6 +82,11 @@ class PolicyDefinitionServerConfStore implements PolicyDefinitionStore {
     @Nullable
     @WithSpan("dsp-find-acl")
     public PolicyDefinition findById(@SpanAttribute String policyId) {
+        return cache.findById(policyId, () -> findByIdInternal(policyId));
+    }
+
+    @Nullable
+    private PolicyDefinition findByIdInternal(String policyId) {
         log.trace("findById policyId={}", policyId);
         if (policyId == null || policyId.isBlank()) {
             log.trace("findById policyId blank, returning null");
@@ -132,8 +138,15 @@ class PolicyDefinitionServerConfStore implements PolicyDefinitionStore {
             log.trace("findAll criteria={} offset={} limit={}",
                     spec.getFilterExpression(), spec.getOffset(), spec.getLimit());
         }
-        var policies = new ArrayList<PolicyDefinition>();
+        var snapshot = cache.getEnumeration(this::buildPolicyList);
+        if (log.isTraceEnabled()) {
+            log.trace("findAll collected={} policies before filtering", snapshot.size());
+        }
+        return queryEvaluator.evaluate(snapshot.stream(), spec);
+    }
 
+    private List<PolicyDefinition> buildPolicyList() {
+        var policies = new ArrayList<PolicyDefinition>();
         for (var member : serverConfProvider.getMembers()) {
             for (var serviceId : serverConfProvider.getAllServices(member)) {
                 collectPoliciesForService(serviceId, policies);
@@ -147,11 +160,7 @@ class PolicyDefinitionServerConfStore implements PolicyDefinitionStore {
                 .forEach(serviceId -> policies.add(policyMapper.toOwnerOnlyPolicyDefinition(
                         ContractDefinitionMapper.ownerOnlyPolicyId(serviceId),
                         serviceId.getClientId(), managementParticipantContextId)));
-
-        if (log.isTraceEnabled()) {
-            log.trace("findAll collected={} policies before filtering", policies.size());
-        }
-        return queryEvaluator.evaluate(policies.stream(), spec);
+        return policies;
     }
 
     @Override

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/StoreCacheConfig.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/StoreCacheConfig.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.catalog;
+
+record StoreCacheConfig(boolean enabled, long ttlSeconds, int findByIdMaxSize) {
+}

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/StoreEnumerationCache.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/StoreEnumerationCache.java
@@ -1,0 +1,165 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.catalog;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import jakarta.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+/**
+ * TTL-based Guava cache wrapping enumeration (find-all) and point-lookup (find-by-id) paths.
+ */
+@Slf4j
+class StoreEnumerationCache<T> {
+
+    @Nullable
+    private final Cache<Boolean, List<T>> enumerationCache;
+    @Nullable
+    private final Cache<String, T> findByIdCache;
+    @Nullable
+    private final Cache<String, DataAddress> dataAddressCache;
+    private final String storeName;
+
+    StoreEnumerationCache(boolean enabled, long ttlSeconds, int findByIdMaxSize, String storeName) {
+        this(enabled, ttlSeconds, findByIdMaxSize, storeName, Ticker.systemTicker());
+    }
+
+    StoreEnumerationCache(boolean enabled, long ttlSeconds, int findByIdMaxSize, String storeName, Ticker ticker) {
+        this.storeName = storeName;
+        if (enabled) {
+            enumerationCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+                    .ticker(ticker)
+                    .recordStats()
+                    .build();
+            findByIdCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+                    .maximumSize(findByIdMaxSize)
+                    .ticker(ticker)
+                    .recordStats()
+                    .build();
+            dataAddressCache = CacheBuilder.newBuilder()
+                    .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+                    .maximumSize(findByIdMaxSize)
+                    .ticker(ticker)
+                    .recordStats()
+                    .build();
+        } else {
+            enumerationCache = null;
+            findByIdCache = null;
+            dataAddressCache = null;
+        }
+    }
+
+    List<T> getEnumeration(Supplier<List<T>> loader) {
+        if (enumerationCache == null) {
+            return loader.get();
+        }
+        try {
+            return enumerationCache.get(Boolean.TRUE, () -> {
+                var result = loader.get();
+                logStatistics();
+                return result;
+            });
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IllegalStateException("Cache load failed", e.getCause());
+        }
+    }
+
+    @Nullable
+    T findById(String id, Supplier<T> loader) {
+        return getOrLoad(findByIdCache, id, loader);
+    }
+
+    @Nullable
+    private static <V> V getOrLoad(@Nullable Cache<String, V> cache, String key, Supplier<V> loader) {
+        if (cache == null) {
+            return loader.get();
+        }
+        var cached = cache.getIfPresent(key);
+        if (cached != null) {
+            return cached;
+        }
+        var result = loader.get();
+        if (result != null) {
+            cache.put(key, result);
+        }
+        return result;
+    }
+
+    void cacheDataAddress(String assetId, @Nullable DataAddress value) {
+        if (dataAddressCache != null && value != null) {
+            dataAddressCache.put(assetId, value);
+        }
+    }
+
+    @Nullable
+    DataAddress getDataAddress(String assetId) {
+        if (dataAddressCache == null) {
+            return null;
+        }
+        return dataAddressCache.getIfPresent(assetId);
+    }
+
+    void logStatistics() {
+        if (!log.isTraceEnabled()) {
+            return;
+        }
+        if (enumerationCache != null) {
+            log.trace("{} enumeration cache stats: {}", storeName, enumerationCache.stats());
+        }
+        if (findByIdCache != null) {
+            log.trace("{} findById cache stats: {}", storeName, findByIdCache.stats());
+        }
+        if (dataAddressCache != null) {
+            log.trace("{} dataAddress cache stats: {}", storeName, dataAddressCache.stats());
+        }
+    }
+
+    void invalidate() {
+        if (enumerationCache != null) {
+            enumerationCache.invalidateAll();
+        }
+        if (findByIdCache != null) {
+            findByIdCache.invalidateAll();
+        }
+        if (dataAddressCache != null) {
+            dataAddressCache.invalidateAll();
+        }
+    }
+}

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/XRoadServerConfCatalogExtension.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/main/java/org/niis/xroad/edc/extension/catalog/XRoadServerConfCatalogExtension.java
@@ -64,6 +64,13 @@ public class XRoadServerConfCatalogExtension implements ServiceExtension {
      */
     static final String SETTING_MANAGEMENT_PARTICIPANT_CONTEXT_ID = "xroad.dsp.management-participant-context-id";
 
+    static final String SETTING_CACHE_ENABLED = "xroad.dsp.catalog.cache.enabled";
+    static final String SETTING_CACHE_TTL_SECONDS = "xroad.dsp.catalog.cache.ttl-seconds";
+    static final String SETTING_CACHE_FIND_BY_ID_MAX_SIZE = "xroad.dsp.catalog.cache.find-by-id-max-size";
+
+    private static final long DEFAULT_CACHE_TTL_SECONDS = 60L;
+    private static final int DEFAULT_CACHE_FIND_BY_ID_MAX_SIZE = 10000;
+
     @Inject
     private ServerConfProvider serverConfProvider;
 
@@ -73,6 +80,8 @@ public class XRoadServerConfCatalogExtension implements ServiceExtension {
     private String participantContextId;
     private String managementParticipantContextId;
     private BuiltinServiceCatalog builtinServiceCatalog;
+    private StoreCacheConfig cacheConfig;
+    private AssetIndexServerConfStore assetIndexStore;
 
     @Override
     public String name() {
@@ -97,20 +106,31 @@ public class XRoadServerConfCatalogExtension implements ServiceExtension {
         builtinServiceCatalog = new BuiltinServiceCatalog(
                 serverConfProvider, proxyMonitorEnabled, opMonitorEnabled, metaservicesEnabled, serverProxyUrl);
         log.info("Built-in service catalog active entries: {}", builtinServiceCatalog.activeServiceIds().size());
+
+        var cacheEnabled = context.getSetting(SETTING_CACHE_ENABLED, true);
+        var cacheTtlSeconds = context.getSetting(SETTING_CACHE_TTL_SECONDS, DEFAULT_CACHE_TTL_SECONDS);
+        var cacheFindByIdMaxSize = context.getSetting(SETTING_CACHE_FIND_BY_ID_MAX_SIZE, DEFAULT_CACHE_FIND_BY_ID_MAX_SIZE);
+        cacheConfig = new StoreCacheConfig(cacheEnabled, cacheTtlSeconds, cacheFindByIdMaxSize);
+        log.info("Store cache enabled={} ttlSeconds={} findByIdMaxSize={}",
+                cacheEnabled, cacheTtlSeconds, cacheFindByIdMaxSize);
+
+        assetIndexStore = new AssetIndexServerConfStore(
+                serverConfProvider, globalConfProvider, participantContextId, managementParticipantContextId,
+                builtinServiceCatalog,
+                new StoreEnumerationCache<>(cacheConfig.enabled(), cacheConfig.ttlSeconds(),
+                        cacheConfig.findByIdMaxSize(), "AssetIndex"));
     }
 
     @Provider
     public AssetIndex assetIndex() {
         log.trace("Providing AssetIndex backed by ServerConf");
-        return new AssetIndexServerConfStore(
-                serverConfProvider, globalConfProvider, participantContextId, managementParticipantContextId,
-                builtinServiceCatalog);
+        return assetIndexStore;
     }
 
     @Provider
     public DataAddressResolver dataAddressResolver() {
         log.trace("Providing DataAddressResolver delegating to ServerConf-backed AssetIndex");
-        return assetIndex();
+        return assetIndexStore;
     }
 
     @Provider
@@ -118,7 +138,9 @@ public class XRoadServerConfCatalogExtension implements ServiceExtension {
         log.trace("Providing PolicyDefinitionStore backed by ServerConf");
         return new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(),
-                participantContextId, managementParticipantContextId, builtinServiceCatalog);
+                participantContextId, managementParticipantContextId, builtinServiceCatalog,
+                new StoreEnumerationCache<>(cacheConfig.enabled(), cacheConfig.ttlSeconds(),
+                        cacheConfig.findByIdMaxSize(), "PolicyDefinition"));
     }
 
     @Provider
@@ -127,6 +149,8 @@ public class XRoadServerConfCatalogExtension implements ServiceExtension {
         return new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider,
                 participantContextId, managementParticipantContextId,
-                builtinServiceCatalog);
+                builtinServiceCatalog,
+                new StoreEnumerationCache<>(cacheConfig.enabled(), cacheConfig.ttlSeconds(),
+                        cacheConfig.findByIdMaxSize(), "ContractDefinition"));
     }
 }

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/AssetIndexServerConfStoreTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/AssetIndexServerConfStoreTest.java
@@ -56,6 +56,8 @@ class AssetIndexServerConfStoreTest {
 
     private static final String PARTICIPANT_CONTEXT_ID = "xroad-provider";
     private static final String MGMT_PARTICIPANT_CONTEXT_ID = "xroad-provider-mgmt";
+    private static final StoreEnumerationCache<Asset> DISABLED_CACHE =
+            new StoreEnumerationCache<>(false, 60, 1000, "test");
 
     @Mock
     private ServerConfProvider serverConfProvider;
@@ -86,7 +88,7 @@ class AssetIndexServerConfStoreTest {
     void setUp() {
         assetIndex = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                noBuiltins());
+                noBuiltins(), DISABLED_CACHE);
     }
 
     private BuiltinServiceCatalog allBuiltins() {
@@ -378,7 +380,7 @@ class AssetIndexServerConfStoreTest {
     void queryAssetsIncludesBuiltinsWhenNoServerconfServices() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = store.queryAssets(QuerySpec.max()).toList();
@@ -392,7 +394,7 @@ class AssetIndexServerConfStoreTest {
     void queryAssetsBuiltinsTaggedWithMgmtContext() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = store.queryAssets(QuerySpec.max()).toList();
@@ -405,7 +407,7 @@ class AssetIndexServerConfStoreTest {
     void queryAssetsBuiltinsNeverTaggedWithHostContext() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = store.queryAssets(QuerySpec.max()).toList();
@@ -418,7 +420,7 @@ class AssetIndexServerConfStoreTest {
     void queryAssetsHostCtxFilterExcludesBuiltins() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var hostSpec = QuerySpec.Builder.newInstance()
@@ -434,7 +436,7 @@ class AssetIndexServerConfStoreTest {
     void findByIdReturnsBuiltinAsset() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         var builtinAssetId = "DEV:GOV:1111:" + BuiltinServiceCatalog.PROXY_MONITOR_SERVICE_CODE;
 
         var result = store.findById(builtinAssetId);
@@ -448,7 +450,7 @@ class AssetIndexServerConfStoreTest {
     void findByIdReturnsNullForUnknownBuiltinServiceCode() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
 
         var result = store.findById("DEV:GOV:1111:nonExistentService");
 
@@ -460,7 +462,7 @@ class AssetIndexServerConfStoreTest {
     void resolveForAssetReturnsDataAddressForBuiltin() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         var builtinAssetId = "DEV:GOV:1111:" + BuiltinServiceCatalog.PROXY_MONITOR_SERVICE_CODE;
 
         var result = store.resolveForAsset(builtinAssetId);
@@ -479,7 +481,7 @@ class AssetIndexServerConfStoreTest {
     void resolveForAssetReturnsNullForDisabledBuiltin() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                noBuiltins());
+                noBuiltins(), DISABLED_CACHE);
         var builtinAssetId = "DEV:GOV:1111:" + BuiltinServiceCatalog.PROXY_MONITOR_SERVICE_CODE;
 
         var result = store.resolveForAsset(builtinAssetId);
@@ -518,7 +520,7 @@ class AssetIndexServerConfStoreTest {
     void countAssetsIncludesBuiltins() {
         var store = new AssetIndexServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var count = store.countAssets(List.of());

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/CachingStoreTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/CachingStoreTest.java
@@ -1,0 +1,329 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.catalog;
+
+import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.identifier.SecurityServerId;
+import ee.ria.xroad.common.identifier.ServiceId;
+
+import com.google.common.base.Ticker;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.globalconf.GlobalConfProvider;
+import org.niis.xroad.serverconf.ServerConfProvider;
+import org.niis.xroad.serverconf.model.AccessRight;
+import org.niis.xroad.serverconf.model.Endpoint;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachingStoreTest {
+
+    private static final String PARTICIPANT_CONTEXT_ID = "xroad-provider";
+    private static final String MGMT_PARTICIPANT_CONTEXT_ID = "xroad-provider-mgmt";
+    private static final ClientId.Conf MEMBER_1 = ClientId.Conf.create("DEV", "GOV", "1111", "SubsystemA");
+    private static final ServiceId.Conf SERVICE_1 = ServiceId.Conf.create("DEV", "GOV", "1111", "SubsystemA", "getRecords", "v1");
+    private static final SecurityServerId.Conf SS_ID = SecurityServerId.Conf.create("DEV", "GOV", "1111", "ss0");
+
+    @Mock
+    private ServerConfProvider serverConfProvider;
+
+    @Mock
+    private GlobalConfProvider globalConfProvider;
+
+    private StoreEnumerationCache<Asset> noCache;
+    private StoreEnumerationCache<Asset> withCache;
+
+    @BeforeEach
+    void setUp() {
+        noCache = new StoreEnumerationCache<>(false, 60, 1000, "test");
+        withCache = new StoreEnumerationCache<>(true, 3600, 1000, "test");
+    }
+
+    private AssetIndexServerConfStore buildStore(StoreEnumerationCache<Asset> cache) {
+        return new AssetIndexServerConfStore(serverConfProvider, globalConfProvider,
+                PARTICIPANT_CONTEXT_ID, MGMT_PARTICIPANT_CONTEXT_ID,
+                new BuiltinServiceCatalog(serverConfProvider, false, false, false,
+                        BuiltinServiceCatalog.DEFAULT_SERVER_PROXY_URL), cache);
+    }
+
+    private void setupSingleMemberService() {
+        lenient().when(serverConfProvider.getMembers()).thenReturn(List.of(MEMBER_1));
+        lenient().when(serverConfProvider.getAllServices(MEMBER_1)).thenReturn(List.of(SERVICE_1));
+        lenient().when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        lenient().when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(nonEmptyAcl());
+        lenient().when(globalConfProvider.getManagementRequestService()).thenReturn(null);
+    }
+
+    @Test
+    void queryAssetsHitServedFromCache() {
+        setupSingleMemberService();
+        var store = buildStore(withCache);
+
+        store.queryAssets(QuerySpec.max()).count();
+        store.queryAssets(QuerySpec.max()).count();
+
+        verify(serverConfProvider, times(1)).getMembers();
+    }
+
+    @Test
+    void queryAssetsAfterInvalidateReloads() {
+        setupSingleMemberService();
+        var store = buildStore(withCache);
+
+        store.queryAssets(QuerySpec.max()).count();
+        withCache.invalidate();
+        store.queryAssets(QuerySpec.max()).count();
+
+        verify(serverConfProvider, times(2)).getMembers();
+    }
+
+    @Test
+    void queryAssetsCacheDisabledReloadsEachCall() {
+        setupSingleMemberService();
+        var store = buildStore(noCache);
+
+        store.queryAssets(QuerySpec.max()).count();
+        store.queryAssets(QuerySpec.max()).count();
+
+        verify(serverConfProvider, times(2)).getMembers();
+    }
+
+    @Test
+    void findByIdHitServedFromCache() {
+        when(serverConfProvider.serviceExists(SERVICE_1)).thenReturn(true);
+        lenient().when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        lenient().when(globalConfProvider.getManagementRequestService()).thenReturn(null);
+        var store = buildStore(withCache);
+
+        store.findById(SERVICE_1.asEncodedId());
+        store.findById(SERVICE_1.asEncodedId());
+
+        verify(serverConfProvider, times(1)).serviceExists(SERVICE_1);
+    }
+
+    @Test
+    void findByIdNotFoundNotCached() {
+        var unknownService = ServiceId.Conf.create("DEV", "GOV", "9999", "Unknown", "noSvc");
+        when(serverConfProvider.serviceExists(unknownService)).thenReturn(false);
+        when(serverConfProvider.getIdentifier()).thenReturn(SS_ID);
+        var unknownClient = unknownService.getClientId();
+        when(globalConfProvider.isSecurityServerClient(unknownClient, SS_ID)).thenReturn(false);
+        var store = buildStore(withCache);
+
+        var r1 = store.findById(unknownService.asEncodedId());
+        var r2 = store.findById(unknownService.asEncodedId());
+
+        assertThat(r1).isNull();
+        assertThat(r2).isNull();
+        verify(serverConfProvider, times(2)).serviceExists(unknownService);
+    }
+
+    @Test
+    void findByIdSynthesisPreservedAfterCaching() {
+        var localService = ServiceId.Conf.create("DEV", "GOV", "1111", "SubsystemA", "localOp");
+        when(serverConfProvider.serviceExists(localService)).thenReturn(false);
+        when(serverConfProvider.getIdentifier()).thenReturn(SS_ID);
+        when(globalConfProvider.isSecurityServerClient(MEMBER_1, SS_ID)).thenReturn(true);
+        var store = buildStore(withCache);
+
+        var r1 = store.findById(localService.asEncodedId());
+        var r2 = store.findById(localService.asEncodedId());
+
+        assertThat(r1).isNotNull();
+        assertThat(r1.getParticipantContextId()).isEqualTo(MGMT_PARTICIPANT_CONTEXT_ID);
+        assertThat(r2).isNotNull();
+        assertThat(r2.getId()).isEqualTo(r1.getId());
+        verify(serverConfProvider, times(1)).serviceExists(localService);
+    }
+
+    @Test
+    void participantContextIdScopingUnchangedWithCache() {
+        setupSingleMemberService();
+        var store = buildStore(withCache);
+
+        var spec = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("participantContextId", "=", PARTICIPANT_CONTEXT_ID))
+                .build();
+        var result = store.queryAssets(spec).toList();
+
+        assertThat(result).allSatisfy(a ->
+                assertThat(a.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID));
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void enumerationCacheServesStaleCopyUntilTtlExpires() {
+        var ticker = new MutableTicker();
+        var ttlSeconds = 5L;
+        var cache = new StoreEnumerationCache<Asset>(true, ttlSeconds, 1000, "test", ticker);
+        var store = buildStore(cache);
+
+        setupSingleMemberService();
+        var firstCount = store.queryAssets(QuerySpec.max()).count();
+        assertThat(firstCount).isGreaterThan(0);
+
+        // Mutate serverconf to return no members — cache should hide this change
+        when(serverConfProvider.getMembers()).thenReturn(List.of());
+        ticker.advance(ttlSeconds - 1, TimeUnit.SECONDS);
+
+        var midCount = store.queryAssets(QuerySpec.max()).count();
+        assertThat(midCount).isEqualTo(firstCount);
+
+        // Advance past TTL — next access must reload and reflect the mutation
+        ticker.advance(2, TimeUnit.SECONDS);
+        var afterCount = store.queryAssets(QuerySpec.max()).count();
+        assertThat(afterCount).isEqualTo(0);
+    }
+
+    @Test
+    void findByIdCacheServesStaleCopyUntilTtlExpires() {
+        var ticker = new MutableTicker();
+        var ttlSeconds = 5L;
+        var cache = new StoreEnumerationCache<Asset>(true, ttlSeconds, 1000, "test", ticker);
+        var store = buildStore(cache);
+
+        when(serverConfProvider.serviceExists(SERVICE_1)).thenReturn(true);
+        lenient().when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        lenient().when(globalConfProvider.getManagementRequestService()).thenReturn(null);
+
+        var first = store.findById(SERVICE_1.asEncodedId());
+        assertThat(first).isNotNull();
+
+        // Second call within TTL still served from cache (loader not called again)
+        ticker.advance(ttlSeconds - 1, TimeUnit.SECONDS);
+        store.findById(SERVICE_1.asEncodedId());
+        verify(serverConfProvider, times(1)).serviceExists(SERVICE_1);
+
+        // Advance past TTL — next access must re-invoke loader
+        ticker.advance(2, TimeUnit.SECONDS);
+        store.findById(SERVICE_1.asEncodedId());
+        assertThat(store.findById(SERVICE_1.asEncodedId())).isNotNull();
+        verify(serverConfProvider, times(2)).serviceExists(SERVICE_1);
+    }
+
+    @Test
+    void resolveForAssetHitServedFromCache() {
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAddress(SERVICE_1)).thenReturn("https://example.com/svc");
+        var store = buildStore(withCache);
+
+        store.resolveForAsset(SERVICE_1.asEncodedId());
+        store.resolveForAsset(SERVICE_1.asEncodedId());
+
+        verify(serverConfProvider, times(1)).getServiceAddress(SERVICE_1);
+    }
+
+    @Test
+    void resolveForAssetNullNotCached() {
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn("Maintenance");
+        var store = buildStore(withCache);
+
+        var r1 = store.resolveForAsset(SERVICE_1.asEncodedId());
+        var r2 = store.resolveForAsset(SERVICE_1.asEncodedId());
+
+        assertThat(r1).isNull();
+        assertThat(r2).isNull();
+        verify(serverConfProvider, times(2)).getDisabledNotice(SERVICE_1);
+    }
+
+    @Test
+    void resolveForAssetCacheDisabledReloadsEachCall() {
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAddress(SERVICE_1)).thenReturn("https://example.com/svc");
+        var store = buildStore(noCache);
+
+        store.resolveForAsset(SERVICE_1.asEncodedId());
+        store.resolveForAsset(SERVICE_1.asEncodedId());
+
+        verify(serverConfProvider, times(2)).getServiceAddress(SERVICE_1);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void resolveForAssetCacheServesStaleCopyUntilTtlExpires() {
+        var ticker = new MutableTicker();
+        var ttlSeconds = 5L;
+        var cache = new StoreEnumerationCache<Asset>(true, ttlSeconds, 1000, "test", ticker);
+        var store = buildStore(cache);
+
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAddress(SERVICE_1)).thenReturn("https://old.example.com/svc");
+
+        var first = store.resolveForAsset(SERVICE_1.asEncodedId());
+        assertThat(first).isNotNull();
+        assertThat(first.getStringProperty("baseUrl")).isEqualTo("https://old.example.com/svc");
+
+        // Address changes in serverconf — cache hides the change within TTL
+        when(serverConfProvider.getServiceAddress(SERVICE_1)).thenReturn("https://new.example.com/svc");
+        ticker.advance(ttlSeconds - 1, TimeUnit.SECONDS);
+
+        var mid = store.resolveForAsset(SERVICE_1.asEncodedId());
+        assertThat(mid.getStringProperty("baseUrl")).isEqualTo("https://old.example.com/svc");
+
+        // Advance past TTL — next access must reload and reflect the new address
+        ticker.advance(2, TimeUnit.SECONDS);
+        var after = store.resolveForAsset(SERVICE_1.asEncodedId());
+        assertThat(after.getStringProperty("baseUrl")).isEqualTo("https://new.example.com/svc");
+    }
+
+    private static List<AccessRight> nonEmptyAcl() {
+        var ar = new AccessRight();
+        ar.setSubjectId(ClientId.Conf.create("DEV", "GOV", "9999", "Consumer"));
+        ar.setEndpoint(new Endpoint("svc", "GET", "/", false));
+        ar.setRightsGiven(new Date());
+        return List.of(ar);
+    }
+
+    static final class MutableTicker extends Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+
+        void advance(long amount, TimeUnit unit) {
+            nanos.addAndGet(unit.toNanos(amount));
+        }
+    }
+}

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/ContractDefinitionServerConfStoreTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/ContractDefinitionServerConfStoreTest.java
@@ -49,6 +49,8 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +58,8 @@ class ContractDefinitionServerConfStoreTest {
 
     private static final String PARTICIPANT_CTX = "xroad-provider";
     private static final String MGMT_PARTICIPANT_CTX = "xroad-provider-mgmt";
+    private static final StoreEnumerationCache<ContractDefinition> DISABLED_CACHE =
+            new StoreEnumerationCache<>(false, 60, 1000, "test");
 
     private static final ClientId.Conf MEMBER_1 = ClientId.Conf.create("DEV", "GOV", "1234", "SubSys");
     private static final ClientId.Conf MEMBER_2 = ClientId.Conf.create("DEV", "GOV", "5678", "SubSys");
@@ -82,7 +86,7 @@ class ContractDefinitionServerConfStoreTest {
     void setUp() {
         store = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                noBuiltins());
+                noBuiltins(), DISABLED_CACHE);
     }
 
     private BuiltinServiceCatalog allBuiltins() {
@@ -398,7 +402,7 @@ class ContractDefinitionServerConfStoreTest {
     void findAllIncludesBuiltinContractDefinitions() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.max()).toList();
@@ -410,7 +414,7 @@ class ContractDefinitionServerConfStoreTest {
     void findAllBuiltinsTaggedWithMgmtContext() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.max()).toList();
@@ -423,7 +427,7 @@ class ContractDefinitionServerConfStoreTest {
     void findAllBuiltinsHostCtxFilterExcludesBuiltins() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var hostSpec = QuerySpec.Builder.newInstance()
@@ -439,7 +443,7 @@ class ContractDefinitionServerConfStoreTest {
     void findByIdReturnsBuiltinContractDefinition() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         var builtinAssetId = "DEV:GOV:1234:" + BuiltinServiceCatalog.PROXY_MONITOR_SERVICE_CODE;
         var contractId = builtinAssetId + ContractDefinitionMapper.getContractDefinitionSuffix();
 
@@ -455,7 +459,7 @@ class ContractDefinitionServerConfStoreTest {
     void findByIdReturnsNullForUnknownBuiltinId() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
 
         var result = builtinStore.findById("DEV:GOV:1234:nonExistentService-contract-definition");
 
@@ -515,7 +519,7 @@ class ContractDefinitionServerConfStoreTest {
     void findAllBuiltinDefinitionsHaveAcceptAllPolicyId() {
         var builtinStore = new ContractDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.max()).toList();
@@ -524,6 +528,79 @@ class ContractDefinitionServerConfStoreTest {
             assertThat(def.getAccessPolicyId()).isNotBlank();
             assertThat(def.getContractPolicyId()).isEqualTo(def.getAccessPolicyId());
         });
+    }
+
+    @Test
+    void findAllCacheHitServesFromCache() {
+        var cache = new StoreEnumerationCache<ContractDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new ContractDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.getMembers()).thenReturn(List.of(MEMBER_1));
+        when(serverConfProvider.getAllServices(MEMBER_1)).thenReturn(List.of(SERVICE_1));
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        cachedStore.findAll(QuerySpec.max()).count();
+        cachedStore.findAll(QuerySpec.max()).count();
+
+        verify(serverConfProvider, times(1)).getMembers();
+    }
+
+    @Test
+    void findAllCacheMissAfterInvalidate() {
+        var cache = new StoreEnumerationCache<ContractDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new ContractDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.getMembers()).thenReturn(List.of(MEMBER_1));
+        when(serverConfProvider.getAllServices(MEMBER_1)).thenReturn(List.of(SERVICE_1));
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        cachedStore.findAll(QuerySpec.max()).count();
+        cache.invalidate();
+        cachedStore.findAll(QuerySpec.max()).count();
+
+        verify(serverConfProvider, times(2)).getMembers();
+    }
+
+    @Test
+    void findByIdCacheHitServesFromCache() {
+        var cache = new StoreEnumerationCache<ContractDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new ContractDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.serviceExists(SERVICE_1)).thenReturn(true);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        var contractId = AssetMapper.encodeAssetId(SERVICE_1)
+                + XRoadId.ENCODED_ID_SEPARATOR + SUBJECT_CLIENT.asEncodedId()
+                + ContractDefinitionMapper.getContractDefinitionSuffix();
+        cachedStore.findById(contractId);
+        cachedStore.findById(contractId);
+
+        verify(serverConfProvider, times(1)).serviceExists(SERVICE_1);
+    }
+
+    @Test
+    void findByIdCacheDoesNotCacheNotFound() {
+        var cache = new StoreEnumerationCache<ContractDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new ContractDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        when(serverConfProvider.serviceExists(SERVICE_1)).thenReturn(false);
+
+        var contractId = "DEV:GOV:1234:SubSys:svc1:v1:DEV:GOV:9999:Consumer-contract-definition";
+        var r1 = cachedStore.findById(contractId);
+        var r2 = cachedStore.findById(contractId);
+
+        assertThat(r1).isNull();
+        assertThat(r2).isNull();
+        verify(serverConfProvider, times(2)).serviceExists(SERVICE_1);
     }
 
     private static AccessRight createAccessRight(XRoadId subjectId, Endpoint endpoint) {

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/PolicyDefinitionServerConfStoreTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/PolicyDefinitionServerConfStoreTest.java
@@ -50,6 +50,8 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,6 +59,8 @@ class PolicyDefinitionServerConfStoreTest {
 
     private static final String PARTICIPANT_CTX = "xroad-provider";
     private static final String MGMT_PARTICIPANT_CTX = "xroad-provider-mgmt";
+    private static final StoreEnumerationCache<PolicyDefinition> DISABLED_CACHE =
+            new StoreEnumerationCache<>(false, 60, 1000, "test");
 
     @Mock
     private ServerConfProvider serverConfProvider;
@@ -83,7 +87,7 @@ class PolicyDefinitionServerConfStoreTest {
     void setUp() {
         store = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                noBuiltins());
+                noBuiltins(), DISABLED_CACHE);
     }
 
     private BuiltinServiceCatalog allBuiltins() {
@@ -362,7 +366,7 @@ class PolicyDefinitionServerConfStoreTest {
     void findAllIncludesBuiltinPolicies() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.none()).toList();
@@ -374,7 +378,7 @@ class PolicyDefinitionServerConfStoreTest {
     void findAllBuiltinPoliciesTaggedWithMgmtContext() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.none()).toList();
@@ -387,7 +391,7 @@ class PolicyDefinitionServerConfStoreTest {
     void findAllBuiltinsHostCtxFilterExcludesBuiltins() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var hostSpec = QuerySpec.Builder.newInstance()
@@ -403,7 +407,7 @@ class PolicyDefinitionServerConfStoreTest {
     void findByIdReturnsBuiltinPolicy() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         var builtinAssetId = "DEV:GOV:1234:" + BuiltinServiceCatalog.PROXY_MONITOR_SERVICE_CODE;
 
         var result = builtinStore.findById(builtinAssetId);
@@ -417,7 +421,7 @@ class PolicyDefinitionServerConfStoreTest {
     void findByIdReturnsNullForUnknownBuiltinId() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
 
         var result = builtinStore.findById("DEV:GOV:1234:nonExistentService");
 
@@ -472,12 +476,86 @@ class PolicyDefinitionServerConfStoreTest {
     void findAllBuiltinPoliciesHavePermissivePolicy() {
         var builtinStore = new PolicyDefinitionServerConfStore(
                 serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
-                allBuiltins());
+                allBuiltins(), DISABLED_CACHE);
         when(serverConfProvider.getMembers()).thenReturn(List.of());
 
         var result = builtinStore.findAll(QuerySpec.none()).toList();
 
         result.forEach(pol -> assertThat(pol.getPolicy()).isNotNull());
+    }
+
+    @Test
+    void findAllCacheHitServesFromCache() {
+        var cache = new StoreEnumerationCache<PolicyDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new PolicyDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.getMembers()).thenReturn(List.of(MEMBER_1));
+        when(serverConfProvider.getAllServices(MEMBER_1)).thenReturn(List.of(SERVICE_1));
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        cachedStore.findAll(QuerySpec.none()).count();
+        cachedStore.findAll(QuerySpec.none()).count();
+
+        verify(serverConfProvider, times(1)).getMembers();
+    }
+
+    @Test
+    void findAllCacheMissAfterInvalidate() {
+        var cache = new StoreEnumerationCache<PolicyDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new PolicyDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.getMembers()).thenReturn(List.of(MEMBER_1));
+        when(serverConfProvider.getAllServices(MEMBER_1)).thenReturn(List.of(SERVICE_1));
+        when(serverConfProvider.getDisabledNotice(SERVICE_1)).thenReturn(null);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        cachedStore.findAll(QuerySpec.none()).count();
+        cache.invalidate();
+        cachedStore.findAll(QuerySpec.none()).count();
+
+        verify(serverConfProvider, times(2)).getMembers();
+    }
+
+    @Test
+    void findByIdCacheHitServesFromCache() {
+        var cache = new StoreEnumerationCache<PolicyDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new PolicyDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var ep = new Endpoint("svc1", "GET", "/api/data", false);
+        when(serverConfProvider.serviceExists(SERVICE_1)).thenReturn(true);
+        when(serverConfProvider.getServiceAccessRights(SERVICE_1)).thenReturn(List.of(createAccessRight(SUBJECT_CLIENT, ep)));
+
+        var policyId = AssetMapper.encodeAssetId(SERVICE_1)
+                + XRoadId.ENCODED_ID_SEPARATOR + SUBJECT_CLIENT.asEncodedId();
+        cachedStore.findById(policyId);
+        cachedStore.findById(policyId);
+
+        verify(serverConfProvider, times(1)).serviceExists(SERVICE_1);
+    }
+
+    @Test
+    void findByIdCacheDoesNotCacheNotFound() {
+        var cache = new StoreEnumerationCache<PolicyDefinition>(true, 3600, 1000, "test");
+        var cachedStore = new PolicyDefinitionServerConfStore(
+                serverConfProvider, globalConfProvider, new PolicyMapper(), PARTICIPANT_CTX, MGMT_PARTICIPANT_CTX,
+                noBuiltins(), cache);
+        var unknownService = ServiceId.Conf.create("DEV", "GOV", "0000", "None", "noSvc", "v1");
+        when(serverConfProvider.serviceExists(unknownService)).thenReturn(false);
+
+        var policyId = AssetMapper.encodeAssetId(unknownService)
+                + XRoadId.ENCODED_ID_SEPARATOR + SUBJECT_CLIENT.asEncodedId();
+        var r1 = cachedStore.findById(policyId);
+        var r2 = cachedStore.findById(policyId);
+
+        assertThat(r1).isNull();
+        assertThat(r2).isNull();
+        verify(serverConfProvider, times(2)).serviceExists(unknownService);
     }
 
     private static AccessRight createAccessRight(ee.ria.xroad.common.identifier.XRoadId subjectId, Endpoint endpoint) {

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/StoreCacheBenchmarkTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/StoreCacheBenchmarkTest.java
@@ -32,8 +32,12 @@ import ee.ria.xroad.common.identifier.ServiceId;
 import ee.ria.xroad.common.metadata.Endpoint;
 import ee.ria.xroad.common.metadata.RestServiceDetailsListType;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -43,6 +47,7 @@ import org.niis.xroad.serverconf.IsAuthentication;
 import org.niis.xroad.serverconf.ServerConfProvider;
 import org.niis.xroad.serverconf.model.AccessRight;
 import org.niis.xroad.serverconf.model.DescriptionType;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,11 +61,27 @@ class StoreCacheBenchmarkTest {
 
     private static final int WARMUP = 50;
     private static final int K = 200;
+    private static final Logger CATALOG_LOGGER =
+            (Logger) LoggerFactory.getLogger("org.niis.xroad.edc.extension.catalog");
+    private static Level originalLevel;
 
     @Mock
     private GlobalConfProvider globalConfProvider;
 
+    @BeforeAll
+    static void silenceCatalogLogging() {
+        originalLevel = CATALOG_LOGGER.getLevel();
+        CATALOG_LOGGER.setLevel(Level.WARN);
+    }
+
+    @AfterAll
+    static void restoreCatalogLogging() {
+        CATALOG_LOGGER.setLevel(originalLevel);
+    }
+
     @Test
+    @SuppressWarnings("java:S2699")
+        // Add at least one assertion to this test case
     void benchmarkCatalogAndFindById() {
         when(globalConfProvider.getManagementRequestService()).thenReturn(null);
 

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/StoreCacheBenchmarkTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/StoreCacheBenchmarkTest.java
@@ -1,0 +1,360 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.catalog;
+
+import ee.ria.xroad.common.identifier.ClientId;
+import ee.ria.xroad.common.identifier.SecurityServerId;
+import ee.ria.xroad.common.identifier.ServiceId;
+import ee.ria.xroad.common.metadata.Endpoint;
+import ee.ria.xroad.common.metadata.RestServiceDetailsListType;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.globalconf.GlobalConfProvider;
+import org.niis.xroad.serverconf.IsAuthentication;
+import org.niis.xroad.serverconf.ServerConfProvider;
+import org.niis.xroad.serverconf.model.AccessRight;
+import org.niis.xroad.serverconf.model.DescriptionType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCacheBenchmarkTest {
+
+    private static final int WARMUP = 50;
+    private static final int K = 200;
+
+    @Mock
+    private GlobalConfProvider globalConfProvider;
+
+    @Test
+    void benchmarkCatalogAndFindById() {
+        when(globalConfProvider.getManagementRequestService()).thenReturn(null);
+
+        System.out.println("\n=== Benchmark Results ===");
+        System.out.printf("%-14s %-6s %-10s %-14s %-10s%n", "Path", "N", "Cache", "Median (µs)", "P95 (µs)");
+
+        runCatalogBenchmark(100);
+        runCatalogBenchmark(1000);
+        runFindByIdBenchmark(100);
+        runFindByIdBenchmark(1000);
+        runResolveForAssetBenchmark(100);
+        runResolveForAssetBenchmark(1000);
+    }
+
+    private void runCatalogBenchmark(int serviceCount) {
+        var fakeProvider = new FakeServerConfProvider(serviceCount);
+
+        var storeDisabled = buildStore(fakeProvider, false);
+        for (int i = 0; i < WARMUP; i++) {
+            storeDisabled.queryAssets(QuerySpec.max()).count();
+        }
+        var timesDisabled = measureQueryAssets(storeDisabled);
+
+        var storeEnabled = buildStore(fakeProvider, true);
+        for (int i = 0; i < WARMUP; i++) {
+            storeEnabled.queryAssets(QuerySpec.max()).count();
+        }
+        var timesEnabled = measureQueryAssets(storeEnabled);
+
+        System.out.printf("%-14s %-6d %-10s %-14d %-10d%n",
+                "queryAssets", serviceCount, "disabled", toMicros(median(timesDisabled)), toMicros(p95(timesDisabled)));
+        System.out.printf("%-14s %-6d %-10s %-14d %-10d%n",
+                "queryAssets", serviceCount, "enabled", toMicros(median(timesEnabled)), toMicros(p95(timesEnabled)));
+    }
+
+    private void runFindByIdBenchmark(int serviceCount) {
+        var fakeProvider = new FakeServerConfProvider(serviceCount);
+        var firstId = fakeProvider.seededIds().get(0).asEncodedId();
+
+        var storeDisabled = buildStore(fakeProvider, false);
+        for (int i = 0; i < WARMUP; i++) {
+            storeDisabled.findById(firstId);
+        }
+        var timesDisabled = measureFindById(storeDisabled, firstId);
+
+        var storeEnabled = buildStore(fakeProvider, true);
+        for (int i = 0; i < WARMUP; i++) {
+            storeEnabled.findById(firstId);
+        }
+        var timesEnabled = measureFindById(storeEnabled, firstId);
+
+        System.out.printf("%-14s %-6d %-10s %-14d %-10d%n",
+                "findById", serviceCount, "disabled", toMicros(median(timesDisabled)), toMicros(p95(timesDisabled)));
+        System.out.printf("%-14s %-6d %-10s %-14d %-10d%n",
+                "findById", serviceCount, "enabled", toMicros(median(timesEnabled)), toMicros(p95(timesEnabled)));
+    }
+
+    private long[] measureQueryAssets(AssetIndexServerConfStore store) {
+        var times = new long[K];
+        for (int i = 0; i < K; i++) {
+            long t = System.nanoTime();
+            store.queryAssets(QuerySpec.max()).count();
+            times[i] = System.nanoTime() - t;
+        }
+        return times;
+    }
+
+    private void runResolveForAssetBenchmark(int serviceCount) {
+        var fakeProvider = new FakeServerConfProvider(serviceCount);
+        var firstId = fakeProvider.seededIds().get(0).asEncodedId();
+
+        var storeDisabled = buildStore(fakeProvider, false);
+        for (int i = 0; i < WARMUP; i++) {
+            storeDisabled.resolveForAsset(firstId);
+        }
+        var timesDisabled = measureResolveForAsset(storeDisabled, firstId);
+
+        var storeEnabled = buildStore(fakeProvider, true);
+        for (int i = 0; i < WARMUP; i++) {
+            storeEnabled.resolveForAsset(firstId);
+        }
+        var timesEnabled = measureResolveForAsset(storeEnabled, firstId);
+
+        System.out.printf("%-17s %-6d %-10s %-14d %-10d%n",
+                "resolveForAsset", serviceCount, "disabled", toMicros(median(timesDisabled)), toMicros(p95(timesDisabled)));
+        System.out.printf("%-17s %-6d %-10s %-14d %-10d%n",
+                "resolveForAsset", serviceCount, "enabled", toMicros(median(timesEnabled)), toMicros(p95(timesEnabled)));
+    }
+
+    private long[] measureResolveForAsset(AssetIndexServerConfStore store, String id) {
+        var times = new long[K];
+        for (int i = 0; i < K; i++) {
+            long t = System.nanoTime();
+            store.resolveForAsset(id);
+            times[i] = System.nanoTime() - t;
+        }
+        return times;
+    }
+
+    private long[] measureFindById(AssetIndexServerConfStore store, String id) {
+        var times = new long[K];
+        for (int i = 0; i < K; i++) {
+            long t = System.nanoTime();
+            store.findById(id);
+            times[i] = System.nanoTime() - t;
+        }
+        return times;
+    }
+
+    private AssetIndexServerConfStore buildStore(ServerConfProvider provider, boolean cacheEnabled) {
+        var cache = new StoreEnumerationCache<Asset>(cacheEnabled, 3600, 10000, "bench");
+        return new AssetIndexServerConfStore(provider, globalConfProvider,
+                "participant", "participant-mgmt",
+                new BuiltinServiceCatalog(provider, false, false, false,
+                        BuiltinServiceCatalog.DEFAULT_SERVER_PROXY_URL),
+                cache);
+    }
+
+    static long median(long[] times) {
+        var sorted = times.clone();
+        Arrays.sort(sorted);
+        return sorted[sorted.length / 2];
+    }
+
+    static long p95(long[] times) {
+        var sorted = times.clone();
+        Arrays.sort(sorted);
+        return sorted[(int) (sorted.length * 0.95)];
+    }
+
+    static long toMicros(long nanos) {
+        return nanos / 1000;
+    }
+
+    static class FakeServerConfProvider implements ServerConfProvider {
+
+        private final List<ServiceId.Conf> services;
+        private final ClientId.Conf member = ClientId.Conf.create("DEV", "GOV", "1111", "SubsystemA");
+
+        FakeServerConfProvider(int serviceCount) {
+            services = new ArrayList<>(serviceCount);
+            for (int i = 0; i < serviceCount; i++) {
+                services.add(ServiceId.Conf.create("DEV", "GOV", "1111", "SubsystemA", "svc" + i, "v1"));
+            }
+        }
+
+        List<ServiceId.Conf> seededIds() {
+            return services;
+        }
+
+        @Override
+        public List<ClientId.Conf> getMembers() {
+            return List.of(member);
+        }
+
+        @Override
+        public List<ServiceId.Conf> getAllServices(ClientId serviceProviderId) {
+            return services;
+        }
+
+        @Override
+        public String getDisabledNotice(ServiceId serviceId) {
+            return null;
+        }
+
+        @Override
+        public List<AccessRight> getServiceAccessRights(ServiceId serviceId) {
+            var ar = new AccessRight();
+            ar.setSubjectId(ClientId.Conf.create("DEV", "GOV", "9999", "Consumer"));
+            ar.setEndpoint(new org.niis.xroad.serverconf.model.Endpoint("svc", "GET", "/", false));
+            ar.setRightsGiven(new Date());
+            return List.of(ar);
+        }
+
+        @Override
+        public boolean serviceExists(ServiceId serviceId) {
+            return true;
+        }
+
+        @Override
+        public SecurityServerId.Conf getIdentifier() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getServiceAddress(ServiceId serviceId) {
+            return "https://example.com/r1/" + serviceId.asEncodedId();
+        }
+
+        @Override
+        public int getServiceTimeout(ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RestServiceDetailsListType getRestServices(ClientId serviceProviderId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RestServiceDetailsListType getAllowedRestServices(ClientId serviceProviderId, ClientId clientId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ServiceId.Conf> getServicesByDescriptionType(ClientId serviceProviderId,
+                                                                 DescriptionType descriptionType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ServiceId.Conf> getAllowedServices(ClientId serviceProviderId, ClientId clientId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<ServiceId.Conf> getAllowedServicesByDescriptionType(ClientId serviceProviderId, ClientId clientId,
+                                                                        DescriptionType descriptionType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public IsAuthentication getIsAuthentication(ClientId clientId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<java.security.cert.X509Certificate> getIsCerts(ClientId clientId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isSslAuthentication(ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMemberStatus(ClientId memberId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isQueryAllowed(ClientId senderId, ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isQueryAllowed(ClientId senderId, ServiceId serviceId, String method, String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DescriptionType getDescriptionType(ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getServiceDescriptionURL(ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Endpoint> getServiceEndpoints(ServiceId serviceId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> getTspUrls() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<java.security.cert.X509Certificate> getAllIsCerts() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ee.ria.xroad.common.conf.InternalSSLKey getSSLKey() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<String> getOrderedTspUrls(ee.ria.xroad.common.ServicePrioritizationStrategy prioritizationStrategy) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.niis.xroad.common.CostType getTspCostType(String tspUrl) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MaintenanceMode getMaintenanceMode() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/XRoadServerConfCatalogExtensionTest.java
+++ b/src/service/ds-control-plane/ds-xroad-catalog/src/test/java/org/niis/xroad/edc/extension/catalog/XRoadServerConfCatalogExtensionTest.java
@@ -39,6 +39,8 @@ import org.niis.xroad.serverconf.ServerConfProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +70,8 @@ class XRoadServerConfCatalogExtensionTest {
         when(serverConfProvider.getIdentifier()).thenReturn(SS_ID);
         when(context.getSetting(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(1));
         when(context.getSetting(anyString(), anyBoolean())).thenAnswer(inv -> inv.getArgument(1));
+        when(context.getSetting(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+        when(context.getSetting(anyString(), anyLong())).thenAnswer(inv -> inv.getArgument(1));
         extension.initialize(context);
     }
 


### PR DESCRIPTION
The AssetIndex, PolicyDefinition and ContractDefinition stores rebuilt the full ServerConf projection on every DSP query. Add a TTL Guava cache above them so the enumeration runs once per TTL instead of per request.

Pure TTL eventual-consistency, no cross-process invalidation: the control plane runs its own ServerConfProvider with no serverconf-change signal. Per store a single-key enumeration snapshot plus a positives-only, bounded findById cache; AssetIndex also caches resolveForAsset. Enable flag, TTL and findById max-size are configurable; hit/miss observable via Guava recordStats.

Refs: XRDDEV-3211