### PR TITLE
fix(packaging): isolate per-distro build trees to fix parallel race

### DIFF
--- a/deployment/native-packages/build-deb.sh
+++ b/deployment/native-packages/build-deb.sh
@@ -87,10 +87,6 @@ function prepare {
 DIR="$(cd "$(dirname $0)" && pwd)"
 cd "$DIR"
 
-mkdir -p build/xroad
-rm -rf build/xroad/ubuntu
-cp -a src/xroad/ubuntu build/xroad/
-
 # version was not given, use empty
 if [ -z "$2" ]; then
   readonly PACKAGE_VERSION="$(date --utc --date @`git show -s --format=%ct` +'%Y%m%d%H%M%S')$(git show -s --format=git%h --abbrev=7)"
@@ -100,15 +96,23 @@ fi
 
 case "$1" in
     noble)
-        prepare ubuntu24.04
-        builddeb build/xroad/ubuntu noble ubuntu24.04 "$PACKAGE_VERSION"
+        DIST=noble
+        SUFFIX=ubuntu24.04
         ;;
     resolute)
-        prepare ubuntu26.04
-        builddeb build/xroad/ubuntu resolute ubuntu26.04 "$PACKAGE_VERSION"
+        DIST=resolute
+        SUFFIX=ubuntu26.04
         ;;
     *)
-        echo "Unsupported distribution $dist"
+        echo "Unsupported distribution $1"
         exit 1;
         ;;
 esac
+
+UBUNTU_BUILD="build/xroad/ubuntu-${DIST}"
+mkdir -p build/xroad
+rm -rf "$UBUNTU_BUILD"
+cp -a src/xroad/ubuntu "$UBUNTU_BUILD"
+
+prepare "$SUFFIX"
+builddeb "$UBUNTU_BUILD" "$DIST" "$SUFFIX" "$PACKAGE_VERSION"

--- a/deployment/native-packages/build-rpm.sh
+++ b/deployment/native-packages/build-rpm.sh
@@ -41,9 +41,15 @@ warn "using packageVersion $SNAPSHOT"
 DIR=$(cd "$(dirname "$0")" && pwd)
 cd "$DIR"
 
-mkdir -p build/xroad/redhat
-rm -rf build/xroad/redhat
-cp -a src/xroad/redhat build/xroad
+RHEL_VER="$(rpm -E %rhel 2>/dev/null)"
+if ! [[ "$RHEL_VER" =~ ^[0-9]+$ ]]; then
+  RHEL_VER="$(. /etc/os-release && echo "${VERSION_ID%%.*}")"
+fi
+REDHAT_BUILD="build/xroad/redhat-el${RHEL_VER}"
+
+mkdir -p build/xroad
+rm -rf "$REDHAT_BUILD"
+cp -a src/xroad/redhat "$REDHAT_BUILD"
 
 if [[ -z "$SNAPSHOT" ]]; then
   macro_snapshot=()
@@ -53,7 +59,7 @@ else
   compress=w1.gzdio
 fi
 
-ROOT=${DIR}/build/xroad/redhat
+ROOT=${DIR}/${REDHAT_BUILD}
 
 HOST_ARCH="$(uname -m)"
 if [[ "$HOST_ARCH" == "x86_64" ]]; then


### PR DESCRIPTION
The four packaging stages run in parallel on one shared Jenkins workspace (reuseNode true). build-rpm.sh wiped and rebuilt a single build/xroad/redhat tree shared by RHEL 9 and RHEL 10, and build-deb.sh did the same with build/xroad/ubuntu shared by Ubuntu 24.04 and 26.04. When two siblings overlapped, the later one's rm -rf deleted the other's in-progress BUILDROOT/staging mid-package, causing random 'cpio: open failed' (rpm) and 'cp: cannot create regular file' (deb) failures.

Give each distro its own working tree: redhat-el<ver> (version from rpm -E %rhel) for rpm, ubuntu-<dist> for deb. Final output locations (build/rhel/<ver>, build/<suffix>) are unchanged.