### PR TITLE
fix(security-server): normalize missing TSP cost type to UNDEFINED

### DIFF
--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfChecker.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfChecker.java
@@ -252,7 +252,7 @@ public class GlobalConfChecker {
     }
 
     private String getCostTypeString(CostType costType) {
-        return costType == null ? null : costType.name();
+        return costType == null ? CostType.UNDEFINED.name() : costType.name();
     }
 
     private SecurityServerId buildSecurityServerId(ClientId ownerId, String serverCode) {

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfCheckerTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/scheduling/GlobalConfCheckerTest.java
@@ -384,6 +384,18 @@ public class GlobalConfCheckerTest extends AbstractFacadeMockingTestContext {
     }
 
     @Test
+    public void testUpdateTimestampServiceCostTypesNullGlobalCostType() {
+        List<SharedParameters.ApprovedTSA> globalTsps =
+                Collections.singletonList(TestUtils.createApprovedTsaType("http://example.com:8121", "Foo", null));
+        List<TimestampingServiceEntity> localTsps =
+                Collections.singletonList(TestUtils.createTspTypeEntity("http://example.com:8121", "Foo", CostType.UNDEFINED.name()));
+
+        globalConfChecker.updateTimestampServiceCostTypes(globalTsps, localTsps);
+
+        assertEquals(CostType.UNDEFINED.name(), localTsps.getFirst().getCostType());
+    }
+
+    @Test
     public void doNotUpdateServerConfOnSlave() {
         System.setProperty(NODE_TYPE, SLAVE.toString());
 


### PR DESCRIPTION
GlobalConfChecker treated an absent cost type from older (<7.8.0) Central Server global configuration as null and tried to persist null into the NOT NULL tsp.cost_type column, failing the scheduled serverconf update every 30s. Map a missing cost type to UNDEFINED so older global configuration stays backwards compatible.

Refs: XRDDEV-3236