### PR TITLE
docs: Add Kubernetes deployment guide for external database

### DIFF
--- a/development/ansible/Resumo
+++ b/development/ansible/Resumo
@@ -1,0 +1,79 @@
+✅ Playbook X-VIA adaptado para On-Premises
+  
+  Sim, funciona perfeitamente em ambiente on-premises com banco PostgreSQL do cliente. O playbook agora suporta:
+  
+  O que foi criado/atualizado:
+  
+  ┌─────────────────────────────────┬────────────────────────────────────────────┐
+  │ Arquivo                         │ Função                                     │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ xvia_install.yml                │ Playbook principal (3 plays: CA → CS → SS) │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ hosts/xvia_onpremises.txt       │ Inventário de exemplo on-premises          │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ vars_files/xvia_cdn.yml         │ Config de pacotes (CDN/S3/local)           │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ vars_files/xvia_database.yml    │ Config banco (customizável)                │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_cs_install.yml       │ Instalação do Central Server               │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_ca_install.yml       │ Instalação do CA (OCSP/TSA)                │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_db_remote.yml        │ Setup banco remoto                         │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_db_local.yml         │ Setup banco local                          │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_postinstall.yml      │ Liquibase, PAM, autologin                  │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ tasks/xvia_validate.yml         │ Validação serviços + login                 │
+  ├─────────────────────────────────┼────────────────────────────────────────────┤
+  │ templates/xvia_db.properties.j2 │ Template JDBC                              │
+  └─────────────────────────────────┴────────────────────────────────────────────┘
+  
+  Como usar no cliente:
+  
+  Instalação completa com banco on-premises:
+  
+  ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+    -e "admin_password=SenhaDoCliente" \
+    -e "database_admin_password=SenhaDoBanco" \
+    -e "xroad_ui_user=admin-orgao" \
+    -e "database_host=192.168.1.50:5432" \
+    -e "database_admin_user=dba_cliente"
+  
+  Com senhas customizadas para todos os bancos:
+  
+  ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+    -e "admin_password=MinhaSenh4" \
+    -e "xroad_ui_user=meu-admin" \
+    -e "database_admin_password=DBSenh4" \
+    -e "database_admin_user=postgres" \
+    -e "serverconf_password=SenhaServerconf" \
+    -e "messagelog_password=SenhaMsglog" \
+    -e "opmonitor_password=SenhaOpmon" \
+    -e "centerui_password=SenhaCenterUI"
+  
+  Apenas Security Server:
+  
+  ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+    -e "admin_password=Senha" -e "database_admin_password=DB" --tags ss
+  
+  Ambiente sem internet (pacotes pré-copiados):
+  
+  # Antes: copie o tarball para os servidores
+  scp xroad-7.8.0-ubuntu24.04.tar.gz ubuntu@servidor:/opt/xvia-packages/
+  
+  ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+    -e "admin_password=Senha" \
+    -e "database_admin_password=DB" \
+    -e "xvia_package_source=local"
+  
+  Tags disponíveis:
+  
+  - --tags ca → Apenas CA Server
+  - --tags cs → Apenas Central Server
+  - --tags ss → Apenas Security Server(s)
+  
+  Para configurar no inventário do cliente:
+  
+  Edite hosts/xvia_onpremises.txt com os IPs/FQDNs reais e a chave SSH do ambiente.

--- a/development/ansible/hosts/xvia_hosts.txt
+++ b/development/ansible/hosts/xvia_hosts.txt
@@ -28,10 +28,15 @@ ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 # Central Servers (se necessário)
 [cs_servers]
 
+# Database Server remoto (necessário se use_remote_db=true)
+[db_servers]
+# Exemplo: db.exemplo.gov.br ansible_host=10.0.1.50 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
 # Super grupo com todos os servidores
 [xvia:children]
 ss_servers
 cs_servers
+db_servers
 
 [all:vars]
 # Usuário admin da UI do X-Road

--- a/development/ansible/hosts/xvia_hosts.txt
+++ b/development/ansible/hosts/xvia_hosts.txt
@@ -1,0 +1,40 @@
+# X-VIA: Inventário para instalação de Security Servers via CDN
+#
+# Uso:
+#   ansible-playbook -i hosts/xvia_hosts.txt xvia_install.yml \
+#     -e "database_admin_password=SuaSenha" \
+#     -e "admin_password=SenhaAdmin"
+#
+# Para instalar em um host específico:
+#   ansible-playbook -i hosts/xvia_hosts.txt xvia_install.yml \
+#     -e "database_admin_password=SuaSenha" \
+#     -e "admin_password=SenhaAdmin" \
+#     --limit ss1.exemplo.gov.br
+
+# Security Servers X-VIA
+[ss_servers]
+# Formato: FQDN ansible_host=IP ansible_ssh_user=USUARIO [ansible_ssh_private_key_file=CHAVE]
+#
+# Exemplos:
+# ss1.exemplo.gov.br ansible_host=10.0.1.10 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+# ss2.exemplo.gov.br ansible_host=10.0.1.11 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+[ss_servers:vars]
+variant=vanilla
+ansible_become=yes
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+# Central Servers (se necessário)
+[cs_servers]
+
+# Super grupo com todos os servidores
+[xvia:children]
+ss_servers
+cs_servers
+
+[all:vars]
+# Usuário admin da UI do X-Road
+xroad_ui_user=xvia-admin
+# Senha definida via -e na linha de comando (NÃO armazenar aqui)
+# xroad_ui_user_password=

--- a/development/ansible/hosts/xvia_onpremises.txt
+++ b/development/ansible/hosts/xvia_onpremises.txt
@@ -1,0 +1,85 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Inventário On-Premises — Todos os Componentes
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Ajuste os hostnames/IPs abaixo para o ambiente do cliente.
+# Use FQDNs reais (não IPs) pois são usados na geração de certificados.
+#
+# EXECUÇÃO:
+#   ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#     -e "admin_password=SenhaAdmin" \
+#     -e "database_admin_password=SenhaBanco"
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Central Server ───────────────────────────────────────────────────────────
+# Apenas 1 por ambiente. Gerencia membros, global configuration, etc.
+[cs_servers]
+cs.exemplo.gov.br ansible_host=192.168.1.10 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── Security Server(s) ──────────────────────────────────────────────────────
+# Pode ter múltiplos. Cada órgão/participante tem o seu.
+[ss_servers]
+ss1.exemplo.gov.br ansible_host=192.168.1.20 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+ss2.exemplo.gov.br ansible_host=192.168.1.21 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── CA Server ────────────────────────────────────────────────────────────────
+# Fornece CA, OCSP e TSA para o ambiente.
+[ca_servers]
+ca.exemplo.gov.br ansible_host=192.168.1.5 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── Super grupo (todos os servidores) ────────────────────────────────────────
+[xvia:children]
+cs_servers
+ss_servers
+ca_servers
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VARIÁVEIS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+[all:vars]
+ansible_become=yes
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+# ─── Admin da UI do X-Road ────────────────────────────────────────────────────
+# Usuário que acessa a interface web (porta 4000)
+xroad_ui_user=xvia-admin
+
+# ─── Banco de dados ──────────────────────────────────────────────────────────
+# PostgreSQL on-premises do cliente
+# Substitua pelo IP/hostname e porta do banco do cliente
+use_remote_db=true
+database_host=192.168.1.50:5432
+database_admin_user=postgres
+# database_admin_password via -e na CLI (NÃO armazenar aqui em produção)
+
+# ─── Senhas customizadas dos bancos (opcionais) ──────────────────────────────
+# Se não definidas, usam os defaults do vars_files/xvia_database.yml
+# Em produção, use ansible-vault:
+#   ansible-vault encrypt_string 'minha-senha' --name 'serverconf_password'
+#
+# serverconf_password=SenhaCustomServerconf
+# messagelog_password=SenhaCustomMsglog
+# opmonitor_password=SenhaCustomOpmon
+# centerui_password=SenhaCustomCenterUI
+# centerui_admin_password=SenhaCustomCenterAdmin
+
+# ─── CA Server ────────────────────────────────────────────────────────────────
+[ca_servers:vars]
+ca_organization=Governo do Estado - X-VIA
+ca_cn=X-VIA Autoridade Certificadora
+
+# ─── Pacotes (escolha o modo) ────────────────────────────────────────────────
+# Para ambientes COM internet (CDN CloudFront):
+#   xvia_package_source=cdn
+#
+# Para ambientes COM AWS CLI (download direto do S3):
+#   xvia_package_source=s3
+#
+# Para ambientes SEM internet (copie o tarball antes):
+#   xvia_package_source=local
+#   xvia_local_tarball_path=/opt/xvia-packages/xroad-7.8.0-ubuntu24.04.tar.gz
+[xvia:vars]
+xvia_package_source=cdn

--- a/development/ansible/hosts/xvia_onpremises.txt
+++ b/development/ansible/hosts/xvia_onpremises.txt
@@ -28,11 +28,17 @@ ss2.exemplo.gov.br ansible_host=192.168.1.21 ansible_ssh_user=ubuntu ansible_ssh
 [ca_servers]
 ca.exemplo.gov.br ansible_host=192.168.1.5 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
 
+# ─── Database Server ──────────────────────────────────────────────────────────
+# Servidor PostgreSQL remoto. Necessário para instalar postgresql-contrib.
+[db_servers]
+db.exemplo.gov.br ansible_host=192.168.1.50 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
 # ─── Super grupo (todos os servidores) ────────────────────────────────────────
 [xvia:children]
 cs_servers
 ss_servers
 ca_servers
+db_servers
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # VARIÁVEIS

--- a/development/ansible/hosts/xvia_onpremises.txt
+++ b/development/ansible/hosts/xvia_onpremises.txt
@@ -29,7 +29,11 @@ ss2.exemplo.gov.br ansible_host=192.168.1.21 ansible_ssh_user=ubuntu ansible_ssh
 ca.exemplo.gov.br ansible_host=192.168.1.5 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
 
 # ─── Database Server ──────────────────────────────────────────────────────────
-# Servidor PostgreSQL remoto. Necessário para instalar postgresql-contrib.
+# Servidor PostgreSQL remoto COM acesso SSH (on-premises).
+# O Ansible usa delegate_to para instalar postgresql-contrib neste host.
+#
+# CENÁRIO ON-PREMISES: descomente e preencha o host abaixo.
+# CENÁRIO RDS/Aurora:  deixe vazio e defina db_is_managed=true em [all:vars].
 [db_servers]
 db.exemplo.gov.br ansible_host=192.168.1.50 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
 
@@ -60,6 +64,11 @@ use_remote_db=true
 database_host=192.168.1.50:5432
 database_admin_user=postgres
 # database_admin_password via -e na CLI (NÃO armazenar aqui em produção)
+
+# Banco gerenciado (RDS/Aurora)?
+#   false = on-premises (Ansible instala postgresql-contrib via SSH em [db_servers])
+#   true  = RDS/Aurora  (sem SSH; extensão hstore criada via CREATE EXTENSION)
+db_is_managed=false
 
 # ─── Senhas customizadas dos bancos (opcionais) ──────────────────────────────
 # Se não definidas, usam os defaults do vars_files/xvia_database.yml

--- a/development/ansible/hosts/xvia_rds.txt
+++ b/development/ansible/hosts/xvia_rds.txt
@@ -1,0 +1,72 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Inventário com Banco RDS/Aurora (AWS)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Use este inventário quando o PostgreSQL é gerenciado pela AWS (RDS ou Aurora).
+# Neste cenário, NÃO há acesso SSH ao servidor de banco — apenas conexão SQL.
+#
+# EXECUÇÃO:
+#   ansible-playbook -i hosts/xvia_rds.txt xvia_install.yml \
+#     -e "admin_password=SenhaAdmin" \
+#     -e "database_admin_password=SenhaBanco"
+#
+# DIFERENÇAS DO ON-PREMISES:
+#   - [db_servers] fica VAZIO (sem SSH ao banco)
+#   - db_is_managed=true (pula instalação de pacotes no DB)
+#   - A extensão hstore é criada via CREATE EXTENSION (funciona em RDS)
+#   - postgresql-contrib já está disponível no RDS por padrão
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Central Server ───────────────────────────────────────────────────────────
+[cs_servers]
+cs.exemplo.gov.br ansible_host=10.0.1.10 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── Security Server(s) ──────────────────────────────────────────────────────
+[ss_servers]
+ss1.exemplo.gov.br ansible_host=10.0.1.20 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── CA Server ────────────────────────────────────────────────────────────────
+[ca_servers]
+ca.exemplo.gov.br ansible_host=10.0.1.5 ansible_ssh_user=ubuntu ansible_ssh_private_key_file=~/.ssh/xvia-key.pem
+
+# ─── Database Server ──────────────────────────────────────────────────────────
+# VAZIO — RDS/Aurora não aceita SSH. A conexão é feita via SQL pelo Central Server.
+[db_servers]
+
+# ─── Super grupo ──────────────────────────────────────────────────────────────
+[xvia:children]
+cs_servers
+ss_servers
+ca_servers
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VARIÁVEIS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+[all:vars]
+ansible_become=yes
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+# ─── Admin da UI do X-Road ────────────────────────────────────────────────────
+xroad_ui_user=xvia-admin
+
+# ─── Banco de dados (RDS/Aurora) ─────────────────────────────────────────────
+use_remote_db=true
+# Endpoint do RDS (substituir pelo seu):
+database_host=xvia-db.abc123xyz.us-east-1.rds.amazonaws.com:5432
+database_admin_user=postgres
+# database_admin_password via -e na CLI
+
+# Banco gerenciado = true (RDS/Aurora, sem SSH)
+db_is_managed=true
+
+# ─── CA Server ────────────────────────────────────────────────────────────────
+[ca_servers:vars]
+ca_organization=Governo do Estado - X-VIA
+ca_cn=X-VIA Autoridade Certificadora
+
+# ─── Pacotes ──────────────────────────────────────────────────────────────────
+[xvia:vars]
+xvia_package_source=cdn

--- a/development/ansible/scripts/update-security-groups.sh
+++ b/development/ansible/scripts/update-security-groups.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Atualizar Security Groups para nova instância/stack
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Este script configura as regras de Security Group necessárias para uma nova
+# stack X-Road (Central Server, Security Server, CA, Management SS).
+#
+# Ele garante que:
+#   - VPN (10.8.0.0/24 e 10.1.0.0/16 masquerade) acessa portas de admin
+#   - Comunicação interna entre componentes via SG references
+#   - Portas de serviço (OCSP, TSA, global config) abertas corretamente
+#
+# USO:
+#   ./update-security-groups.sh --region sa-east-1 --vpc-id vpc-XXXXX
+#   ./update-security-groups.sh --region sa-east-1 --stack-name xvia-maringa-prod
+#   ./update-security-groups.sh --region sa-east-1 --sg-cs sg-XXX --sg-ss sg-XXX --sg-ca sg-XXX --sg-mss sg-XXX
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+# ─── Cores ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+REGION="sa-east-1"
+VPC_ID=""
+STACK_NAME=""
+SG_CS=""    # Central Server
+SG_SS=""    # Security Server
+SG_CA=""    # CA Server
+SG_MSS=""   # Management Security Server
+SG_DB=""    # Database (RDS)
+VPN_CIDR="10.8.0.0/24"
+VPN_VPC_CIDR="10.1.0.0/16"  # VPC onde está o servidor VPN (masquerade)
+DRY_RUN=false
+ADMIN_IP=""  # IP específico para admin UI (opcional)
+
+# ─── Funções ──────────────────────────────────────────────────────────────────
+
+usage() {
+    cat << EOF
+Uso: $(basename "$0") [opções]
+
+Opções:
+  --region REGION           Região AWS (default: sa-east-1)
+  --vpc-id VPC_ID           VPC ID para descobrir SGs automaticamente
+  --stack-name STACK        Nome da stack CloudFormation para descobrir SGs
+  --sg-cs SG_ID             Security Group do Central Server
+  --sg-ss SG_ID             Security Group do Security Server
+  --sg-ca SG_ID             Security Group do CA Server
+  --sg-mss SG_ID            Security Group do Management Security Server
+  --sg-db SG_ID             Security Group do Database (RDS)
+  --vpn-cidr CIDR           CIDR da VPN (default: 10.8.0.0/24)
+  --vpn-vpc-cidr CIDR       CIDR da VPC da VPN/masquerade (default: 10.1.0.0/16)
+  --admin-ip IP             IP público para Admin UI (ex: 177.193.214.120/32)
+  --dry-run                 Apenas mostrar o que seria feito
+  --help                    Mostrar esta ajuda
+
+Exemplos:
+  # Descobrir SGs pela stack CloudFormation:
+  $(basename "$0") --stack-name xvia-maringa-prod
+
+  # Especificar SGs manualmente:
+  $(basename "$0") --sg-cs sg-0e92... --sg-ss sg-0064... --sg-ca sg-0be0... --sg-mss sg-09c0...
+
+  # Com IP público para admin:
+  $(basename "$0") --stack-name xvia-maringa-prod --admin-ip 200.100.50.25/32
+EOF
+    exit 0
+}
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_dry()   { echo -e "${YELLOW}[DRY-RUN]${NC} $*"; }
+
+# Adiciona regra de ingress (idempotente - ignora se já existe)
+add_ingress_cidr() {
+    local sg_id="$1"
+    local protocol="$2"
+    local from_port="$3"
+    local to_port="$4"
+    local cidr="$5"
+    local description="$6"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "authorize-security-group-ingress $sg_id: ${protocol}/${from_port}-${to_port} from ${cidr} (${description})"
+        return 0
+    fi
+
+    aws ec2 authorize-security-group-ingress \
+        --region "$REGION" \
+        --group-id "$sg_id" \
+        --ip-permissions "[{
+            \"IpProtocol\": \"$protocol\",
+            \"FromPort\": $from_port,
+            \"ToPort\": $to_port,
+            \"IpRanges\": [{\"CidrIp\": \"$cidr\", \"Description\": \"$description\"}]
+        }]" 2>/dev/null && log_ok "  $sg_id: ${protocol}/${from_port}-${to_port} ← ${cidr} ($description)" \
+        || log_warn "  $sg_id: ${protocol}/${from_port}-${to_port} ← ${cidr} (já existe ou erro)"
+}
+
+# Adiciona regra de ingress referenciando outro SG (idempotente)
+add_ingress_sg() {
+    local sg_id="$1"
+    local protocol="$2"
+    local from_port="$3"
+    local to_port="$4"
+    local source_sg="$5"
+    local description="$6"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "authorize-security-group-ingress $sg_id: ${protocol}/${from_port}-${to_port} from SG:${source_sg} (${description})"
+        return 0
+    fi
+
+    aws ec2 authorize-security-group-ingress \
+        --region "$REGION" \
+        --group-id "$sg_id" \
+        --ip-permissions "[{
+            \"IpProtocol\": \"$protocol\",
+            \"FromPort\": $from_port,
+            \"ToPort\": $to_port,
+            \"UserIdGroupPairs\": [{\"GroupId\": \"$source_sg\", \"Description\": \"$description\"}]
+        }]" 2>/dev/null && log_ok "  $sg_id: ${protocol}/${from_port}-${to_port} ← SG:${source_sg} ($description)" \
+        || log_warn "  $sg_id: ${protocol}/${from_port}-${to_port} ← SG:${source_sg} (já existe ou erro)"
+}
+
+# Adiciona regra "all traffic" de um CIDR (protocolo -1)
+add_ingress_all_cidr() {
+    local sg_id="$1"
+    local cidr="$2"
+    local description="$3"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "authorize-security-group-ingress $sg_id: ALL from ${cidr} (${description})"
+        return 0
+    fi
+
+    aws ec2 authorize-security-group-ingress \
+        --region "$REGION" \
+        --group-id "$sg_id" \
+        --ip-permissions "[{
+            \"IpProtocol\": \"-1\",
+            \"IpRanges\": [{\"CidrIp\": \"$cidr\", \"Description\": \"$description\"}]
+        }]" 2>/dev/null && log_ok "  $sg_id: ALL ← ${cidr} ($description)" \
+        || log_warn "  $sg_id: ALL ← ${cidr} (já existe ou erro)"
+}
+
+# Descobrir SGs via CloudFormation stack
+discover_sgs_from_stack() {
+    local stack="$1"
+    log_info "Descobrindo Security Groups da stack: $stack"
+
+    local resources
+    resources=$(aws cloudformation describe-stack-resources \
+        --region "$REGION" \
+        --stack-name "$stack" \
+        --query "StackResources[?ResourceType=='AWS::EC2::SecurityGroup'].{LogicalId:LogicalResourceId,PhysicalId:PhysicalResourceId}" \
+        --output json 2>/dev/null)
+
+    if [[ -z "$resources" ]]; then
+        log_error "Não foi possível encontrar a stack: $stack"
+        exit 1
+    fi
+
+    SG_CS=$(echo "$resources" | jq -r '.[] | select(.LogicalId=="SGCentralServer") | .PhysicalId' 2>/dev/null || true)
+    SG_SS=$(echo "$resources" | jq -r '.[] | select(.LogicalId=="SGSecurityServer") | .PhysicalId' 2>/dev/null || true)
+    SG_CA=$(echo "$resources" | jq -r '.[] | select(.LogicalId=="SGCA") | .PhysicalId' 2>/dev/null || true)
+    SG_MSS=$(echo "$resources" | jq -r '.[] | select(.LogicalId=="SGManagementSecurityServer") | .PhysicalId' 2>/dev/null || true)
+
+    [[ -n "$SG_CS" ]]  && log_ok "  Central Server:     $SG_CS"  || log_warn "  Central Server: não encontrado"
+    [[ -n "$SG_SS" ]]  && log_ok "  Security Server:    $SG_SS"  || log_warn "  Security Server: não encontrado"
+    [[ -n "$SG_CA" ]]  && log_ok "  CA Server:          $SG_CA"  || log_warn "  CA Server: não encontrado"
+    [[ -n "$SG_MSS" ]] && log_ok "  Management SS:      $SG_MSS" || log_warn "  Management SS: não encontrado"
+}
+
+# ─── Parse args ───────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --region)       REGION="$2"; shift 2 ;;
+        --vpc-id)       VPC_ID="$2"; shift 2 ;;
+        --stack-name)   STACK_NAME="$2"; shift 2 ;;
+        --sg-cs)        SG_CS="$2"; shift 2 ;;
+        --sg-ss)        SG_SS="$2"; shift 2 ;;
+        --sg-ca)        SG_CA="$2"; shift 2 ;;
+        --sg-mss)       SG_MSS="$2"; shift 2 ;;
+        --sg-db)        SG_DB="$2"; shift 2 ;;
+        --vpn-cidr)     VPN_CIDR="$2"; shift 2 ;;
+        --vpn-vpc-cidr) VPN_VPC_CIDR="$2"; shift 2 ;;
+        --admin-ip)     ADMIN_IP="$2"; shift 2 ;;
+        --dry-run)      DRY_RUN=true; shift ;;
+        --help|-h)      usage ;;
+        *) log_error "Opção desconhecida: $1"; usage ;;
+    esac
+done
+
+# ─── Descobrir SGs ────────────────────────────────────────────────────────────
+
+if [[ -n "$STACK_NAME" ]]; then
+    discover_sgs_from_stack "$STACK_NAME"
+fi
+
+# Validar que temos pelo menos o CS
+if [[ -z "$SG_CS" ]]; then
+    log_error "Security Group do Central Server não definido."
+    log_error "Use --stack-name ou --sg-cs para especificar."
+    exit 1
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════════════"
+echo " X-VIA: Configurando Security Groups"
+echo "═══════════════════════════════════════════════════════════════════════════════"
+echo ""
+echo " Região:          $REGION"
+echo " VPN CIDR:        $VPN_CIDR"
+echo " VPN VPC CIDR:    $VPN_VPC_CIDR"
+echo " Central Server:  ${SG_CS:-N/A}"
+echo " Security Server: ${SG_SS:-N/A}"
+echo " CA Server:       ${SG_CA:-N/A}"
+echo " Management SS:   ${SG_MSS:-N/A}"
+echo " Database:        ${SG_DB:-N/A}"
+echo " Admin IP:        ${ADMIN_IP:-não definido}"
+echo " Dry Run:         $DRY_RUN"
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════════════"
+echo ""
+
+# ─── 1. Central Server (CS) ──────────────────────────────────────────────────
+
+if [[ -n "$SG_CS" ]]; then
+    log_info "═══ Central Server ($SG_CS) ═══"
+
+    # VPN access (all traffic)
+    add_ingress_all_cidr "$SG_CS" "$VPN_CIDR" "VPN users via VPC Peering"
+
+    # VPN masquerade (porta 4000 para admin via VPN)
+    add_ingress_cidr "$SG_CS" "tcp" 4000 4000 "$VPN_VPC_CIDR" "Admin UI - VPN server VPC (peering masquerade)"
+
+    # Admin IP público (se fornecido)
+    if [[ -n "$ADMIN_IP" ]]; then
+        add_ingress_cidr "$SG_CS" "tcp" 4000 4000 "$ADMIN_IP" "Admin UI - IP admin"
+    fi
+
+    # Global config download (HTTP/HTTPS) - de SS e Management SS
+    if [[ -n "$SG_SS" ]]; then
+        add_ingress_sg "$SG_CS" "tcp" 80  80  "$SG_SS"  "Global config download - Security Server"
+        add_ingress_sg "$SG_CS" "tcp" 443 443 "$SG_SS"  "Global config download HTTPS - Security Server"
+        add_ingress_sg "$SG_CS" "tcp" 4001 4001 "$SG_SS" "Auth cert registration - Security Server"
+    fi
+    if [[ -n "$SG_MSS" ]]; then
+        add_ingress_sg "$SG_CS" "tcp" 80  80  "$SG_MSS" "Global config download - Management SS"
+        add_ingress_sg "$SG_CS" "tcp" 443 443 "$SG_MSS" "Global config download HTTPS - Management SS"
+        add_ingress_sg "$SG_CS" "tcp" 4001 4001 "$SG_MSS" "Auth cert registration - Management SS"
+        add_ingress_sg "$SG_CS" "tcp" 4002 4002 "$SG_MSS" "Management services - Management SS"
+    fi
+
+    # Postgres (se tiver SG de DB)
+    if [[ -n "$SG_DB" ]]; then
+        add_ingress_sg "$SG_CS" "tcp" 5432 5432 "$SG_DB" "PostgreSQL - Database"
+    fi
+
+    echo ""
+fi
+
+# ─── 2. Security Server (SS) ─────────────────────────────────────────────────
+
+if [[ -n "$SG_SS" ]]; then
+    log_info "═══ Security Server ($SG_SS) ═══"
+
+    # VPN access (all traffic)
+    add_ingress_all_cidr "$SG_SS" "$VPN_CIDR" "VPN users via VPC Peering"
+
+    # VPN masquerade (portas admin)
+    add_ingress_cidr "$SG_SS" "tcp" 4000 4000 "$VPN_VPC_CIDR" "Admin UI - VPN server VPC (peering masquerade)"
+    add_ingress_cidr "$SG_SS" "tcp" 8080 8080 "$VPN_VPC_CIDR" "Info system HTTP - VPN server VPC (peering masquerade)"
+    add_ingress_cidr "$SG_SS" "tcp" 8443 8443 "$VPN_VPC_CIDR" "Info system HTTPS - VPN server VPC (peering masquerade)"
+
+    # Admin IP público (se fornecido)
+    if [[ -n "$ADMIN_IP" ]]; then
+        add_ingress_cidr "$SG_SS" "tcp" 4000 4000 "$ADMIN_IP" "Admin UI - IP admin"
+        add_ingress_cidr "$SG_SS" "tcp" 8080 8080 "$ADMIN_IP" "Information system access - IP admin"
+        add_ingress_cidr "$SG_SS" "tcp" 8443 8443 "$ADMIN_IP" "Information system access HTTPS - IP admin"
+    fi
+
+    # Message exchange e OCSP - de Management SS
+    if [[ -n "$SG_MSS" ]]; then
+        add_ingress_sg "$SG_SS" "tcp" 5500 5500 "$SG_MSS" "Message exchange - Management SS (monitoring)"
+        add_ingress_sg "$SG_SS" "tcp" 5577 5577 "$SG_MSS" "OCSP query - Management SS (monitoring)"
+    fi
+
+    echo ""
+fi
+
+# ─── 3. CA Server ────────────────────────────────────────────────────────────
+
+if [[ -n "$SG_CA" ]]; then
+    log_info "═══ CA Server ($SG_CA) ═══"
+
+    # VPN access (all traffic)
+    add_ingress_all_cidr "$SG_CA" "$VPN_CIDR" "VPN users via VPC Peering"
+    add_ingress_all_cidr "$SG_CA" "$VPN_VPC_CIDR" "VPC DEV (VPN server MASQUERADE)"
+
+    # OCSP Responder (8888) - de SS e Management SS
+    if [[ -n "$SG_SS" ]]; then
+        add_ingress_sg "$SG_CA" "tcp" 8888 8888 "$SG_SS"  "OCSP Responder - Security Server"
+        add_ingress_sg "$SG_CA" "tcp" 8899 8899 "$SG_SS"  "TSA - Security Server"
+        add_ingress_sg "$SG_CA" "tcp" 8887 8887 "$SG_SS"  "Security Server ACME"
+        add_ingress_sg "$SG_CA" "tcp" 443  443  "$SG_SS"  "SS-ACME/OCSP/TSA via HTTPS"
+    fi
+    if [[ -n "$SG_MSS" ]]; then
+        add_ingress_sg "$SG_CA" "tcp" 8888 8888 "$SG_MSS" "OCSP Responder - Management SS"
+        add_ingress_sg "$SG_CA" "tcp" 8899 8899 "$SG_MSS" "TSA - Management SS"
+        add_ingress_sg "$SG_CA" "tcp" 443  443  "$SG_MSS" "GER-ACME/OCSP/TSA via HTTPS"
+    fi
+    if [[ -n "$SG_CS" ]]; then
+        add_ingress_sg "$SG_CA" "tcp" 443 443 "$SG_CS" "SC-ACME/OCSP/TSA via HTTPS"
+    fi
+
+    echo ""
+fi
+
+# ─── 4. Management Security Server (MSS) ─────────────────────────────────────
+
+if [[ -n "$SG_MSS" ]]; then
+    log_info "═══ Management Security Server ($SG_MSS) ═══"
+
+    # VPN access (all traffic)
+    add_ingress_all_cidr "$SG_MSS" "$VPN_CIDR" "VPN users via VPC Peering"
+
+    # VPN masquerade (portas admin)
+    add_ingress_cidr "$SG_MSS" "tcp" 4000 4000 "$VPN_VPC_CIDR" "Admin UI - VPN server VPC (peering masquerade)"
+    add_ingress_cidr "$SG_MSS" "tcp" 8080 8080 "$VPN_VPC_CIDR" "Info system HTTP - VPN server VPC (peering masquerade)"
+    add_ingress_cidr "$SG_MSS" "tcp" 8443 8443 "$VPN_VPC_CIDR" "Info system HTTPS - VPN server VPC (peering masquerade)"
+
+    # Admin IP público (se fornecido)
+    if [[ -n "$ADMIN_IP" ]]; then
+        add_ingress_cidr "$SG_MSS" "tcp" 4000 4000 "$ADMIN_IP" "Admin UI - IP admin"
+        add_ingress_cidr "$SG_MSS" "tcp" 8080 8080 "$ADMIN_IP" "Information system access - IP admin"
+        add_ingress_cidr "$SG_MSS" "tcp" 8443 8443 "$ADMIN_IP" "Information system access HTTPS - IP admin"
+    fi
+
+    # Message exchange e OCSP - de Security Server
+    if [[ -n "$SG_SS" ]]; then
+        add_ingress_sg "$SG_MSS" "tcp" 5500 5500 "$SG_SS" "Message exchange - Security Server"
+        add_ingress_sg "$SG_MSS" "tcp" 5577 5577 "$SG_SS" "OCSP query - Security Server"
+    fi
+
+    echo ""
+fi
+
+# ─── Resumo ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════════════"
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e " ${YELLOW}DRY RUN concluído. Nenhuma alteração foi feita.${NC}"
+    echo " Execute novamente sem --dry-run para aplicar."
+else
+    echo -e " ${GREEN}✅ Security Groups configurados com sucesso!${NC}"
+fi
+echo "═══════════════════════════════════════════════════════════════════════════════"
+echo ""
+echo " Portas abertas por componente:"
+echo "   Central Server:  4000(admin), 80/443(global conf), 4001(auth reg), 4002(mgmt)"
+echo "   Security Server: 4000(admin), 5500(msg), 5577(OCSP), 8080/8443(info sys)"
+echo "   CA Server:       8888(OCSP), 8899(TSA), 8887(ACME), 443(HTTPS)"
+echo "   Management SS:   4000(admin), 5500(msg), 5577(OCSP), 8080/8443(info sys)"
+echo ""
+echo " Acesso VPN: ${VPN_CIDR} (direto) + ${VPN_VPC_CIDR} (masquerade)"
+echo ""

--- a/development/ansible/tasks/xvia_ca_install.yml
+++ b/development/ansible/tasks/xvia_ca_install.yml
@@ -1,0 +1,405 @@
+---
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Instalação do CA Server (Test CA, TSA, OCSP)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# O CA Server fornece serviços de certificação para o ambiente X-Road:
+#   - CA (Certificate Authority)
+#   - OCSP (Online Certificate Status Protocol)
+#   - TSA (Time Stamping Authority)
+#
+# Variáveis:
+#   xvia_ca_organization: Nome da organização no certificado
+#   xvia_ca_cn: Common Name do CA
+# ═══════════════════════════════════════════════════════════════════════════════
+
+- name: "CA — Install required packages"
+  apt:
+    name:
+      - python3
+      - acl
+      - nginx-core
+      - openssl
+      - python3-pip
+      - uwsgi
+      - uwsgi-plugin-python3
+    state: present
+    update_cache: yes
+
+- name: "CA — Create ca group"
+  group:
+    name: ca
+    system: yes
+
+- name: "CA — Create ca user"
+  user:
+    name: ca
+    group: ca
+    comment: "CA user"
+    createhome: yes
+    system: yes
+
+- name: "CA — Ensure nginx access to ca home"
+  file:
+    mode: "0755"
+    path: /home/ca
+
+- name: "CA — Create ocsp user"
+  user:
+    name: ocsp
+    group: ca
+    comment: "OCSP user"
+    createhome: yes
+    system: yes
+
+- name: "CA — Create CA directory structure"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: ca
+    group: ca
+    mode: '0755'
+  loop:
+    - /home/ca/CA
+    - /home/ca/CA/newcerts
+    - /home/ca/CA/certs
+    - /home/ca/TSA
+
+- name: "CA — Create CA init script"
+  copy:
+    content: |
+      #!/bin/bash
+      set -e
+      cd /home/ca/CA
+
+      # Configuração
+      export CA_O="{{ xvia_ca_organization | default('X-VIA CA') }}"
+      export CA_CN="{{ xvia_ca_cn | default('X-VIA Test CA') }}"
+      export OCSP_O="{{ xvia_ca_ocsp_organization | default(xvia_ca_organization | default('X-VIA CA')) }}"
+      export OCSP_CN="{{ xvia_ca_ocsp_cn | default('X-VIA Test OCSP') }}"
+      export TSA_O="{{ xvia_ca_tsa_organization | default(xvia_ca_organization | default('X-VIA CA')) }}"
+      export TSA_CN="{{ xvia_ca_tsa_cn | default('X-VIA Test TSA') }}"
+
+      if [ -f .init ]; then
+        echo "CA already initialized"
+        exit 0
+      fi
+
+      # Gerar CA root key e certificado
+      openssl genrsa -out ca.key 4096
+      openssl req -new -x509 -key ca.key -out ca.pem -days 7300 \
+        -subj "/O=$CA_O/CN=$CA_CN"
+
+      # Criar index e serial
+      touch index.txt
+      echo 01 > serial
+      echo 01 > crlnumber
+
+      # OpenSSL CA config
+      cat > ca.cnf << 'CACNF'
+      [ca]
+      default_ca = CA_default
+
+      [CA_default]
+      dir = /home/ca/CA
+      certs = $dir/certs
+      new_certs_dir = $dir/newcerts
+      database = $dir/index.txt
+      serial = $dir/serial
+      certificate = $dir/ca.pem
+      private_key = $dir/ca.key
+      default_days = 3650
+      default_md = sha256
+      policy = policy_anything
+      copy_extensions = copy
+
+      [policy_anything]
+      countryName = optional
+      stateOrProvinceName = optional
+      localityName = optional
+      organizationName = optional
+      organizationalUnitName = optional
+      commonName = supplied
+      emailAddress = optional
+      CACNF
+
+      # Gerar OCSP key e certificado
+      openssl genrsa -out ocsp.key 2048
+      openssl req -new -key ocsp.key -out ocsp.csr \
+        -subj "/O=$OCSP_O/CN=$OCSP_CN"
+      openssl ca -config ca.cnf -in ocsp.csr -out ocsp.pem -days 3650 -batch \
+        -extensions ocsp_ext -extfile <(echo -e "[ocsp_ext]\nbasicConstraints=CA:FALSE\nkeyUsage=digitalSignature\nextendedKeyUsage=OCSPSigning")
+
+      # Gerar TSA key e certificado
+      openssl genrsa -out tsa.key 2048
+      openssl req -new -key tsa.key -out tsa.csr \
+        -subj "/O=$TSA_O/CN=$TSA_CN"
+      openssl ca -config ca.cnf -in tsa.csr -out tsa.pem -days 3650 -batch \
+        -extensions tsa_ext -extfile <(echo -e "[tsa_ext]\nbasicConstraints=CA:FALSE\nkeyUsage=digitalSignature\nextendedKeyUsage=timeStamping")
+
+      # Gerar CRL inicial
+      openssl ca -config ca.cnf -gencrl -out crl.pem
+
+      touch .init
+      echo "CA initialized successfully"
+    dest: /home/ca/CA/init.sh
+    owner: ca
+    group: ca
+    mode: '0700'
+
+- name: "CA — Create OCSP responder script"
+  copy:
+    content: |
+      #!/usr/bin/env python3
+      """Simple OCSP responder using openssl ocsp"""
+      import subprocess, sys, os
+      from http.server import HTTPServer, BaseHTTPRequestHandler
+
+      CA_DIR = "/home/ca/CA"
+      PORT = int(os.environ.get("OCSP_PORT", "8888"))
+
+      class OCSPHandler(BaseHTTPRequestHandler):
+          def do_POST(self):
+              content_length = int(self.headers['Content-Length'])
+              request_data = self.rfile.read(content_length)
+              try:
+                  result = subprocess.run(
+                      ["openssl", "ocsp", "-index", f"{CA_DIR}/index.txt",
+                       "-CA", f"{CA_DIR}/ca.pem",
+                       "-rsigner", f"{CA_DIR}/ocsp.pem",
+                       "-rkey", f"{CA_DIR}/ocsp.key",
+                       "-reqin", "/dev/stdin", "-respout", "/dev/stdout"],
+                      input=request_data, capture_output=True)
+                  self.send_response(200)
+                  self.send_header("Content-Type", "application/ocsp-response")
+                  self.end_headers()
+                  self.wfile.write(result.stdout)
+              except Exception as e:
+                  self.send_response(500)
+                  self.end_headers()
+          def log_message(self, format, *args):
+              pass
+
+      if __name__ == "__main__":
+          server = HTTPServer(("0.0.0.0", PORT), OCSPHandler)
+          print(f"OCSP responder on port {PORT}")
+          server.serve_forever()
+    dest: /home/ca/CA/ocsp.py
+    owner: ca
+    group: ca
+    mode: '0755'
+
+- name: "CA — Create TSA server script"
+  copy:
+    content: |
+      #!/usr/bin/env python3
+      """Simple TSA responder"""
+      import subprocess, tempfile, os
+      from http.server import HTTPServer, BaseHTTPRequestHandler
+
+      CA_DIR = "/home/ca/CA"
+      TSA_DIR = "/home/ca/TSA"
+      PORT = int(os.environ.get("TSA_PORT", "8899"))
+
+      class TSAHandler(BaseHTTPRequestHandler):
+          def do_POST(self):
+              content_length = int(self.headers['Content-Length'])
+              request_data = self.rfile.read(content_length)
+              with tempfile.NamedTemporaryFile(suffix='.tsq') as req_file:
+                  req_file.write(request_data)
+                  req_file.flush()
+                  with tempfile.NamedTemporaryFile(suffix='.tsr') as resp_file:
+                      subprocess.run(
+                          ["openssl", "ts", "-reply",
+                           "-config", f"{TSA_DIR}/TSA.cnf",
+                           "-queryfile", req_file.name,
+                           "-out", resp_file.name,
+                           "-inkey", f"{CA_DIR}/tsa.key",
+                           "-signer", f"{CA_DIR}/tsa.pem",
+                           "-chain", f"{CA_DIR}/ca.pem"],
+                          capture_output=True)
+                      resp_file.seek(0)
+                      response = resp_file.read()
+              self.send_response(200)
+              self.send_header("Content-Type", "application/timestamp-reply")
+              self.end_headers()
+              self.wfile.write(response)
+          def log_message(self, format, *args):
+              pass
+
+      if __name__ == "__main__":
+          server = HTTPServer(("0.0.0.0", PORT), TSAHandler)
+          print(f"TSA server on port {PORT}")
+          server.serve_forever()
+    dest: /home/ca/TSA/tsa_server.py
+    owner: ca
+    group: ca
+    mode: '0755'
+
+- name: "CA — Create TSA config"
+  copy:
+    content: |
+      [tsa]
+      default_tsa = tsa_config1
+
+      [tsa_config1]
+      dir = /home/ca/TSA
+      serial = $dir/serial
+      signer_cert = /home/ca/CA/tsa.pem
+      certs = /home/ca/CA/ca.pem
+      signer_key = /home/ca/CA/tsa.key
+      default_policy = 1.2.3.4.1
+      digests = sha256,sha384,sha512
+      accuracy = secs:1, millisecs:500, microsecs:100
+      ordering = yes
+      tsa_name = yes
+      ess_cert_id_chain = no
+    dest: /home/ca/TSA/TSA.cnf
+    owner: ca
+    group: ca
+    mode: '0664'
+
+- name: "CA — Create TSA serial"
+  copy:
+    content: "01"
+    dest: /home/ca/TSA/serial
+    owner: ca
+    group: ca
+    mode: '0644'
+    force: no
+
+- name: "CA — Check if CA initialized"
+  stat:
+    path: /home/ca/CA/.init
+  register: _ca_init_marker
+
+- name: "CA — Run CA init"
+  shell: ./init.sh
+  args:
+    chdir: /home/ca/CA
+  become: true
+  become_user: ca
+  when: not _ca_init_marker.stat.exists
+
+- name: "CA — Create sign script"
+  copy:
+    content: |
+      #!/bin/bash
+      # Sign a CSR with the test CA
+      openssl ca -config /home/ca/CA/ca.cnf -in "$1" -out "$2" -days 3650 -batch
+    dest: /usr/local/bin/sign
+    mode: '0755'
+
+- name: "CA — Create OCSP systemd unit"
+  copy:
+    content: |
+      [Unit]
+      Description=X-VIA OCSP Responder
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=ca
+      Group=ca
+      ExecStart=/usr/bin/python3 /home/ca/CA/ocsp.py
+      Environment=OCSP_PORT=8888
+      Restart=always
+      RestartSec=5
+
+      [Install]
+      WantedBy=multi-user.target
+    dest: /etc/systemd/system/ocsp.service
+    mode: '0644'
+
+- name: "CA — Create TSA systemd unit"
+  copy:
+    content: |
+      [Unit]
+      Description=X-VIA TSA Server
+      After=network.target
+
+      [Service]
+      Type=simple
+      User=ca
+      Group=ca
+      ExecStart=/usr/bin/python3 /home/ca/TSA/tsa_server.py
+      Environment=TSA_PORT=8899
+      Restart=always
+      RestartSec=5
+
+      [Install]
+      WantedBy=multi-user.target
+    dest: /etc/systemd/system/tsa.service
+    mode: '0644'
+
+- name: "CA — Reload systemd"
+  systemd:
+    daemon_reload: true
+
+- name: "CA — Start and enable services"
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  loop:
+    - ocsp
+    - tsa
+    - nginx
+
+- name: "CA — Create nginx config for OCSP/CRL"
+  copy:
+    content: |
+      server {
+          listen 8080 default_server;
+
+          location /crl {
+              alias /home/ca/CA/crl.pem;
+              default_type application/pkix-crl;
+          }
+
+          location /ca.pem {
+              alias /home/ca/CA/ca.pem;
+              default_type application/x-pem-file;
+          }
+
+          location /ocsp {
+              proxy_pass http://127.0.0.1:8888;
+              proxy_set_header Host $host;
+          }
+
+          location /tsa {
+              proxy_pass http://127.0.0.1:8899;
+              proxy_set_header Host $host;
+          }
+      }
+    dest: /etc/nginx/sites-available/xvia-ca
+    mode: '0644'
+
+- name: "CA — Enable nginx site"
+  file:
+    src: /etc/nginx/sites-available/xvia-ca
+    dest: /etc/nginx/sites-enabled/xvia-ca
+    state: link
+
+- name: "CA — Remove default nginx site"
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: "CA — Restart nginx"
+  service:
+    name: nginx
+    state: restarted
+
+- name: "✅ CA Server instalado!"
+  debug:
+    msg: |
+      ══════════════════════════════════════════════════════════════
+       X-VIA CA Server instalado com sucesso!
+      ══════════════════════════════════════════════════════════════
+       CA cert:  http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:8080/ca.pem
+       CRL:      http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:8080/crl
+       OCSP:     http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:8080/ocsp
+       TSA:      http://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:8080/tsa
+       Org:      {{ xvia_ca_organization | default('X-VIA CA') }}
+      ══════════════════════════════════════════════════════════════

--- a/development/ansible/tasks/xvia_cs_install.yml
+++ b/development/ansible/tasks/xvia_cs_install.yml
@@ -117,6 +117,18 @@
   changed_when: false
   no_log: true
 
+- name: "CS — Ensure postgresql-contrib is installed on DB server"
+  apt:
+    name: "postgresql-{{ xvia_pg_version | default('16') }}-contrib"
+    state: present
+    update_cache: yes
+  delegate_to: "{{ groups['db_servers'][0] }}"
+  become: true
+  when:
+    - _use_remote_db | bool
+    - groups['db_servers'] is defined
+    - groups['db_servers'] | length > 0
+
 - name: "CS — Install hstore extension"
   shell: >
     PGPASSWORD='{{ database_admin_password }}'

--- a/development/ansible/tasks/xvia_cs_install.yml
+++ b/development/ansible/tasks/xvia_cs_install.yml
@@ -1,0 +1,315 @@
+---
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Instalação do Central Server
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FASE CS-1: Download de pacotes do Central Server
+# ──────────────────────────────────────────────────────────────────────────────
+- name: "CS — Check if CS packages already downloaded"
+  find:
+    paths: "{{ xvia_cs_debs_dir }}"
+    patterns: "*.deb"
+  register: _cs_debs_existing
+
+- name: Create CS packages directory
+  file:
+    path: "{{ xvia_cs_debs_dir }}"
+    state: directory
+    mode: '0755'
+  when: _cs_debs_existing.matched == 0
+
+- name: "CS — Download CS packages from CDN"
+  get_url:
+    url: "{{ xvia_cdn_base_url }}/central-server/{{ xvia_ubuntu_version }}/{{ item }}"
+    dest: "{{ xvia_cs_debs_dir }}/{{ item }}"
+    timeout: 600
+  loop:
+    - "xroad-base_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_amd64.deb"
+    - "xroad-centralserver_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-center_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-center-management-service_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-center-registration-service_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-centralserver-monitoring_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-confclient_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_amd64.deb"
+    - "xroad-database-remote_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+    - "xroad-nginx_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_amd64.deb"
+    - "xroad-signer_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_amd64.deb"
+    - "xroad-autologin_{{ xvia_version }}-0.gite6139dc.{{ xvia_ubuntu_version }}_all.deb"
+  when:
+    - _cs_debs_existing.matched == 0
+    - xvia_package_source == "cdn"
+
+- name: "CS — Download CS packages from S3"
+  shell: >
+    aws s3 cp s3://{{ xvia_s3_bucket }}/central-server/{{ xvia_ubuntu_version }}/
+    {{ xvia_cs_debs_dir }}/ --recursive
+    {% if xvia_s3_profile | default('') != '' %}--profile {{ xvia_s3_profile }}{% endif %}
+    --region {{ xvia_s3_region }}
+  when:
+    - _cs_debs_existing.matched == 0
+    - xvia_package_source == "s3"
+
+- name: "CS — Copy CS .deb packages to APT repo"
+  shell: cp -f {{ xvia_cs_debs_dir }}/*.deb {{ xvia_apt_repo_dir }}/
+  changed_when: false
+
+- name: "CS — Regenerate APT Packages index"
+  shell: dpkg-scanpackages -m . > Packages
+  args:
+    chdir: "{{ xvia_apt_repo_dir }}"
+
+- name: "CS — Update APT cache"
+  apt:
+    update_cache: yes
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FASE CS-2: Banco de dados do Central Server
+# ──────────────────────────────────────────────────────────────────────────────
+- name: "CS — Generate centerui passwords if empty"
+  set_fact:
+    centerui_password: "{{ centerui_password if centerui_password != '' else lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
+    centerui_admin_password: "{{ centerui_admin_password if centerui_admin_password != '' else lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
+
+- name: "CS — Create centerui_production database"
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -tc "SELECT 1 FROM pg_database WHERE datname='{{ cs_database_name }}'" | grep -q 1 ||
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -c "CREATE DATABASE \"{{ cs_database_name }}\" ENCODING 'UTF8';
+        REVOKE ALL ON DATABASE \"{{ cs_database_name }}\" FROM PUBLIC;"
+  changed_when: false
+  no_log: true
+
+- name: "CS — Create centerui roles"
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c "
+    DO \$\$ BEGIN
+      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='{{ item.name }}') THEN
+        CREATE ROLE {{ item.name }} LOGIN PASSWORD '{{ item.password }}';
+      ELSE
+        ALTER ROLE {{ item.name }} PASSWORD '{{ item.password }}';
+      END IF;
+    END \$\$;"
+  loop:
+    - { name: "{{ centerui_admin_username }}", password: "{{ centerui_admin_password }}" }
+    - { name: "{{ centerui_username }}", password: "{{ centerui_password }}" }
+  changed_when: false
+  no_log: true
+
+- name: "CS — Grant DB permissions"
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c "
+      GRANT {{ centerui_admin_username }} TO {{ database_admin_user }};
+      GRANT {{ centerui_username }} TO {{ database_admin_user }};
+      GRANT CREATE, TEMPORARY, CONNECT ON DATABASE \"{{ cs_database_name }}\" TO {{ centerui_admin_username }};
+      GRANT TEMPORARY, CONNECT ON DATABASE \"{{ cs_database_name }}\" TO {{ centerui_username }};
+    "
+  changed_when: false
+  no_log: true
+
+- name: "CS — Install hstore extension"
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -d {{ cs_database_name }} -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+  changed_when: false
+  no_log: true
+
+- name: "CS — Create centerui schema and permissions"
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -d "{{ cs_database_name }}" -c "
+      CREATE SCHEMA IF NOT EXISTS centerui AUTHORIZATION {{ centerui_admin_username }};
+      GRANT ALL PRIVILEGES ON SCHEMA centerui TO {{ centerui_admin_username }};
+      GRANT USAGE ON SCHEMA centerui TO {{ centerui_username }};
+      REVOKE ALL ON SCHEMA public FROM PUBLIC;
+      GRANT USAGE ON SCHEMA public TO {{ centerui_admin_username }};
+      GRANT USAGE ON SCHEMA public TO {{ centerui_username }};
+      ALTER DEFAULT PRIVILEGES FOR ROLE {{ centerui_admin_username }} IN SCHEMA centerui
+        GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {{ centerui_username }};
+      ALTER DEFAULT PRIVILEGES FOR ROLE {{ centerui_admin_username }} IN SCHEMA centerui
+        GRANT USAGE, SELECT ON SEQUENCES TO {{ centerui_username }};
+      ALTER DEFAULT PRIVILEGES FOR ROLE {{ centerui_admin_username }} IN SCHEMA centerui
+        GRANT EXECUTE ON FUNCTIONS TO {{ centerui_username }};
+    "
+  changed_when: false
+  no_log: true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FASE CS-3: Configuração e instalação de pacotes
+# ──────────────────────────────────────────────────────────────────────────────
+- name: "CS — Create /etc/xroad.properties"
+  copy:
+    content: |
+      postgres.connection.password={{ database_admin_password }}
+      centerui.database.admin_user={{ centerui_admin_username }}
+      centerui.database.admin_password={{ centerui_admin_password }}
+    dest: /etc/xroad.properties
+    mode: '0600'
+  no_log: true
+
+- name: "CS — Ensure /etc/xroad directory"
+  file:
+    path: /etc/xroad
+    state: directory
+    owner: xroad
+    group: xroad
+    mode: '0751'
+
+- name: "CS — Create /etc/xroad/db.properties (Spring format)"
+  copy:
+    content: |
+      spring.datasource.url=jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/{{ cs_database_name }}
+      spring.datasource.username={{ centerui_username }}
+      spring.datasource.password={{ centerui_password }}
+      spring.datasource.hikari.data-source-properties.currentSchema=centerui,public
+    dest: /etc/xroad/db.properties
+    owner: xroad
+    group: xroad
+    mode: '0640'
+  no_log: true
+
+- name: "CS — Set debconf values"
+  debconf:
+    name: xroad-center
+    question: "{{ item.question }}"
+    vtype: string
+    value: "{{ item.value }}"
+  loop:
+    - { question: "xroad-common/username", value: "{{ _admin_user }}" }
+    - { question: "xroad-common/database-host", value: "{{ _database_host_full }}" }
+    - { question: "xroad-common/admin-subject", value: "{{ inventory_hostname }}" }
+    - { question: "xroad-common/admin-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
+    - { question: "xroad-common/service-subject", value: "{{ inventory_hostname }}" }
+    - { question: "xroad-common/service-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
+    - { question: "xroad-common/global-conf-subject", value: "/CN={{ inventory_hostname }}" }
+    - { question: "xroad-common/global-conf-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
+    - { question: "xroad-common/skip-cs-db-migrations", value: "false" }
+
+- name: "CS — Mask CS services before install"
+  shell: systemctl mask {{ item }} 2>/dev/null || true
+  loop:
+    - xroad-center
+    - xroad-signer
+    - xroad-confclient
+    - xroad-center-management-service
+    - xroad-center-registration-service
+  changed_when: false
+
+- name: "CS — Install xroad-database-remote"
+  apt:
+    name: xroad-database-remote
+    state: present
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: "CS — Install xroad-base"
+  apt:
+    name: xroad-base
+    state: present
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: "CS — Install xroad-centralserver"
+  apt:
+    name: "{{ xvia_cs_packages }}"
+    state: present
+    force: yes
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: "CS — Ensure all packages configured"
+  shell: dpkg --configure -a
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  changed_when: false
+
+- name: "CS — Unmask CS services"
+  shell: systemctl unmask {{ item }}
+  loop:
+    - xroad-center
+    - xroad-signer
+    - xroad-confclient
+    - xroad-center-management-service
+    - xroad-center-registration-service
+  changed_when: false
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FASE CS-4: Pós-instalação — reescrever configs, run migrations, start
+# ──────────────────────────────────────────────────────────────────────────────
+- name: "CS — Rewrite db.properties after install"
+  copy:
+    content: |
+      spring.datasource.url=jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/{{ cs_database_name }}
+      spring.datasource.username={{ centerui_username }}
+      spring.datasource.password={{ centerui_password }}
+      spring.datasource.hikari.data-source-properties.currentSchema=centerui,public
+    dest: /etc/xroad/db.properties
+    owner: xroad
+    group: xroad
+    mode: '0640'
+  no_log: true
+
+- name: "CS — Run database migrations"
+  shell: /usr/share/xroad/db/migrate.sh
+  register: _cs_migrate
+  changed_when: "'migrated' in _cs_migrate.stdout | default('')"
+  failed_when: _cs_migrate.rc != 0
+
+- name: "CS — Create PAM config"
+  copy:
+    content: |
+      #%PAM-1.0
+      @include common-auth
+      @include common-account
+      @include common-session
+    dest: /etc/pam.d/xroad
+    mode: '0644'
+
+- name: "CS — Add admin to xroad groups"
+  user:
+    name: "{{ _admin_user }}"
+    groups: "{{ item }}"
+    append: yes
+  loop:
+    - xroad-security-officer
+    - xroad-registration-officer
+    - xroad-service-administrator
+    - xroad-system-administrator
+    - xroad-securityserver-observer
+
+- name: "CS — Start Central Server services"
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  loop:
+    - xroad-signer
+    - xroad-confclient
+    - xroad-center
+
+- name: "CS — Wait for CS UI (port 4000)"
+  uri:
+    url: "https://localhost:4000"
+    validate_certs: no
+    status_code: [200, 302]
+  register: _cs_ui
+  until: _cs_ui.status is defined and _cs_ui.status in [200, 302]
+  retries: 30
+  delay: 10
+
+- name: "✅ Central Server instalado!"
+  debug:
+    msg: |
+      ══════════════════════════════════════════════════════════════
+       X-VIA Central Server instalado com sucesso!
+      ══════════════════════════════════════════════════════════════
+       URL:       https://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:4000
+       Usuário:   {{ _admin_user }}
+       Banco:     {{ _db_host }}:{{ _db_port }}/{{ cs_database_name }}
+      ══════════════════════════════════════════════════════════════

--- a/development/ansible/tasks/xvia_cs_install.yml
+++ b/development/ansible/tasks/xvia_cs_install.yml
@@ -117,17 +117,47 @@
   changed_when: false
   no_log: true
 
-- name: "CS — Ensure postgresql-contrib is installed on DB server"
+- name: "CS — Ensure postgresql-contrib is installed on DB server (on-premises)"
   apt:
     name: "postgresql-{{ xvia_pg_version | default('16') }}-contrib"
     state: present
     update_cache: yes
-  delegate_to: "{{ groups['db_servers'][0] }}"
+  delegate_to: "{{ groups['db_servers'][0] if (groups['db_servers'] | default([])) | length > 0 else inventory_hostname }}"
   become: true
   when:
     - _use_remote_db | bool
-    - groups['db_servers'] is defined
-    - groups['db_servers'] | length > 0
+    - not (db_is_managed | default(false) | bool)
+    - (groups['db_servers'] | default([])) | length > 0
+  ignore_errors: true
+  register: _contrib_install
+
+- name: "CS — AVISO: postgresql-contrib não pôde ser instalado automaticamente"
+  debug:
+    msg: >
+      ATENÇÃO: Não foi possível instalar postgresql-contrib no servidor de banco ({{ _db_host }}).
+      Instale manualmente no servidor de banco: sudo apt-get install -y postgresql-{{ xvia_pg_version | default('16') }}-contrib
+  when:
+    - _contrib_install is defined
+    - _contrib_install is failed
+
+- name: "CS — AVISO: banco gerenciado (RDS/Aurora) detectado"
+  debug:
+    msg: >
+      INFO: Banco gerenciado (RDS/Aurora) detectado — instalação de postgresql-contrib via SSH não é
+      necessária. A extensão hstore será criada via SQL (CREATE EXTENSION) diretamente.
+  when:
+    - _use_remote_db | bool
+    - db_is_managed | default(false) | bool
+
+- name: "CS — AVISO: db_servers vazio, não é possível instalar postgresql-contrib"
+  debug:
+    msg: >
+      ATENÇÃO: use_remote_db=true mas nenhum host em [db_servers] e db_is_managed=false.
+      Adicione o servidor de banco ao grupo [db_servers] no inventário ou defina db_is_managed=true para RDS/Aurora.
+  when:
+    - _use_remote_db | bool
+    - not (db_is_managed | default(false) | bool)
+    - (groups['db_servers'] | default([])) | length == 0
 
 - name: "CS — Install hstore extension"
   shell: >

--- a/development/ansible/tasks/xvia_cs_install.yml
+++ b/development/ansible/tasks/xvia_cs_install.yml
@@ -71,17 +71,22 @@
     centerui_password: "{{ centerui_password if centerui_password != '' else lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
     centerui_admin_password: "{{ centerui_admin_password if centerui_admin_password != '' else lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
 
-- name: "CS — Create centerui_production database"
+- name: "CS — Drop centerui_production if exists"
   shell: >
     PGPASSWORD='{{ database_admin_password }}'
     psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
-    -tc "SELECT 1 FROM pg_database WHERE datname='{{ cs_database_name }}'" | grep -q 1 ||
-    PGPASSWORD='{{ database_admin_password }}'
-    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
-    -c "CREATE DATABASE \"{{ cs_database_name }}\" ENCODING 'UTF8';
-        REVOKE ALL ON DATABASE \"{{ cs_database_name }}\" FROM PUBLIC;"
+    -c "DROP DATABASE IF EXISTS \"{{ cs_database_name }}\";"
   changed_when: false
   no_log: true
+  failed_when: false
+
+- name: "CS — Create centerui_production database"
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c "CREATE DATABASE \"{{ cs_database_name }}\" ENCODING 'UTF8';"
+    PGPASSWORD='{{ database_admin_password }}' psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c "REVOKE ALL ON DATABASE \"{{ cs_database_name }}\" FROM PUBLIC;"
+  changed_when: false
+  no_log: false
+
 
 - name: "CS — Create centerui roles"
   shell: |
@@ -183,23 +188,17 @@
   loop:
     - { question: "xroad-common/username", value: "{{ _admin_user }}" }
     - { question: "xroad-common/database-host", value: "{{ _database_host_full }}" }
-    - { question: "xroad-common/admin-subject", value: "{{ inventory_hostname }}" }
+    - { question: "xroad-common/admin-subject", value: "/CN={{ inventory_hostname }}" }
     - { question: "xroad-common/admin-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
-    - { question: "xroad-common/service-subject", value: "{{ inventory_hostname }}" }
+    - { question: "xroad-common/service-subject", value: "/CN={{ inventory_hostname }}" }
     - { question: "xroad-common/service-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
     - { question: "xroad-common/global-conf-subject", value: "/CN={{ inventory_hostname }}" }
     - { question: "xroad-common/global-conf-altsubject", value: "IP:{{ ansible_default_ipv4.address }},DNS:{{ inventory_hostname }}" }
     - { question: "xroad-common/skip-cs-db-migrations", value: "false" }
 
-- name: "CS — Mask CS services before install"
-  shell: systemctl mask {{ item }} 2>/dev/null || true
-  loop:
-    - xroad-center
-    - xroad-signer
-    - xroad-confclient
-    - xroad-center-management-service
-    - xroad-center-registration-service
-  changed_when: false
+# NOTE: Do NOT mask CS services before install.
+# The xroad-center postinst needs services unmasked to start them.
+# (Different from SS which can mask/unmask around install.)
 
 - name: "CS — Install xroad-database-remote"
   apt:
@@ -229,15 +228,6 @@
     DEBIAN_FRONTEND: noninteractive
   changed_when: false
 
-- name: "CS — Unmask CS services"
-  shell: systemctl unmask {{ item }}
-  loop:
-    - xroad-center
-    - xroad-signer
-    - xroad-confclient
-    - xroad-center-management-service
-    - xroad-center-registration-service
-  changed_when: false
 
 # ──────────────────────────────────────────────────────────────────────────────
 # FASE CS-4: Pós-instalação — reescrever configs, run migrations, start
@@ -279,9 +269,7 @@
   loop:
     - xroad-security-officer
     - xroad-registration-officer
-    - xroad-service-administrator
     - xroad-system-administrator
-    - xroad-securityserver-observer
 
 - name: "CS — Start Central Server services"
   service:

--- a/development/ansible/tasks/xvia_db_local.yml
+++ b/development/ansible/tasks/xvia_db_local.yml
@@ -1,0 +1,94 @@
+---
+# X-VIA: Configuração de banco de dados LOCAL (PostgreSQL na mesma VM)
+
+- name: "FASE 4 (local) — Install PostgreSQL {{ xvia_pg_version }}"
+  apt:
+    name:
+      - "postgresql-{{ xvia_pg_version }}"
+      - "postgresql-contrib-{{ xvia_pg_version }}"
+    state: present
+
+- name: Unmask local PostgreSQL
+  systemd:
+    name: postgresql
+    masked: no
+  failed_when: false
+
+- name: Ensure PostgreSQL is running
+  service:
+    name: postgresql
+    state: started
+    enabled: yes
+
+- name: Configure pg_hba.conf for local password auth
+  lineinfile:
+    path: "/etc/postgresql/{{ xvia_pg_version }}/main/pg_hba.conf"
+    insertafter: "^# IPv4 local connections"
+    line: "host    all             all             127.0.0.1/32            scram-sha-256"
+    state: present
+  notify: reload postgresql
+
+- name: Flush handlers (reload pg_hba before creating users)
+  meta: flush_handlers
+
+- name: Create local DB users
+  become_user: postgres
+  shell: |
+    psql -tc "SELECT 1 FROM pg_roles WHERE rolname='{{ item.name }}'" | grep -q 1 && \
+    psql -c "ALTER ROLE {{ item.name }} PASSWORD '{{ item.password }}';" || \
+    psql -c "CREATE ROLE {{ item.name }} LOGIN PASSWORD '{{ item.password }}';"
+  loop:
+    - { name: "serverconf", password: "{{ serverconf_password }}" }
+    - { name: "serverconf_admin", password: "{{ serverconf_password }}" }
+    - { name: "messagelog", password: "{{ messagelog_password }}" }
+    - { name: "messagelog_admin", password: "{{ messagelog_password }}" }
+    - { name: "opmonitor", password: "{{ opmonitor_password }}" }
+    - { name: "opmonitor_admin", password: "{{ opmonitor_password }}" }
+  changed_when: false
+  no_log: true
+
+- name: Create local databases
+  become_user: postgres
+  shell: |
+    psql -tc "SELECT 1 FROM pg_database WHERE datname='{{ item.db }}'" | grep -q 1 || \
+    psql -c "CREATE DATABASE \"{{ item.db }}\" OWNER {{ item.owner }} ENCODING 'UTF8';"
+  loop:
+    - { db: "serverconf", owner: "serverconf_admin" }
+    - { db: "messagelog", owner: "messagelog_admin" }
+    - { db: "op-monitor", owner: "opmonitor_admin" }
+  changed_when: false
+
+- name: Install hstore extension on serverconf
+  become_user: postgres
+  shell: psql -d serverconf -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+  changed_when: false
+
+- name: Create schemas and grant permissions (local)
+  become_user: postgres
+  shell: |
+    psql -d {{ item.db }} -c "
+      CREATE SCHEMA IF NOT EXISTS {{ item.schema }} AUTHORIZATION {{ item.admin }};
+      GRANT USAGE ON SCHEMA {{ item.schema }} TO {{ item.user }};
+      GRANT ALL ON SCHEMA {{ item.schema }} TO {{ item.admin }};
+      ALTER DEFAULT PRIVILEGES FOR ROLE {{ item.admin }} IN SCHEMA {{ item.schema }}
+        GRANT SELECT,INSERT,UPDATE,DELETE ON TABLES TO {{ item.user }};
+      ALTER DEFAULT PRIVILEGES FOR ROLE {{ item.admin }} IN SCHEMA {{ item.schema }}
+        GRANT USAGE,SELECT ON SEQUENCES TO {{ item.user }};
+    "
+  loop:
+    - { db: "serverconf", schema: "serverconf", admin: "serverconf_admin", user: "serverconf" }
+    - { db: "messagelog", schema: "messagelog", admin: "messagelog_admin", user: "messagelog" }
+    - { db: "op-monitor", schema: "opmonitor", admin: "opmonitor_admin", user: "opmonitor" }
+  changed_when: false
+
+- name: Grant connect on local databases
+  become_user: postgres
+  shell: |
+    psql -c "GRANT ALL ON DATABASE \"{{ item.db }}\" TO {{ item.admin }};"
+    psql -c "GRANT CONNECT ON DATABASE \"{{ item.db }}\" TO {{ item.user }};"
+    psql -d "{{ item.db }}" -c "GRANT ALL ON SCHEMA public TO {{ item.admin }};"
+  loop:
+    - { db: "serverconf", admin: "serverconf_admin", user: "serverconf" }
+    - { db: "messagelog", admin: "messagelog_admin", user: "messagelog" }
+    - { db: "op-monitor", admin: "opmonitor_admin", user: "opmonitor" }
+  changed_when: false

--- a/development/ansible/tasks/xvia_db_remote.yml
+++ b/development/ansible/tasks/xvia_db_remote.yml
@@ -1,0 +1,130 @@
+---
+# X-VIA: Configuração de banco de dados REMOTO (PostgreSQL RDS)
+
+- name: "FASE 4 (remoto) — Remove xroad-database-local if present"
+  apt:
+    name: xroad-database-local
+    state: absent
+  failed_when: false
+
+- name: Mask local PostgreSQL
+  systemd:
+    name: postgresql
+    masked: yes
+  when: mask_local_postgresql | default(true) | bool
+  failed_when: false
+
+- name: Validate remote database connection
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -c 'SELECT version()' 2>&1
+  register: _db_test
+  failed_when: false
+  no_log: true
+
+- name: Fail if remote database is unreachable
+  fail:
+    msg: |
+      Não foi possível conectar ao banco remoto!
+      Host: {{ _db_host }}:{{ _db_port }}
+      Usuário: {{ database_admin_user }}
+      Erro: {{ _db_test.stdout | default('') }} {{ _db_test.stderr | default('') }}
+      
+      Verifique:
+        - Security Group permite acesso na porta {{ _db_port }}
+        - Endpoint RDS está correto
+        - Senha do admin está correta
+  when: _db_test.rc != 0
+
+- name: Create remote databases
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -tc "SELECT 1 FROM pg_database WHERE datname='{{ item }}'" | grep -q 1 ||
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -c "CREATE DATABASE \"{{ item }}\" ENCODING 'UTF8'"
+  loop:
+    - serverconf
+    - messagelog
+    - op-monitor
+  run_once: true
+  changed_when: false
+  no_log: true
+
+- name: Create remote DB users
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c "
+    DO \$\$ BEGIN
+      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='{{ item.name }}') THEN
+        CREATE ROLE {{ item.name }} LOGIN PASSWORD '{{ item.password }}';
+      ELSE
+        ALTER ROLE {{ item.name }} PASSWORD '{{ item.password }}';
+      END IF;
+    END \$\$;"
+  loop:
+    - { name: "serverconf", password: "{{ serverconf_password }}" }
+    - { name: "serverconf_admin", password: "{{ serverconf_password }}" }
+    - { name: "messagelog", password: "{{ messagelog_password }}" }
+    - { name: "messagelog_admin", password: "{{ messagelog_password }}" }
+    - { name: "opmonitor", password: "{{ opmonitor_password }}" }
+    - { name: "opmonitor_admin", password: "{{ opmonitor_password }}" }
+  run_once: true
+  changed_when: false
+  no_log: true
+
+- name: Grant remote DB permissions
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -c \
+    "GRANT ALL ON DATABASE \"{{ item.db }}\" TO {{ item.admin }};
+     GRANT CONNECT ON DATABASE \"{{ item.db }}\" TO {{ item.user }};"
+
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -d "{{ item.db }}" -c \
+    "GRANT ALL ON SCHEMA public TO {{ item.admin }};
+     GRANT USAGE ON SCHEMA public TO {{ item.user }};"
+  loop:
+    - { db: "serverconf", admin: "serverconf_admin", user: "serverconf" }
+    - { db: "messagelog", admin: "messagelog_admin", user: "messagelog" }
+    - { db: "op-monitor", admin: "opmonitor_admin", user: "opmonitor" }
+  run_once: true
+  changed_when: false
+  no_log: true
+
+- name: Install hstore on remote serverconf
+  shell: >
+    PGPASSWORD='{{ database_admin_password }}'
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }}
+    -d serverconf -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+  run_once: true
+  changed_when: false
+  no_log: true
+
+- name: Create remote schemas and grant permissions
+  shell: |
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -d "{{ item.db }}" -c \
+    "GRANT {{ item.admin }} TO {{ database_admin_user }};"
+
+    PGPASSWORD='{{ database_admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ database_admin_user }} -d "{{ item.db }}" -c \
+    "CREATE SCHEMA IF NOT EXISTS {{ item.schema }} AUTHORIZATION {{ item.admin }};
+     GRANT USAGE ON SCHEMA {{ item.schema }} TO {{ item.user }};
+     GRANT ALL ON SCHEMA {{ item.schema }} TO {{ item.admin }};"
+
+    PGPASSWORD='{{ item.admin_password }}' \
+    psql -h {{ _db_host }} -p {{ _db_port }} -U {{ item.admin }} -d "{{ item.db }}" -c \
+    "ALTER DEFAULT PRIVILEGES IN SCHEMA {{ item.schema }}
+       GRANT SELECT,INSERT,UPDATE,DELETE ON TABLES TO {{ item.user }};
+     ALTER DEFAULT PRIVILEGES IN SCHEMA {{ item.schema }}
+       GRANT USAGE,SELECT ON SEQUENCES TO {{ item.user }};"
+  loop:
+    - { db: "serverconf", schema: "serverconf", admin: "serverconf_admin", user: "serverconf", admin_password: "{{ serverconf_password }}" }
+    - { db: "messagelog", schema: "messagelog", admin: "messagelog_admin", user: "messagelog", admin_password: "{{ messagelog_password }}" }
+    - { db: "op-monitor", schema: "opmonitor", admin: "opmonitor_admin", user: "opmonitor", admin_password: "{{ opmonitor_password }}" }
+  run_once: true
+  changed_when: false
+  no_log: true

--- a/development/ansible/tasks/xvia_postinstall.yml
+++ b/development/ansible/tasks/xvia_postinstall.yml
@@ -182,3 +182,35 @@
     daemon_reload: yes
     enabled: yes
   when: (autologin_pin | default('')) != ''
+
+# --- Mail notification stub (silencia aviso de configuração incompleta) ---
+- name: Create mail.yml stub (disables mail notifications)
+  copy:
+    content: |
+      host: ""
+      port: 0
+      username: ""
+      password: ""
+      use-ssl-tls: false
+      contacts: {}
+    dest: /etc/xroad/conf.d/mail.yml
+    owner: xroad
+    group: xroad
+    mode: '0640'
+  when: xvia_mail_config | default({}) | length == 0
+
+- name: Create mail.yml with custom config
+  copy:
+    content: |
+      host: "{{ xvia_mail_config.host }}"
+      port: {{ xvia_mail_config.port | default(587) }}
+      username: "{{ xvia_mail_config.username | default('') }}"
+      password: "{{ xvia_mail_config.password | default('') }}"
+      use-ssl-tls: {{ xvia_mail_config.use_ssl_tls | default(false) | lower }}
+      contacts: {{ xvia_mail_config.contacts | default({}) | to_nice_yaml | indent(2) }}
+    dest: /etc/xroad/conf.d/mail.yml
+    owner: xroad
+    group: xroad
+    mode: '0640'
+  when: xvia_mail_config | default({}) | length > 0
+  no_log: true

--- a/development/ansible/tasks/xvia_postinstall.yml
+++ b/development/ansible/tasks/xvia_postinstall.yml
@@ -113,9 +113,9 @@
 # --- Memória do proxy ---
 - name: Configure proxy memory
   lineinfile:
-    path: /etc/xroad/services/proxy.conf
+    path: /etc/xroad/services/local.conf
     regexp: '^XROAD_PROXY_PARAMS='
-    line: 'XROAD_PROXY_PARAMS=" -Xms{{ xvia_proxy_memory }}m -Xmx{{ xvia_proxy_memory }}m -XX:MaxMetaspaceSize=140m -XX:+UseG1GC -Dfile.encoding=UTF-8 -Xshare:auto -Djdk.tls.ephemeralDHKeySize=2048 $XROAD_PROXY_PARAMS"'
+    line: 'XROAD_PROXY_PARAMS="$XROAD_PROXY_PARAMS -Xms{{ xvia_proxy_memory }}m -Xmx{{ xvia_proxy_memory }}m -XX:MaxMetaspaceSize=140m"'
     create: yes
   when: xvia_proxy_memory != "d"
 

--- a/development/ansible/tasks/xvia_postinstall.yml
+++ b/development/ansible/tasks/xvia_postinstall.yml
@@ -1,0 +1,184 @@
+---
+# X-VIA: Pós-instalação — Migrations Liquibase, PAM, grupos, autologin
+
+# Reescrever db.properties (o post-install do pacote pode sobrescrever)
+- name: "FASE 7 — Ensure db.properties after install"
+  template:
+    src: templates/xvia_db.properties.j2
+    dest: /etc/xroad/db.properties
+    owner: xroad
+    group: xroad
+    mode: '0640'
+    force: yes
+
+# --- Liquibase Migrations ---
+- name: Wait for Liquibase files
+  wait_for:
+    path: /usr/share/xroad/db/serverconf-changelog.xml
+    timeout: 30
+
+- name: Run Liquibase migration - serverconf
+  shell: |
+    cd /usr/share/xroad/db
+    /usr/share/xroad/db/liquibase.sh \
+      --classpath=/usr/share/xroad/jlib/postgresql.jar \
+      --url="jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/serverconf" \
+      --changeLogFile=serverconf-changelog.xml \
+      --password={{ serverconf_password }} \
+      --username=serverconf_admin \
+      --defaultSchemaName=serverconf \
+      --contexts=admin \
+      update \
+      -Ddb_schema=serverconf \
+      -Ddb_user=serverconf
+  register: _liquibase_serverconf
+  changed_when: "'Running Changeset' in _liquibase_serverconf.stdout"
+
+- name: Run Liquibase migration - messagelog
+  shell: |
+    cd /usr/share/xroad/db
+    /usr/share/xroad/db/liquibase.sh \
+      --classpath=/usr/share/xroad/jlib/postgresql.jar \
+      --url="jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/messagelog" \
+      --changeLogFile=messagelog-changelog.xml \
+      --password={{ messagelog_password }} \
+      --username=messagelog_admin \
+      --defaultSchemaName=messagelog \
+      --contexts=admin \
+      update \
+      -Ddb_schema=messagelog \
+      -Ddb_user=messagelog
+  register: _liquibase_messagelog
+  changed_when: "'Running Changeset' in _liquibase_messagelog.stdout"
+
+- name: Run Liquibase migration - op-monitor
+  shell: |
+    cd /usr/share/xroad/db
+    /usr/share/xroad/db/liquibase.sh \
+      --classpath=/usr/share/xroad/jlib/postgresql.jar \
+      --url="jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/op-monitor" \
+      --changeLogFile=op-monitor-changelog.xml \
+      --password={{ opmonitor_password }} \
+      --username=opmonitor_admin \
+      --defaultSchemaName=opmonitor \
+      --contexts=admin \
+      update \
+      -Ddb_schema=opmonitor \
+      -Ddb_user=opmonitor
+  register: _liquibase_opmonitor
+  changed_when: "'Running Changeset' in _liquibase_opmonitor.stdout"
+
+# --- PAM ---
+- name: Create /etc/pam.d/xroad
+  copy:
+    content: |
+      #%PAM-1.0
+      @include common-auth
+      @include common-account
+      @include common-session
+    dest: /etc/pam.d/xroad
+    mode: '0644'
+
+# --- Grupos do admin ---
+- name: Add admin to xroad groups
+  user:
+    name: "{{ _admin_user }}"
+    groups: "{{ item }}"
+    append: yes
+  loop:
+    - xroad-security-officer
+    - xroad-registration-officer
+    - xroad-service-administrator
+    - xroad-system-administrator
+    - xroad-securityserver-observer
+
+# --- Messagelog toggle ---
+- name: Disable messagelog
+  copy:
+    content: |
+      [message-log]
+      enabled=false
+    dest: /etc/xroad/conf.d/messagelog.ini
+    owner: xroad
+    group: xroad
+    mode: '0640'
+  when: not (xvia_enable_messagelog | default(true) | bool)
+
+- name: Enable messagelog (remove override)
+  file:
+    path: /etc/xroad/conf.d/messagelog.ini
+    state: absent
+  when: xvia_enable_messagelog | default(true) | bool
+
+# --- Memória do proxy ---
+- name: Configure proxy memory
+  lineinfile:
+    path: /etc/xroad/services/proxy.conf
+    regexp: '^XROAD_PROXY_PARAMS='
+    line: 'XROAD_PROXY_PARAMS=" -Xms{{ xvia_proxy_memory }}m -Xmx{{ xvia_proxy_memory }}m -XX:MaxMetaspaceSize=140m -XX:+UseG1GC -Dfile.encoding=UTF-8 -Xshare:auto -Djdk.tls.ephemeralDHKeySize=2048 $XROAD_PROXY_PARAMS"'
+    create: yes
+  when: xvia_proxy_memory != "d"
+
+# --- Autologin do token (opcional) ---
+- name: Create autologin directory
+  file:
+    path: /usr/share/xroad/autologin
+    state: directory
+    owner: xroad
+    group: xroad
+    mode: '0755'
+  when: (autologin_pin | default('')) != ''
+
+- name: Create autologin retry script
+  copy:
+    content: |
+      #!/bin/bash
+      PIN=$(cat /etc/xroad/autologin)
+      for i in $(seq 1 30); do
+          echo "Attempting to log in to token 0"
+          echo $PIN | /usr/share/xroad/bin/signer-console login-token 0 && break
+          sleep 5
+      done
+    dest: /usr/share/xroad/autologin/xroad-autologin-retry.sh
+    owner: xroad
+    group: xroad
+    mode: '0755'
+  when: (autologin_pin | default('')) != ''
+
+- name: Create autologin PIN file
+  copy:
+    content: "{{ autologin_pin }}"
+    dest: /etc/xroad/autologin
+    owner: xroad
+    group: xroad
+    mode: '0600'
+  when: (autologin_pin | default('')) != ''
+  no_log: true
+
+- name: Create xroad-autologin systemd unit
+  copy:
+    content: |
+      [Unit]
+      Description=X-Road Automatic Token Login
+      After=xroad-signer.service
+      Requires=xroad-signer.service
+
+      [Service]
+      Type=oneshot
+      User=xroad
+      Group=xroad
+      ExecStart=/usr/share/xroad/autologin/xroad-autologin-retry.sh
+      RemainAfterExit=no
+
+      [Install]
+      WantedBy=multi-user.target
+    dest: /etc/systemd/system/xroad-autologin.service
+    mode: '0644'
+  when: (autologin_pin | default('')) != ''
+
+- name: Enable xroad-autologin service
+  systemd:
+    name: xroad-autologin
+    daemon_reload: yes
+    enabled: yes
+  when: (autologin_pin | default('')) != ''

--- a/development/ansible/tasks/xvia_postinstall.yml
+++ b/development/ansible/tasks/xvia_postinstall.yml
@@ -183,16 +183,17 @@
     enabled: yes
   when: (autologin_pin | default('')) != ''
 
-# --- Mail notification stub (silencia aviso de configuração incompleta) ---
+# --- Mail notification stub (silencia aviso de configuração incompleta na UI) ---
 - name: Create mail.yml stub (disables mail notifications)
   copy:
     content: |
-      host: ""
-      port: 0
+      host: localhost
+      port: 25
       username: ""
       password: ""
       use-ssl-tls: false
-      contacts: {}
+      contacts:
+        '{{ xvia_instance_id | default("XVIA") }}:{{ xvia_member_class | default("GOV") }}:{{ xvia_member_code | default("XVIA") }}': noreply@localhost
     dest: /etc/xroad/conf.d/mail.yml
     owner: xroad
     group: xroad
@@ -214,3 +215,8 @@
     mode: '0640'
   when: xvia_mail_config | default({}) | length > 0
   no_log: true
+
+- name: Restart xroad-proxy-ui-api after mail config
+  service:
+    name: xroad-proxy-ui-api
+    state: restarted

--- a/development/ansible/tasks/xvia_validate.yml
+++ b/development/ansible/tasks/xvia_validate.yml
@@ -1,0 +1,61 @@
+---
+# X-VIA: Validação da instalação — iniciar serviços e testar UI
+
+- name: "FASE 8 — Start and enable xroad services"
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  loop:
+    - xroad-signer
+    - xroad-proxy
+    - xroad-confclient
+    - xroad-proxy-ui-api
+
+- name: Start xroad-opmonitor
+  service:
+    name: xroad-opmonitor
+    state: restarted
+    enabled: yes
+  when: xvia_enable_opmonitoring | default(true) | bool
+
+- name: Wait for UI to be ready (port 4000)
+  uri:
+    url: "https://localhost:4000"
+    validate_certs: no
+    status_code: [200, 302]
+  register: _ui_result
+  until: _ui_result.status is defined and _ui_result.status in [200, 302]
+  retries: 30
+  delay: 10
+
+- name: Validate admin login
+  uri:
+    url: "https://localhost:4000/login"
+    method: POST
+    validate_certs: no
+    body_format: form-urlencoded
+    body:
+      username: "{{ _admin_user }}"
+      password: "{{ _admin_password }}"
+    headers:
+      X-XSRF-TOKEN: "validate"
+      Cookie: "XSRF-TOKEN=validate"
+    status_code: [200]
+  register: _login_test
+  retries: 3
+  delay: 5
+  no_log: true
+
+- name: "✅ Installation complete!"
+  debug:
+    msg: |
+      ══════════════════════════════════════════════════════════════
+       X-VIA Security Server instalado com sucesso!
+      ══════════════════════════════════════════════════════════════
+       URL:       https://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:4000
+       Usuário:   {{ _admin_user }}
+       Banco:     {{ _database_host_full }} ({{ 'REMOTO/RDS' if _use_remote_db else 'LOCAL' }})
+       Messagelog: {{ 'habilitado' if xvia_enable_messagelog | default(true) | bool else 'desabilitado' }}
+       Proxy Mem: {{ xvia_proxy_memory }}MB
+      ══════════════════════════════════════════════════════════════

--- a/development/ansible/tasks/xvia_validate.yml
+++ b/development/ansible/tasks/xvia_validate.yml
@@ -55,7 +55,7 @@
       ══════════════════════════════════════════════════════════════
        URL:       https://{{ ansible_default_ipv4.address | default(inventory_hostname) }}:4000
        Usuário:   {{ _admin_user }}
-       Banco:     {{ _database_host_full }} ({{ 'REMOTO/RDS' if _use_remote_db else 'LOCAL' }})
+       Banco:     {{ _database_host_full }} ({{ 'RDS/Aurora' if (db_is_managed | default(false) | bool) else ('REMOTO on-premises' if _use_remote_db else 'LOCAL') }})
        Messagelog: {{ 'habilitado' if xvia_enable_messagelog | default(true) | bool else 'desabilitado' }}
        Proxy Mem: {{ xvia_proxy_memory }}MB
       ══════════════════════════════════════════════════════════════

--- a/development/ansible/templates/xvia_db.properties.j2
+++ b/development/ansible/templates/xvia_db.properties.j2
@@ -1,0 +1,21 @@
+serverconf.hibernate.jdbc.use_streams_for_binary = true
+serverconf.hibernate.dialect = ee.ria.xroad.common.db.CustomPostgreSQLDialect
+serverconf.hibernate.connection.driver_class = org.postgresql.Driver
+serverconf.hibernate.connection.url = jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/serverconf
+serverconf.hibernate.hikari.dataSource.currentSchema = serverconf,public
+serverconf.hibernate.connection.username = {{ serverconf_username }}
+serverconf.hibernate.connection.password = {{ serverconf_password }}
+
+messagelog.hibernate.jdbc.use_streams_for_binary = true
+messagelog.hibernate.connection.driver_class = org.postgresql.Driver
+messagelog.hibernate.connection.url = jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/messagelog
+messagelog.hibernate.hikari.dataSource.currentSchema = messagelog,public
+messagelog.hibernate.connection.username = {{ messagelog_username }}
+messagelog.hibernate.connection.password = {{ messagelog_password }}
+
+op-monitor.hibernate.jdbc.use_streams_for_binary = true
+op-monitor.hibernate.connection.driver_class = org.postgresql.Driver
+op-monitor.hibernate.connection.url = jdbc:postgresql://{{ _db_host }}:{{ _db_port }}/op-monitor
+op-monitor.hibernate.hikari.dataSource.currentSchema = opmonitor,public
+op-monitor.hibernate.connection.username = {{ opmonitor_username }}
+op-monitor.hibernate.connection.password = {{ opmonitor_password }}

--- a/development/ansible/vars_files/xvia_cdn.yml
+++ b/development/ansible/vars_files/xvia_cdn.yml
@@ -1,0 +1,66 @@
+---
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Origem dos pacotes .deb
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Modos suportados:
+#   cdn    → Download via CloudFront (requer internet)
+#   s3     → Download direto do S3 (requer AWS CLI + credenciais)
+#   local  → Pacotes já copiados manualmente no servidor (on-premises sem internet)
+#
+# Para ambientes ON-PREMISES SEM INTERNET:
+#   1. Copie o tarball para o servidor antes de rodar o playbook:
+#      scp xroad-7.8.0-ubuntu24.04.tar.gz ubuntu@servidor:/opt/xvia-packages/
+#   2. Defina:
+#      xvia_package_source: "local"
+#      xvia_local_tarball_path: "/opt/xvia-packages/xroad-7.8.0-ubuntu24.04.tar.gz"
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Modo de obtenção dos pacotes: "cdn", "s3", ou "local"
+xvia_package_source: "cdn"
+
+# ─── CDN (CloudFront) ─────────────────────────────────────────────────────────
+xvia_cdn_base_url: "https://d35jgvswdswkzm.cloudfront.net"
+
+# ─── S3 (download direto) ────────────────────────────────────────────────────
+xvia_s3_bucket: "xvia-packages"
+xvia_s3_region: "sa-east-1"
+xvia_s3_profile: "demo"  # Profile AWS CLI (deixe vazio para usar default/instance role)
+
+# ─── Versão e distribuição ────────────────────────────────────────────────────
+xvia_version: "7.8.0"
+xvia_ubuntu_version: "ubuntu24.04"
+
+# ─── URLs derivadas (CDN) ─────────────────────────────────────────────────────
+xvia_ss_tarball_url: "{{ xvia_cdn_base_url }}/{{ xvia_ubuntu_version }}/xroad-{{ xvia_version }}-{{ xvia_ubuntu_version }}.tar.gz"
+xvia_cs_tarball_url: "{{ xvia_cdn_base_url }}/central-server/{{ xvia_ubuntu_version }}/xroad-{{ xvia_version }}-{{ xvia_ubuntu_version }}.tar.gz"
+
+# ─── Paths S3 ─────────────────────────────────────────────────────────────────
+xvia_s3_ss_prefix: "{{ xvia_ubuntu_version }}/"
+xvia_s3_cs_prefix: "central-server/{{ xvia_ubuntu_version }}/"
+
+# ─── Local (pacotes já no servidor) ──────────────────────────────────────────
+xvia_local_tarball_path: "/opt/xvia-packages/xroad-{{ xvia_version }}-{{ xvia_ubuntu_version }}.tar.gz"
+xvia_local_cs_debs_path: "/opt/xvia-packages/central-server"
+
+# ─── Diretórios de trabalho ──────────────────────────────────────────────────
+xvia_debs_dir: "/opt/xvia-packages/{{ xvia_ubuntu_version }}"
+xvia_cs_debs_dir: "/opt/xvia-packages/central-server/{{ xvia_ubuntu_version }}"
+xvia_apt_repo_dir: "/xroad"
+
+# ─── Pacotes a instalar ──────────────────────────────────────────────────────
+xvia_ss_packages:
+  - xroad-securityserver
+
+xvia_cs_packages:
+  - xroad-centralserver
+
+# ─── Configurações de instalação ─────────────────────────────────────────────
+# Memória do proxy (MB) — "d" = default do pacote
+xvia_proxy_memory: "1024"
+
+# Habilitar messagelog no Security Server
+xvia_enable_messagelog: true
+
+# Habilitar opmonitoring no Security Server
+xvia_enable_opmonitoring: true

--- a/development/ansible/vars_files/xvia_database.yml
+++ b/development/ansible/vars_files/xvia_database.yml
@@ -1,0 +1,68 @@
+---
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Configuração de Banco de Dados PostgreSQL
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Suporta: RDS AWS, PostgreSQL on-premises, PostgreSQL local na mesma VM
+#
+# Para banco REMOTO (on-premises ou RDS):
+#   - use_remote_db: true
+#   - database_host: IP ou hostname do banco:porta
+#   - database_admin_user: usuário com permissão de CREATE DATABASE/ROLE
+#   - database_admin_password: senha do admin
+#
+# Para banco LOCAL (instalado na mesma VM):
+#   - use_remote_db: false
+#
+# SENHAS EM PRODUÇÃO: use Ansible Vault!
+#   ansible-vault encrypt_string 'minha-senha' --name 'database_admin_password'
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Tipo de banco (true = remoto, false = local na mesma VM)
+use_remote_db: true
+
+# ─── Conexão com o PostgreSQL ─────────────────────────────────────────────────
+# Formato: host:porta
+# Exemplos:
+#   - RDS:         postgres-rds.cgj2yoomuxp0.us-east-1.rds.amazonaws.com:5432
+#   - On-premises: 192.168.1.50:5432
+#   - Local:       127.0.0.1:5432
+database_host: "192.168.1.50:5432"
+
+# Usuário admin do PostgreSQL (precisa de CREATE DATABASE, CREATE ROLE)
+# Em RDS: geralmente 'postgres' com role 'rds_superuser'
+# Em on-premises: qualquer superuser ou user com CREATE DB/ROLE
+database_admin_user: "postgres"
+
+# Senha do admin do banco (OBRIGATÓRIO para remoto)
+database_admin_password: ""
+
+# Versão do PostgreSQL no servidor remoto (para instalar client compatível)
+xvia_pg_version: "16"
+
+# Mascarar PostgreSQL local quando usando remoto (evita conflito de porta)
+mask_local_postgresql: true
+
+# ─── Security Server: credenciais dos bancos ──────────────────────────────────
+# O cliente pode definir seus próprios usuários/senhas aqui
+serverconf_username: "serverconf"
+serverconf_password: "serverconf"
+serverconf_admin_username: "serverconf_admin"
+
+messagelog_username: "messagelog"
+messagelog_password: "messagelog"
+messagelog_admin_username: "messagelog_admin"
+
+opmonitor_username: "opmonitor"
+opmonitor_password: "opmonitor"
+opmonitor_admin_username: "opmonitor_admin"
+
+# ─── Central Server: credenciais do banco ─────────────────────────────────────
+# Nome do banco do Central Server
+cs_database_name: "centerui_production"
+
+# Usuários do Central Server
+centerui_username: "centerui"
+centerui_password: ""  # Gerada automaticamente se vazia
+centerui_admin_username: "centerui_admin"
+centerui_admin_password: ""  # Gerada automaticamente se vazia

--- a/development/ansible/vars_files/xvia_database.yml
+++ b/development/ansible/vars_files/xvia_database.yml
@@ -21,6 +21,11 @@
 # Tipo de banco (true = remoto, false = local na mesma VM)
 use_remote_db: true
 
+# Banco gerenciado (RDS/Aurora)?
+# true  = banco gerenciado (AWS RDS, Aurora) — SEM acesso SSH ao servidor de banco
+# false = banco on-premises — COM acesso SSH (permite instalar pacotes via Ansible)
+db_is_managed: false
+
 # ─── Conexão com o PostgreSQL ─────────────────────────────────────────────────
 # Formato: host:porta
 # Exemplos:

--- a/development/ansible/xvia_install.yml
+++ b/development/ansible/xvia_install.yml
@@ -120,6 +120,12 @@
         fail_msg: "database_admin_password é obrigatório para banco remoto"
       when: _use_remote_db
 
+    - name: "CS — Remove stale local repo config (pre-install cleanup)"
+      file:
+        path: /etc/apt/sources.list.d/xvia-local.list
+        state: absent
+      changed_when: false
+
     - name: "CS — Install prerequisites"
       apt:
         name:
@@ -226,6 +232,12 @@
     # ──────────────────────────────────────────────────────────────────────────
     # FASE 1: Pré-requisitos
     # ──────────────────────────────────────────────────────────────────────────
+    - name: "SS — Remove stale local repo config (pre-install cleanup)"
+      file:
+        path: /etc/apt/sources.list.d/xvia-local.list
+        state: absent
+      changed_when: false
+
     - name: "SS — Install prerequisites"
       apt:
         name:

--- a/development/ansible/xvia_install.yml
+++ b/development/ansible/xvia_install.yml
@@ -136,12 +136,26 @@
           - curl
           - locales
           - software-properties-common
+          - dialog
+          - ca-certificates
+          - gnupg2
+          - rsyslog
+          - openjdk-21-jre-headless
+          - rlwrap
+          - ca-certificates-java
+          - crudini
+          - lsb-release
+          - net-tools
+          - expect
           - dpkg-dev
           - apt-transport-https
           - postgresql-common
-          - crudini
+          - postgresql
+          - postgresql-contrib
         state: present
         update_cache: yes
+      environment:
+        DEBIAN_FRONTEND: noninteractive
 
     - name: Configure PostgreSQL PGDG apt repository
       command: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
@@ -251,11 +265,26 @@
           - curl
           - locales
           - software-properties-common
+          - dialog
+          - ca-certificates
+          - gnupg2
+          - rsyslog
+          - openjdk-21-jre-headless
+          - rlwrap
+          - ca-certificates-java
+          - crudini
+          - lsb-release
+          - net-tools
+          - expect
           - dpkg-dev
           - apt-transport-https
           - postgresql-common
+          - postgresql
+          - postgresql-contrib
         state: present
         update_cache: yes
+      environment:
+        DEBIAN_FRONTEND: noninteractive
 
     - name: Configure PostgreSQL PGDG apt repository
       command: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y

--- a/development/ansible/xvia_install.yml
+++ b/development/ansible/xvia_install.yml
@@ -120,10 +120,13 @@
         fail_msg: "database_admin_password é obrigatório para banco remoto"
       when: _use_remote_db
 
-    - name: "CS — Remove stale local repo config (pre-install cleanup)"
-      file:
-        path: /etc/apt/sources.list.d/xvia-local.list
-        state: absent
+    - name: "CS — Remove ALL stale local xroad repo configs"
+      shell: |
+        rm -f /etc/apt/sources.list.d/xvia-local*.list
+        rm -f /etc/apt/sources.list.d/xroad*.list
+        grep -rl 'file:/xroad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f
+        grep -rl 'file:///xroad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f
+        sed -i '/file:.*\/xroad/d' /etc/apt/sources.list 2>/dev/null || true
       changed_when: false
 
     - name: "CS — Install prerequisites"
@@ -232,10 +235,13 @@
     # ──────────────────────────────────────────────────────────────────────────
     # FASE 1: Pré-requisitos
     # ──────────────────────────────────────────────────────────────────────────
-    - name: "SS — Remove stale local repo config (pre-install cleanup)"
-      file:
-        path: /etc/apt/sources.list.d/xvia-local.list
-        state: absent
+    - name: "SS — Remove ALL stale local xroad repo configs"
+      shell: |
+        rm -f /etc/apt/sources.list.d/xvia-local*.list
+        rm -f /etc/apt/sources.list.d/xroad*.list
+        grep -rl 'file:/xroad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f
+        grep -rl 'file:///xroad' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r rm -f
+        sed -i '/file:.*\/xroad/d' /etc/apt/sources.list 2>/dev/null || true
       changed_when: false
 
     - name: "SS — Install prerequisites"

--- a/development/ansible/xvia_install.yml
+++ b/development/ansible/xvia_install.yml
@@ -1,0 +1,493 @@
+---
+# ═══════════════════════════════════════════════════════════════════════════════
+# X-VIA: Playbook completo para instalação on-premises
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Instala todos os componentes X-Road X-VIA 7.8.0:
+#   - Central Server (cs_servers)
+#   - Security Server (ss_servers)
+#   - CA Server - OCSP/TSA (ca_servers)
+#
+# REQUISITOS:
+#   - Ubuntu 22.04 ou 24.04 (amd64)
+#   - Mínimo 4GB RAM, 2 vCPUs por servidor
+#   - PostgreSQL on-premises acessível (ou banco local por VM)
+#   - Portas: 4000(UI), 443, 5500, 5577, 8080(CA)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# EXEMPLOS DE USO:
+#
+# 1) INSTALAÇÃO COMPLETA (todos os componentes):
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=SenhaAdmin" \
+#      -e "database_admin_password=SenhaBanco"
+#
+# 2) APENAS CENTRAL SERVER:
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=SenhaAdmin" \
+#      -e "database_admin_password=SenhaBanco" \
+#      --tags cs
+#
+# 3) APENAS SECURITY SERVER:
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=SenhaAdmin" \
+#      -e "database_admin_password=SenhaBanco" \
+#      --tags ss
+#
+# 4) APENAS CA:
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      --tags ca
+#
+# 5) COM USUÁRIOS/SENHAS CUSTOMIZADOS:
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=MinhaSenh4" \
+#      -e "xroad_ui_user=meu-admin" \
+#      -e "database_admin_password=DBSenh4" \
+#      -e "database_admin_user=dba_cliente" \
+#      -e "serverconf_password=SenhaServerconf" \
+#      -e "messagelog_password=SenhaMsglog" \
+#      -e "opmonitor_password=SenhaOpmon" \
+#      -e "centerui_password=SenhaCenterUI" \
+#      -e "centerui_admin_password=SenhaCenterAdmin"
+#
+# 6) BANCO LOCAL (sem PostgreSQL externo):
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=SenhaAdmin" \
+#      -e "use_remote_db=false"
+#
+# 7) PACOTES LOCAIS (sem internet):
+#    ansible-playbook -i hosts/xvia_onpremises.txt xvia_install.yml \
+#      -e "admin_password=SenhaAdmin" \
+#      -e "database_admin_password=SenhaBanco" \
+#      -e "xvia_package_source=local"
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PLAY 1: CA Server (deve ser instalado primeiro — emite certificados)
+# ══════════════════════════════════════════════════════════════════════════════
+- name: "X-VIA: Install CA Server"
+  hosts: ca_servers
+  become: true
+  become_user: root
+  tags: [ca]
+
+  vars_files:
+    - vars_files/xvia_cdn.yml
+
+  vars:
+    xvia_ca_organization: "{{ ca_organization | default('X-VIA CA') }}"
+    xvia_ca_cn: "{{ ca_cn | default('X-VIA Test CA') }}"
+    xvia_ca_ocsp_organization: "{{ ca_ocsp_organization | default(xvia_ca_organization) }}"
+    xvia_ca_ocsp_cn: "{{ ca_ocsp_cn | default('X-VIA Test OCSP') }}"
+    xvia_ca_tsa_organization: "{{ ca_tsa_organization | default(xvia_ca_organization) }}"
+    xvia_ca_tsa_cn: "{{ ca_tsa_cn | default('X-VIA Test TSA') }}"
+
+  tasks:
+    - include_tasks: tasks/xvia_ca_install.yml
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PLAY 2: Central Server
+# ══════════════════════════════════════════════════════════════════════════════
+- name: "X-VIA: Install Central Server"
+  hosts: cs_servers
+  become: true
+  become_user: root
+  tags: [cs]
+
+  vars_files:
+    - vars_files/xvia_cdn.yml
+    - vars_files/xvia_database.yml
+
+  vars:
+    _use_remote_db: "{{ use_remote_db | default(true) | bool }}"
+    _db_host: "{{ database_host.split(':')[0] if _use_remote_db else '127.0.0.1' }}"
+    _db_port: "{{ database_host.split(':')[1] | default('5432') if _use_remote_db else '5432' }}"
+    _database_host_full: "{{ _db_host }}:{{ _db_port }}"
+    _admin_user: "{{ xroad_ui_user | default('xvia-admin') }}"
+    _admin_password: "{{ admin_password | default('') }}"
+
+  pre_tasks:
+    - name: Validate admin_password
+      assert:
+        that: _admin_password != ''
+        fail_msg: "admin_password é obrigatório. Passe via -e admin_password=SENHA"
+
+    - name: Validate database_admin_password (remote)
+      assert:
+        that: database_admin_password != ''
+        fail_msg: "database_admin_password é obrigatório para banco remoto"
+      when: _use_remote_db
+
+    - name: "CS — Install prerequisites"
+      apt:
+        name:
+          - acl
+          - curl
+          - locales
+          - software-properties-common
+          - dpkg-dev
+          - apt-transport-https
+          - postgresql-common
+          - crudini
+        state: present
+        update_cache: yes
+
+    - name: Configure PostgreSQL PGDG apt repository
+      command: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+      args:
+        creates: /etc/apt/sources.list.d/pgdg.list
+
+    - name: Install PostgreSQL client
+      apt:
+        name: "postgresql-client-{{ xvia_pg_version }}"
+        state: present
+        update_cache: yes
+
+    - name: Enable UTF-8 locale
+      locale_gen:
+        name: en_US.UTF-8
+        state: present
+
+    - name: Create xroad group
+      group:
+        name: xroad
+        system: true
+
+    - name: Create xroad user
+      user:
+        name: xroad
+        group: xroad
+        system: true
+        shell: /bin/bash
+        createhome: yes
+
+    - name: Create admin user
+      user:
+        name: "{{ _admin_user }}"
+        shell: /usr/sbin/nologin
+        create_home: no
+
+    - name: Set admin password
+      shell: "echo '{{ _admin_user }}:{{ _admin_password }}' | chpasswd"
+      changed_when: true
+      no_log: true
+
+    - name: Ensure APT repo directory exists
+      shell: |
+        [ -d {{ xvia_apt_repo_dir }} ] || { rm -f {{ xvia_apt_repo_dir }}; mkdir -p {{ xvia_apt_repo_dir }}; }
+      changed_when: false
+
+    - name: Add local APT repository
+      apt_repository:
+        repo: "deb [trusted=yes] file://{{ xvia_apt_repo_dir }} /"
+        filename: xvia-local
+        update_cache: no
+
+  tasks:
+    - include_tasks: tasks/xvia_cs_install.yml
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PLAY 3: Security Server(s)
+# ══════════════════════════════════════════════════════════════════════════════
+- name: "X-VIA: Install Security Server"
+  hosts: ss_servers
+  become: true
+  become_user: root
+  tags: [ss]
+
+  vars_files:
+    - vars_files/xvia_cdn.yml
+    - vars_files/xvia_database.yml
+
+  vars:
+    _use_remote_db: "{{ use_remote_db | default(true) | bool }}"
+    _db_host: "{{ database_host.split(':')[0] if _use_remote_db else '127.0.0.1' }}"
+    _db_port: "{{ database_host.split(':')[1] | default('5432') if _use_remote_db else '5432' }}"
+    _database_host_full: "{{ _db_host }}:{{ _db_port }}"
+    _admin_user: "{{ xroad_ui_user | default('xvia-admin') }}"
+    _admin_password: "{{ admin_password | default('') }}"
+
+  pre_tasks:
+    - name: Validate admin_password
+      assert:
+        that: _admin_password != ''
+        fail_msg: "admin_password é obrigatório. Passe via -e admin_password=SENHA"
+
+    - name: Validate database_admin_password (remote)
+      assert:
+        that: database_admin_password != ''
+        fail_msg: "database_admin_password é obrigatório para banco remoto"
+      when: _use_remote_db
+
+  tasks:
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 1: Pré-requisitos
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: "SS — Install prerequisites"
+      apt:
+        name:
+          - acl
+          - curl
+          - locales
+          - software-properties-common
+          - dpkg-dev
+          - apt-transport-https
+          - postgresql-common
+        state: present
+        update_cache: yes
+
+    - name: Configure PostgreSQL PGDG apt repository
+      command: /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+      args:
+        creates: /etc/apt/sources.list.d/pgdg.list
+
+    - name: Install PostgreSQL client
+      apt:
+        name: "postgresql-client-{{ xvia_pg_version }}"
+        state: present
+        update_cache: yes
+
+    - name: Enable UTF-8 locale
+      locale_gen:
+        name: en_US.UTF-8
+        state: present
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 2: Download de pacotes
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: Check if SS packages already downloaded
+      find:
+        paths: "{{ xvia_debs_dir }}"
+        patterns: "*.deb"
+      register: _debs_existing
+
+    - name: Create packages directory
+      file:
+        path: "{{ xvia_debs_dir }}"
+        state: directory
+        mode: '0755'
+      when: _debs_existing.matched == 0
+
+    - name: "SS — Download packages from CDN"
+      get_url:
+        url: "{{ xvia_ss_tarball_url }}"
+        dest: /tmp/xvia-ss-packages.tar.gz
+        timeout: 900
+      when:
+        - _debs_existing.matched == 0
+        - xvia_package_source == "cdn"
+
+    - name: "SS — Download packages from S3"
+      shell: >
+        aws s3 cp s3://{{ xvia_s3_bucket }}/{{ xvia_ubuntu_version }}/xroad-{{ xvia_version }}-{{ xvia_ubuntu_version }}.tar.gz
+        /tmp/xvia-ss-packages.tar.gz
+        {% if xvia_s3_profile | default('') != '' %}--profile {{ xvia_s3_profile }}{% endif %}
+        --region {{ xvia_s3_region }}
+      when:
+        - _debs_existing.matched == 0
+        - xvia_package_source == "s3"
+
+    - name: "SS — Copy local tarball"
+      copy:
+        src: "{{ xvia_local_tarball_path }}"
+        dest: /tmp/xvia-ss-packages.tar.gz
+        remote_src: yes
+      when:
+        - _debs_existing.matched == 0
+        - xvia_package_source == "local"
+
+    - name: Extract packages
+      unarchive:
+        src: /tmp/xvia-ss-packages.tar.gz
+        dest: "{{ xvia_debs_dir }}"
+        remote_src: yes
+      when: _debs_existing.matched == 0
+
+    - name: Cleanup tarball
+      file:
+        path: /tmp/xvia-ss-packages.tar.gz
+        state: absent
+
+    - name: Ensure APT repo directory exists
+      shell: |
+        [ -d {{ xvia_apt_repo_dir }} ] || { rm -f {{ xvia_apt_repo_dir }}; mkdir -p {{ xvia_apt_repo_dir }}; }
+      changed_when: false
+
+    - name: Copy .deb packages to APT repo
+      shell: cp -f {{ xvia_debs_dir }}/*.deb {{ xvia_apt_repo_dir }}/
+      changed_when: false
+
+    - name: Generate APT Packages index
+      shell: dpkg-scanpackages -m . > Packages
+      args:
+        chdir: "{{ xvia_apt_repo_dir }}"
+
+    - name: Remove old xroad repo config
+      file:
+        path: /etc/apt/sources.list.d/xroad.list
+        state: absent
+
+    - name: Add local APT repository
+      apt_repository:
+        repo: "deb [trusted=yes] file://{{ xvia_apt_repo_dir }} /"
+        filename: xvia-local
+        update_cache: yes
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 3: Usuários do sistema
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: Create xroad group
+      group:
+        name: xroad
+        system: true
+
+    - name: Create xroad user
+      user:
+        name: xroad
+        group: xroad
+        system: true
+        shell: /bin/bash
+        createhome: yes
+
+    - name: Add xroad to shadow group
+      user:
+        name: xroad
+        groups: shadow
+        append: yes
+
+    - name: Create admin user
+      user:
+        name: "{{ _admin_user }}"
+        shell: /usr/sbin/nologin
+        create_home: no
+
+    - name: Set admin password
+      shell: "echo '{{ _admin_user }}:{{ _admin_password }}' | chpasswd"
+      changed_when: true
+      no_log: true
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 4: Banco de dados
+    # ──────────────────────────────────────────────────────────────────────────
+    - include_tasks: tasks/xvia_db_local.yml
+      when: not _use_remote_db
+
+    - include_tasks: tasks/xvia_db_remote.yml
+      when: _use_remote_db
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 5: Configuração
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: Ensure /etc/xroad directory
+      file:
+        path: /etc/xroad
+        state: directory
+        owner: xroad
+        group: xroad
+        mode: '0751'
+
+    - name: Create /etc/xroad.properties
+      copy:
+        content: "postgres.connection.password = {{ database_admin_password if _use_remote_db else '' }}\n"
+        dest: /etc/xroad.properties
+        mode: '0600'
+      no_log: true
+
+    - name: Create /etc/xroad/db.properties
+      template:
+        src: templates/xvia_db.properties.j2
+        dest: /etc/xroad/db.properties
+        owner: xroad
+        group: xroad
+        mode: '0640'
+        force: yes
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 6: Instalação de pacotes
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: Set debconf values
+      debconf:
+        name: xroad-proxy
+        question: "{{ item.question }}"
+        vtype: string
+        value: "{{ item.value }}"
+      loop:
+        - { question: "xroad-common/username", value: "{{ _admin_user }}" }
+        - { question: "xroad-common/database-host", value: "{{ _database_host_full }}" }
+        - { question: "xroad-common/proxy-memory", value: "{{ xvia_proxy_memory }}" }
+
+    - name: Mask xroad services before install
+      shell: systemctl mask {{ item }} 2>/dev/null || true
+      loop:
+        - xroad-proxy
+        - xroad-signer
+        - xroad-confclient
+        - xroad-proxy-ui-api
+        - xroad-monitor
+        - xroad-addon-messagelog
+        - xroad-opmonitor
+      changed_when: false
+
+    - name: Install xroad-database-remote
+      apt:
+        name: xroad-database-remote
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      when: _use_remote_db
+
+    - name: Install xroad-base
+      apt:
+        name: xroad-base
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+
+    - name: Install X-Road Security Server
+      apt:
+        name: "{{ xvia_ss_packages }}"
+        state: present
+        force: yes
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+
+    - name: Install xroad-addon-opmonitoring
+      apt:
+        name: xroad-addon-opmonitoring
+        state: present
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      when: xvia_enable_opmonitoring | default(true) | bool
+
+    - name: Ensure all packages configured
+      shell: dpkg --configure -a
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      changed_when: false
+
+    - name: Unmask xroad services
+      shell: systemctl unmask {{ item }}
+      loop:
+        - xroad-proxy
+        - xroad-signer
+        - xroad-confclient
+        - xroad-proxy-ui-api
+        - xroad-monitor
+        - xroad-addon-messagelog
+        - xroad-opmonitor
+      changed_when: false
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # FASE 7-8: Pós-instalação e Validação
+    # ──────────────────────────────────────────────────────────────────────────
+    - include_tasks: tasks/xvia_postinstall.yml
+    - include_tasks: tasks/xvia_validate.yml
+
+  handlers:
+    - name: reload postgresql
+      service:
+        name: postgresql
+        state: reloaded

--- a/development/xroad-api-test.env.example
+++ b/development/xroad-api-test.env.example
@@ -1,0 +1,35 @@
+# =============================================================================
+# xroad-api-test.env — Configuração do ambiente para xroad-api-test.sh
+# Copie este arquivo para .env.local e ajuste os valores
+# =============================================================================
+
+# --- Security Server ---
+SS_HOST=localhost
+SS_PORT=8080
+PROTOCOL=http
+SKIP_TLS_VERIFY=true
+
+# --- Identidade do consumer (sua aplicação) ---
+CLIENT_INSTANCE=DEV
+CLIENT_CLASS=COM
+CLIENT_MEMBER=4321
+CLIENT_SUBSYSTEM=TestClient
+
+# --- Identidade do provider (serviço alvo) ---
+PROVIDER_INSTANCE=DEV
+PROVIDER_CLASS=COM
+PROVIDER_MEMBER=1234
+PROVIDER_SUBSYSTEM=TestService
+SERVICE_CODE=mock1
+
+# --- Request padrão ---
+HTTP_METHOD=GET
+SERVICE_PATH=
+QUERY_PARAMS=
+BODY=
+CONTENT_TYPE=application/json
+
+# --- Headers opcionais ---
+XROAD_USER_ID=
+XROAD_ISSUE=
+XROAD_ID=

--- a/development/xroad-api-test.sh
+++ b/development/xroad-api-test.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# =============================================================================
+# xroad-api-test.sh — Teste rápido de chamadas X-Road REST via curl
+# =============================================================================
+# Uso:
+#   ./xroad-api-test.sh [opções]
+#   ./xroad-api-test.sh --env .env.local
+#
+# Configuração: edite as variáveis abaixo ou crie um arquivo .env e passe com --env
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Cores para output
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Defaults — sobrescreva via .env ou flags
+# ---------------------------------------------------------------------------
+SS_HOST="localhost"
+SS_PORT="8080"
+PROTOCOL="http"          # http ou https
+SKIP_TLS_VERIFY="true"   # true = ignora cert inválido (dev), false = valida
+
+# Identidade do consumer (quem está chamando)
+CLIENT_INSTANCE="DEV"
+CLIENT_CLASS="COM"
+CLIENT_MEMBER="4321"
+CLIENT_SUBSYSTEM="TestClient"
+
+# Identidade do provider (quem está sendo chamado)
+PROVIDER_INSTANCE="DEV"
+PROVIDER_CLASS="COM"
+PROVIDER_MEMBER="1234"
+PROVIDER_SUBSYSTEM="TestService"
+SERVICE_CODE="mock1"
+
+# Request
+HTTP_METHOD="GET"
+SERVICE_PATH=""          # ex: /v1/pets/123
+QUERY_PARAMS=""          # ex: "status=available&limit=10"
+BODY=""                  # JSON body para POST/PUT
+CONTENT_TYPE="application/json"
+
+# Headers opcionais
+XROAD_USER_ID=""         # ex: EE12345678901
+XROAD_ISSUE=""           # ex: DOC-42
+XROAD_ID=""              # UUID — gerado automaticamente se vazio
+
+# Modo
+VERBOSE="false"
+META_CMD=""              # listMethods | allowedMethods | getOpenAPI | listClients
+ENV_FILE=""
+
+# ---------------------------------------------------------------------------
+# Funções utilitárias
+# ---------------------------------------------------------------------------
+log()      { echo -e "${BLUE}[INFO]${RESET}  $*"; }
+success()  { echo -e "${GREEN}[OK]${RESET}    $*"; }
+warn()     { echo -e "${YELLOW}[WARN]${RESET}  $*"; }
+error()    { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+header()   { echo -e "\n${BOLD}${CYAN}=== $* ===${RESET}\n"; }
+die()      { error "$*"; exit 1; }
+
+usage() {
+  cat <<EOF
+${BOLD}xroad-api-test.sh${RESET} — Tester rápido de APIs X-Road REST
+
+${BOLD}USO${RESET}
+  $0 [opções]
+
+${BOLD}CONFIGURAÇÃO${RESET}
+  --env FILE            Carrega variáveis de um arquivo .env
+  --host HOST           Security Server host (default: $SS_HOST)
+  --port PORT           Security Server porta (default: $SS_PORT)
+  --https               Usa HTTPS (default: HTTP)
+  --verify-tls          Valida certificado TLS (default: ignora em dev)
+
+${BOLD}IDENTIDADE${RESET}
+  --client  I/C/M/S     X-Road-Client completo (ex: DEV/COM/4321/TestClient)
+  --service I/C/M/S/SC  ServiceId completo     (ex: DEV/COM/1234/TestService/mock1)
+
+${BOLD}REQUEST${RESET}
+  -X, --method METHOD   Método HTTP: GET POST PUT DELETE PATCH (default: GET)
+  -p, --path PATH       Caminho após o serviceId (ex: /v1/pets/123)
+  -q, --query PARAMS    Query string (ex: "status=ok&page=1")
+  -d, --data JSON       Body JSON para POST/PUT
+  --content-type TYPE   Content-Type (default: application/json)
+
+${BOLD}HEADERS OPCIONAIS${RESET}
+  --user-id ID          X-Road-UserId (ex: EE12345678901)
+  --issue ID            X-Road-Issue
+  --id UUID             X-Road-Id (gerado automaticamente se omitido)
+
+${BOLD}METASERVIÇOS${RESET}
+  --list-methods        Chama listMethods no provider
+  --allowed-methods     Chama allowedMethods no provider
+  --get-openapi CODE    Chama getOpenAPI?serviceCode=CODE
+  --list-clients        Chama listClients (discovery de providers)
+
+${BOLD}OUTROS${RESET}
+  -v, --verbose         Mostra headers e detalhes completos
+  -h, --help            Mostra esta ajuda
+
+${BOLD}EXEMPLOS${RESET}
+  # GET simples
+  $0 --host 192.168.1.100 -X GET -p /v2/pets/1
+
+  # POST com body
+  $0 -X POST -d '{"name":"Rex","status":"available"}' -p /v2/pets
+
+  # Descobrir serviços disponíveis
+  $0 --list-methods
+
+  # Usando arquivo de configuração
+  $0 --env .env.staging -X GET -p /status
+
+  # Verbose com HTTPS
+  $0 --https --verify-tls -v -X GET -p /v1/health
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parser de argumentos
+# ---------------------------------------------------------------------------
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env)          ENV_FILE="$2";        shift 2 ;;
+      --host)         SS_HOST="$2";         shift 2 ;;
+      --port)         SS_PORT="$2";         shift 2 ;;
+      --https)        PROTOCOL="https";     shift   ;;
+      --verify-tls)   SKIP_TLS_VERIFY="false"; shift ;;
+      --client)
+        IFS='/' read -r CLIENT_INSTANCE CLIENT_CLASS CLIENT_MEMBER CLIENT_SUBSYSTEM <<< "$2"
+        shift 2 ;;
+      --service)
+        IFS='/' read -r PROVIDER_INSTANCE PROVIDER_CLASS PROVIDER_MEMBER PROVIDER_SUBSYSTEM SERVICE_CODE <<< "$2"
+        shift 2 ;;
+      -X|--method)    HTTP_METHOD="${2^^}";  shift 2 ;;
+      -p|--path)      SERVICE_PATH="$2";    shift 2 ;;
+      -q|--query)     QUERY_PARAMS="$2";    shift 2 ;;
+      -d|--data)      BODY="$2";            shift 2 ;;
+      --content-type) CONTENT_TYPE="$2";    shift 2 ;;
+      --user-id)      XROAD_USER_ID="$2";   shift 2 ;;
+      --issue)        XROAD_ISSUE="$2";     shift 2 ;;
+      --id)           XROAD_ID="$2";        shift 2 ;;
+      --list-methods)    META_CMD="listMethods";   shift ;;
+      --allowed-methods) META_CMD="allowedMethods"; shift ;;
+      --get-openapi)     META_CMD="getOpenAPI"; QUERY_PARAMS="serviceCode=$2"; shift 2 ;;
+      --list-clients)    META_CMD="listClients";   shift ;;
+      -v|--verbose)   VERBOSE="true";       shift   ;;
+      -h|--help)      usage; exit 0 ;;
+      *) die "Argumento desconhecido: $1. Use --help para ajuda." ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Carrega .env se fornecido
+# ---------------------------------------------------------------------------
+load_env() {
+  [[ -z "$ENV_FILE" ]] && return
+  [[ ! -f "$ENV_FILE" ]] && die "Arquivo .env não encontrado: $ENV_FILE"
+  log "Carregando configuração de: $ENV_FILE"
+  # shellcheck disable=SC1090
+  set -a; source "$ENV_FILE"; set +a
+}
+
+# ---------------------------------------------------------------------------
+# Gera UUID v4 simples (sem dependência de uuidgen)
+# ---------------------------------------------------------------------------
+gen_uuid() {
+  if command -v uuidgen &>/dev/null; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null \
+      || cat /proc/sys/kernel/random/uuid 2>/dev/null \
+      || echo "$(date +%s)-$$-$(shuf -i 1000-9999 -n 1)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Monta e executa a chamada
+# ---------------------------------------------------------------------------
+run_request() {
+  local base_url="${PROTOCOL}://${SS_HOST}:${SS_PORT}"
+  local client_id="${CLIENT_INSTANCE}/${CLIENT_CLASS}/${CLIENT_MEMBER}/${CLIENT_SUBSYSTEM}"
+  local service_id="${PROVIDER_INSTANCE}/${PROVIDER_CLASS}/${PROVIDER_MEMBER}/${PROVIDER_SUBSYSTEM}/${SERVICE_CODE}"
+  local msg_id="${XROAD_ID:-$(gen_uuid)}"
+
+  # Monta URL
+  local url
+  if [[ "$META_CMD" == "listClients" ]]; then
+    # listClients não segue o padrão /r1/{serviceId}
+    url="${base_url}/r1/${PROVIDER_INSTANCE}/${PROVIDER_CLASS}/${PROVIDER_MEMBER}/${PROVIDER_SUBSYSTEM}/listClients"
+  elif [[ -n "$META_CMD" ]]; then
+    url="${base_url}/r1/${service_id%/*}/${META_CMD}"
+    service_id="${service_id%/*}/${META_CMD}"
+  else
+    url="${base_url}/r1/${service_id}${SERVICE_PATH}"
+  fi
+
+  [[ -n "$QUERY_PARAMS" ]] && url="${url}?${QUERY_PARAMS}"
+
+  # Monta headers curl
+  local curl_args=()
+  curl_args+=(-s -S)                            # silencioso mas mostra erros
+  curl_args+=(-w "\n%{http_code}")              # adiciona status code na última linha
+  curl_args+=(-X "$HTTP_METHOD")
+  curl_args+=(-H "X-Road-Client: ${client_id}")
+  curl_args+=(-H "X-Road-Id: ${msg_id}")
+  curl_args+=(-H "Accept: application/json")
+
+  [[ -n "$XROAD_USER_ID" ]] && curl_args+=(-H "X-Road-UserId: ${XROAD_USER_ID}")
+  [[ -n "$XROAD_ISSUE"   ]] && curl_args+=(-H "X-Road-Issue: ${XROAD_ISSUE}")
+
+  if [[ -n "$BODY" ]]; then
+    curl_args+=(-H "Content-Type: ${CONTENT_TYPE}")
+    curl_args+=(-d "$BODY")
+  fi
+
+  [[ "$SKIP_TLS_VERIFY" == "true" ]] && curl_args+=(-k)
+  [[ "$VERBOSE"         == "true" ]] && curl_args+=(-v) || curl_args+=(-D /tmp/xroad_headers_$$.txt)
+
+  # ---------------------------------------------------------------------------
+  # Exibe resumo da chamada
+  # ---------------------------------------------------------------------------
+  header "X-Road REST Request"
+  echo -e "  ${BOLD}URL:${RESET}            ${url}"
+  echo -e "  ${BOLD}Método:${RESET}         ${HTTP_METHOD}"
+  echo -e "  ${BOLD}Client:${RESET}         ${client_id}"
+  echo -e "  ${BOLD}Service:${RESET}        ${service_id}"
+  echo -e "  ${BOLD}X-Road-Id:${RESET}      ${msg_id}"
+  [[ -n "$XROAD_USER_ID" ]] && echo -e "  ${BOLD}UserId:${RESET}         ${XROAD_USER_ID}"
+  [[ -n "$XROAD_ISSUE"   ]] && echo -e "  ${BOLD}Issue:${RESET}          ${XROAD_ISSUE}"
+  [[ -n "$BODY"          ]] && echo -e "  ${BOLD}Body:${RESET}           ${BODY}"
+  echo ""
+
+  # Mostra o curl equivalente para copiar/colar
+  echo -e "${YELLOW}── curl equivalente ──────────────────────────────────────${RESET}"
+  local curl_display="curl -X ${HTTP_METHOD} \"${url}\" \\\n"
+  curl_display+="  -H \"X-Road-Client: ${client_id}\" \\\n"
+  curl_display+="  -H \"X-Road-Id: ${msg_id}\" \\\n"
+  curl_display+="  -H \"Accept: application/json\""
+  [[ -n "$XROAD_USER_ID" ]] && curl_display+=" \\\n  -H \"X-Road-UserId: ${XROAD_USER_ID}\""
+  [[ -n "$BODY"          ]] && curl_display+=" \\\n  -H \"Content-Type: ${CONTENT_TYPE}\" \\\n  -d '${BODY}'"
+  [[ "$SKIP_TLS_VERIFY"  == "true" ]] && curl_display+=" \\\n  -k"
+  echo -e "$curl_display"
+  echo -e "${YELLOW}──────────────────────────────────────────────────────────${RESET}\n"
+
+  # ---------------------------------------------------------------------------
+  # Executa
+  # ---------------------------------------------------------------------------
+  header "Response"
+
+  local raw_output http_status response_body
+
+  # Captura output + status code (última linha)
+  raw_output=$(curl "${curl_args[@]}" "$url" 2>/dev/null || true)
+  http_status=$(echo "$raw_output" | tail -n1)
+  response_body=$(echo "$raw_output" | head -n -1)
+
+  # Status code colorido
+  local status_color="$GREEN"
+  [[ "$http_status" -ge 400 ]] && status_color="$RED"
+  [[ "$http_status" -ge 300 && "$http_status" -lt 400 ]] && status_color="$YELLOW"
+
+  echo -e "  ${BOLD}Status:${RESET} ${status_color}${http_status}${RESET}"
+  echo ""
+
+  # Mostra headers de resposta X-Road (se não verbose)
+  if [[ "$VERBOSE" == "false" && -f /tmp/xroad_headers_$$.txt ]]; then
+    local xroad_headers
+    xroad_headers=$(grep -i "x-road-" /tmp/xroad_headers_$$.txt 2>/dev/null || true)
+    if [[ -n "$xroad_headers" ]]; then
+      echo -e "${CYAN}── Headers X-Road na resposta ──${RESET}"
+      echo "$xroad_headers" | while IFS= read -r line; do
+        echo "  $line"
+      done
+      echo ""
+    fi
+    rm -f /tmp/xroad_headers_$$.txt
+  fi
+
+  # Body formatado
+  echo -e "${CYAN}── Body ────────────────────────────────────────────────────${RESET}"
+  if command -v python3 &>/dev/null && [[ -n "$response_body" ]]; then
+    echo "$response_body" | python3 -m json.tool 2>/dev/null || echo "$response_body"
+  else
+    echo "$response_body"
+  fi
+  echo -e "${CYAN}────────────────────────────────────────────────────────────${RESET}"
+
+  # Verifica header X-Road-Error
+  if [[ -n "${response_body}" ]] && echo "$response_body" | grep -q '"type"'; then
+    local error_type
+    error_type=$(echo "$response_body" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('type',''))" 2>/dev/null || true)
+    if [[ -n "$error_type" ]]; then
+      echo ""
+      if echo "$error_type" | grep -q "^Client\."; then
+        warn "Erro no Consumer Security Server: ${error_type}"
+      elif echo "$error_type" | grep -q "^Server\.ServerProxy"; then
+        warn "Erro no Provider Security Server: ${error_type}"
+      fi
+    fi
+  fi
+
+  echo ""
+  [[ "$http_status" -lt 400 ]] && success "Chamada concluída com status ${http_status}" \
+                                || error   "Falha com status ${http_status}"
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+  load_env
+
+  # Validações básicas
+  [[ -z "$SS_HOST" ]]           && die "SS_HOST não definido. Use --host ou --env."
+  [[ -z "$CLIENT_MEMBER" ]]     && die "CLIENT não definido. Use --client I/C/M/S ou --env."
+  [[ -z "$PROVIDER_MEMBER" ]]   && die "PROVIDER não definido. Use --service I/C/M/S/SC ou --env."
+  [[ -z "$SERVICE_CODE" && -z "$META_CMD" ]] && die "SERVICE_CODE não definido. Use --service ou um metaserviço (--list-methods etc)."
+
+  run_request
+}
+
+main "$@"

--- a/sidecar/kubernetes/Central-server/cs-deployment.yaml
+++ b/sidecar/kubernetes/Central-server/cs-deployment.yaml
@@ -1,0 +1,213 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cs-deployment
+  namespace: sidecar
+spec:
+  selector:
+    matchLabels:
+      app: cs
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cs
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 999
+      initContainers:
+        - name: fix-permissions
+          image: 183619025107.dkr.ecr.sa-east-1.amazonaws.com/xroad-central-server:7.8.0
+          env:
+            - name: XROAD_TOKEN_PIN
+              valueFrom:
+                secretKeyRef:
+                  name: secret-sidecar-variables
+                  key: XROAD_TOKEN_PIN
+          command:
+            - sh
+            - -c
+            - |
+              chown -R 101:103 /var/lib/postgresql/16/main
+              chmod 0700 /var/lib/postgresql/16/main
+              if [ ! -f /var/lib/postgresql/16/main/PG_VERSION ]; then
+                rm -rf /var/lib/postgresql/16/main/lost+found
+                su -s /bin/sh postgres -c "/usr/lib/postgresql/16/bin/initdb -D /var/lib/postgresql/16/main"
+              fi
+              if [ ! -f /etc/xroad/VERSION ]; then
+                cp -a /root/etc/xroad/* /etc/xroad/
+              fi
+              # Ensure db.properties exists for xroad services
+              if [ ! -f /etc/xroad/db.properties ]; then
+                cat > /etc/xroad/db.properties << 'DBEOF'
+                spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/centerui_production
+                spring.datasource.username=centerui
+                spring.datasource.password=centerui
+                spring.datasource.hikari.data-source-properties.currentSchema=centerui,public
+              DBEOF
+                sed -i 's/^[[:space:]]*//' /etc/xroad/db.properties
+              fi
+              # Ensure devices.ini exists for xroad-signer
+              if [ ! -f /etc/xroad/devices.ini ]; then
+                cp /usr/share/xroad/doc/devices.ini /etc/xroad/devices.ini
+              fi
+              # Autologin para o token PIN
+              echo "$XROAD_TOKEN_PIN" > /etc/xroad/autologin
+              chmod 600 /etc/xroad/autologin
+              chown -R 999:999 /etc/xroad
+              chown -R 999:999 /home/ca
+              chown -R 998:998 /opt/openbao/data
+              # Setup database if needed
+              su -s /bin/sh postgres -c "/usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/main start -w -o '-c config_file=/etc/postgresql/16/main/postgresql.conf'" 2>/dev/null
+              if ! su -s /bin/sh postgres -c "psql -lqt" | grep -q centerui_production; then
+                su -s /bin/sh postgres -c "psql -c \"CREATE USER centerui WITH PASSWORD 'centerui';\""
+                su -s /bin/sh postgres -c "psql -c \"CREATE DATABASE centerui_production OWNER centerui;\""
+                su -s /bin/sh postgres -c "psql -d centerui_production -c 'CREATE EXTENSION IF NOT EXISTS hstore;'"
+                su -s /bin/sh postgres -c "psql -d centerui_production -c 'CREATE SCHEMA IF NOT EXISTS centerui AUTHORIZATION centerui;'"
+                ADMIN_PW=$(crudini --get /etc/xroad.properties '' 'centerui.database.admin_password' 2>/dev/null || echo 'centerui')
+                su -s /bin/sh postgres -c "psql -c \"CREATE USER centerui_admin WITH SUPERUSER PASSWORD '$ADMIN_PW';\""
+                cd /usr/share/xroad/db && ./migrate.sh
+              else
+                cd /usr/share/xroad/db && ./migrate.sh
+              fi
+              su -s /bin/sh postgres -c "/usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/main stop -w" 2>/dev/null
+              # Ensure hstore extension is available in centerui schema search path
+              true
+          volumeMounts:
+            - name: cs-db-volume
+              mountPath: /var/lib/postgresql/16/main
+            - name: cs-conf-volume
+              mountPath: /etc/xroad
+            - name: cs-test-ca-volume
+              mountPath: /home/ca
+            - name: openbao-data
+              mountPath: /opt/openbao/data
+            - name: supervisor-config
+              mountPath: /usr/share/xroad/scripts/secret-store-init.sh
+              subPath: secret-store-init.sh
+      containers:
+        - name: cs
+          image: 183619025107.dkr.ecr.sa-east-1.amazonaws.com/xroad-central-server:7.8.0
+          env:
+            - name: XROAD_TOKEN_PIN
+              valueFrom:
+                secretKeyRef:
+                  name: secret-sidecar-variables
+                  key: XROAD_TOKEN_PIN
+            - name: BAO_ADDR
+              value: "http://127.0.0.1:8200"
+          ports:
+            - containerPort: 4000
+              protocol: TCP
+            - containerPort: 4001
+              protocol: TCP
+            - containerPort: 4002
+              protocol: TCP
+            - containerPort: 80
+              protocol: TCP
+            - containerPort: 8899
+              protocol: TCP
+            - containerPort: 8888
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              scheme: HTTPS
+            initialDelaySeconds: 180
+            periodSeconds: 30
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              scheme: HTTPS
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            failureThreshold: 20
+          volumeMounts:
+            - name: cs-db-volume
+              mountPath: /var/lib/postgresql/16/main
+            - name: cs-conf-volume
+              mountPath: /etc/xroad
+            - name: cs-test-ca-volume
+              mountPath: /home/ca
+            - name: supervisor-config
+              mountPath: /etc/supervisor/conf.d/xroad.conf
+              subPath: xroad.conf
+            - name: supervisor-config
+              mountPath: /usr/share/xroad/scripts/secret-store-init.sh
+              subPath: secret-store-init.sh
+            - name: supervisor-config
+              mountPath: /etc/openbao/openbao.hcl
+              subPath: openbao.hcl
+            - name: supervisor-config
+              mountPath: /usr/share/xroad/scripts/init-signing-keys.sh
+              subPath: init-signing-keys.sh
+            - name: supervisor-config
+              mountPath: /usr/share/xroad/autologin/autologin.sh
+              subPath: autologin.sh
+            - name: openbao-data
+              mountPath: /opt/openbao/data
+      volumes:
+        - name: cs-db-volume
+          persistentVolumeClaim:
+            claimName: cs-db-pvc
+        - name: cs-conf-volume
+          persistentVolumeClaim:
+            claimName: cs-conf-pvc
+        - name: cs-test-ca-volume
+          persistentVolumeClaim:
+            claimName: cs-test-ca-pvc
+        - name: supervisor-config
+          configMap:
+            name: cs-supervisor-config
+            defaultMode: 0755
+        - name: openbao-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cs-service
+  namespace: sidecar
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+spec:
+  type: LoadBalancer
+  selector:
+    app: cs
+  ports:
+    - port: 4000
+      targetPort: 4000
+      protocol: TCP
+      name: admin-ui
+    - port: 4001
+      targetPort: 4001
+      protocol: TCP
+      name: management
+    - port: 4002
+      targetPort: 4002
+      protocol: TCP
+      name: registration
+    - port: 8888
+      targetPort: 8888
+      protocol: TCP
+      name: ca
+    - port: 8899
+      targetPort: 8899
+      protocol: TCP
+      name: tsa
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/sidecar/kubernetes/Central-server/cs-deployment.yaml
+++ b/sidecar/kubernetes/Central-server/cs-deployment.yaml
@@ -172,7 +172,8 @@ spec:
             name: cs-supervisor-config
             defaultMode: 0755
         - name: openbao-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: openbao-data-pvc
 ---
 apiVersion: v1
 kind: Service

--- a/sidecar/kubernetes/Central-server/cs-pvcs.yaml
+++ b/sidecar/kubernetes/Central-server/cs-pvcs.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-db-pvc
+  namespace: sidecar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-conf-pvc
+  namespace: sidecar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-test-ca-pvc
+  namespace: sidecar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/sidecar/kubernetes/Central-server/cs-pvcs.yaml
+++ b/sidecar/kubernetes/Central-server/cs-pvcs.yaml
@@ -1,6 +1,17 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: openbao-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: cs-db-pvc
   namespace: sidecar
 spec:

--- a/sidecar/kubernetes/Central-server/cs-supervisor-configmap.yaml
+++ b/sidecar/kubernetes/Central-server/cs-supervisor-configmap.yaml
@@ -1,0 +1,354 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cs-supervisor-config
+  namespace: sidecar
+data:
+  xroad.conf: |
+    [supervisord]
+    user=root
+
+    [program:postgres]
+    command=/usr/lib/postgresql/16/bin/postgres -D /var/lib/postgresql/16/main -c config_file=/etc/postgresql/16/main/postgresql.conf
+    user=postgres
+    stopsignal=INT
+    stopwaitsecs=30
+    autorestart=unexpected
+    priority=100
+
+    [program:nginx]
+    command=/usr/sbin/nginx -g "daemon off;"
+    autorestart=unexpected
+    priority=100
+
+    [program:openbao]
+    command=/usr/bin/bao server -config=/etc/openbao/openbao.hcl
+    user=openbao
+    autorestart=true
+    stopsignal=INT
+    stopwaitsecs=30
+    priority=120
+
+    [program:xroad-secret-store-local]
+    command=/usr/share/xroad/scripts/secret-store-init.sh
+    autorestart=false
+    exitcodes=0
+    priority=150
+
+    [program:xroad-center]
+    command=/usr/share/xroad/scripts/wait-for-secret-store.sh /usr/share/xroad/bin/xroad-centralserver-admin-service
+    user=xroad
+    autorestart=true
+    priority=300
+
+    [program:xroad-center-registration-service]
+    command=/usr/share/xroad/scripts/wait-for-secret-store.sh /usr/share/xroad/bin/xroad-centralserver-registration-service
+    user=xroad
+    autorestart=true
+    priority=300
+
+    [program:xroad-center-management-service]
+    command=/usr/share/xroad/scripts/wait-for-secret-store.sh /usr/share/xroad/bin/xroad-centralserver-management-service
+    user=xroad
+    autorestart=true
+    priority=300
+
+    [program:xroad-signer]
+    command=/usr/share/xroad/scripts/wait-for-secret-store.sh /usr/share/xroad/bin/xroad-signer
+    user=xroad
+    autorestart=true
+    priority=300
+
+    [program:xroad-confclient]
+    command=/usr/share/xroad/scripts/wait-for-secret-store.sh /usr/share/xroad/bin/xroad-confclient
+    user=xroad
+    autorestart=true
+    priority=300
+
+    [program:xroad-autologin]
+    command=/usr/share/xroad/autologin/autologin.sh
+    autorestart=false
+    exitcodes=0
+    startsecs=0
+    priority=350
+
+    [program:init-signing-keys]
+    command=/usr/share/xroad/scripts/init-signing-keys.sh
+    autorestart=false
+    exitcodes=0
+    startsecs=0
+    priority=400
+
+  secret-store-init.sh: |
+    #!/bin/bash
+    set -e
+
+    export BAO_ADDR="http://127.0.0.1:8200"
+    TOKEN_FILE="/etc/xroad/secret-store-client-token"
+
+    # Generate gRPC internal keypair
+    mkdir -p /var/run/xroad
+    chown xroad:xroad /var/run/xroad
+    su -s /bin/bash xroad -c "/usr/share/xroad/scripts/xroad-base.sh"
+
+    echo "Waiting for OpenBao to be available..."
+    for i in $(seq 1 30); do
+      if bao status -format=json 2>/dev/null | grep -q '"initialized"'; then
+        break
+      fi
+      sleep 1
+    done
+
+    # Initialize if needed
+    if ! bao status -format=json 2>/dev/null | grep -q '"initialized":true'; then
+      echo "Initializing OpenBao..."
+      INIT_OUTPUT=$(bao operator init -key-shares=1 -key-threshold=1 -format=json)
+      UNSEAL_KEY=$(echo "$INIT_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['unseal_keys_b64'][0])")
+      ROOT_TOKEN=$(echo "$INIT_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['root_token'])")
+      echo "$UNSEAL_KEY" > /opt/openbao/data/.unseal_key
+      echo "$ROOT_TOKEN" > /opt/openbao/data/.root_token
+      chmod 600 /opt/openbao/data/.unseal_key /opt/openbao/data/.root_token
+    fi
+
+    # Unseal
+    SEALED=$(bao status -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('sealed','true'))" 2>/dev/null || echo "true")
+    if [ "$SEALED" = "True" ] || [ "$SEALED" = "true" ]; then
+      echo "Unsealing OpenBao..."
+      UNSEAL_KEY=$(cat /opt/openbao/data/.unseal_key)
+      bao operator unseal "$UNSEAL_KEY" >/dev/null
+    fi
+
+    # Login and create xroad token
+    export BAO_TOKEN=$(cat /opt/openbao/data/.root_token)
+
+    # Enable kv secrets engine if not already
+    if ! bao secrets list -format=json 2>/dev/null | grep -q '"secret/"'; then
+      bao secrets enable -path=secret kv-v2 2>/dev/null || true
+    fi
+
+    # Create policy for xroad
+    bao policy write xroad-policy - <<EOF 2>/dev/null || true
+    path "secret/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    }
+    EOF
+
+    # Create token for xroad services
+    XROAD_TOKEN=$(bao token create -policy=xroad-policy -ttl=87600h -format=json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])")
+
+    echo "$XROAD_TOKEN" > "$TOKEN_FILE"
+    chown xroad:xroad "$TOKEN_FILE"
+    chmod 600 "$TOKEN_FILE"
+
+    echo "Secret store initialized successfully. Token written to $TOKEN_FILE"
+
+  openbao.hcl: |
+    ui = false
+    disable_mlock = true
+
+    storage "file" {
+      path = "/opt/openbao/data"
+    }
+
+    listener "tcp" {
+      address     = "127.0.0.1:8200"
+      tls_disable = 1
+    }
+
+  init-signing-keys.sh: |
+    #!/bin/bash
+    # Initializes Central Server: signing keys, API tokens for services,
+    # member class GOV, member CS-EKS, subsystem MANAGEMENT, and management service provider
+    set -e
+
+    MARKER_FILE="/etc/xroad/signer/.signing-keys-initialized"
+    if [ -f "$MARKER_FILE" ]; then
+      echo "Signing keys already initialized."
+      exit 0
+    fi
+
+    # Ensure devices.ini exists
+    if [ ! -f /etc/xroad/devices.ini ]; then
+      cp /usr/share/xroad/doc/devices.ini /etc/xroad/devices.ini
+      chown xroad:xroad /etc/xroad/devices.ini
+      echo "devices.ini copied."
+    fi
+
+    API_URL="https://localhost:4000/api/v1"
+
+    # Wait for xroad-center admin service to be ready
+    echo "Waiting for Central Server admin service..."
+    for i in $(seq 1 90); do
+      if curl -sk "${API_URL}/system/version" | grep -q "info"; then
+        break
+      fi
+      sleep 2
+    done
+
+    # --- Configure API tokens for registration-service and management-service ---
+    echo "Configuring API tokens for registration/management services..."
+    /usr/share/xroad/scripts/configure_management_api_key.sh registration-service
+    /usr/share/xroad/scripts/configure_management_api_key.sh management-service
+
+    # --- Create temporary API key for initialization ---
+    source /usr/share/xroad/scripts/_read_cs_db_properties.sh
+    prepare_db_props
+    if [ -f /etc/xroad/db_libpq.env ]; then source /etc/xroad/db_libpq.env; fi
+
+    API_TOKEN=$(tr -C -d "[:alnum:]" </dev/urandom | head -c32)
+    ENCODED_TOKEN=$(echo -n "$API_TOKEN" | sha256sum -b | cut -d' ' -f1)
+
+    PGOPTIONS="${PGOPTIONS_EXTRA-}" PGDATABASE="$db_database" PGUSER="$db_user" PGPASSWORD="$db_password" psql -h "${PGHOST:-$db_host}" -p "${PGPORT:-$db_port}" -qtA -c "
+      INSERT INTO apikey(id, encodedkey) VALUES ((SELECT NEXTVAL('hibernate_sequence')), '$ENCODED_TOKEN');
+      INSERT INTO apikey_roles(apikey_id,role)
+        SELECT id, role FROM apikey, (VALUES
+          ('XROAD_SYSTEM_ADMINISTRATOR'),('XROAD_SECURITY_OFFICER'),
+          ('XROAD_REGISTRATION_OFFICER'),('XROAD_MANAGEMENT_SERVICE')
+        ) AS r(role) WHERE encodedkey = '$ENCODED_TOKEN';
+    " 2>/dev/null
+
+    AUTH="Authorization: X-Road-ApiKey token=${API_TOKEN}"
+
+    # Wait for token to be logged in (autologin with XROAD_TOKEN_PIN)
+    echo "Waiting for softToken login..."
+    for i in $(seq 1 60); do
+      TOKEN_STATUS=$(curl -sk "${API_URL}/tokens" -H "$AUTH" 2>/dev/null)
+      if echo "$TOKEN_STATUS" | grep -q '"logged_in":true'; then
+        break
+      fi
+      sleep 2
+    done
+
+    # --- Generate signing keys ---
+    HAS_INTERNAL=$(echo "$TOKEN_STATUS" | grep -c '"source_type":"INTERNAL"' || echo "0")
+    if [ "$HAS_INTERNAL" -gt "0" ]; then
+      echo "Signing keys already exist."
+    else
+      echo "Generating INTERNAL signing key via API..."
+      curl -sk -X POST "${API_URL}/configuration-sources/INTERNAL/signing-keys" \
+        -H "$AUTH" -H "Content-Type: application/json" \
+        -d '{"token_id":"0","key_label":"internal-sign-key"}'
+      echo ""
+
+      echo "Generating EXTERNAL signing key via API..."
+      curl -sk -X POST "${API_URL}/configuration-sources/EXTERNAL/signing-keys" \
+        -H "$AUTH" -H "Content-Type: application/json" \
+        -d '{"token_id":"0","key_label":"external-sign-key"}'
+      echo ""
+    fi
+
+    # --- Register member class, member, subsystem, and management service provider ---
+    echo "Configuring member GOV:CS-EKS and management service provider..."
+
+    # Add member class GOV (ignore if exists)
+    curl -sk -X POST "${API_URL}/member-classes" -H "$AUTH" -H "Content-Type: application/json" \
+      -d '{"code":"GOV","description":"Government"}' 2>/dev/null
+
+    # Add member GOV:CS-EKS (ignore if exists)
+    curl -sk -X POST "${API_URL}/members" -H "$AUTH" -H "Content-Type: application/json" \
+      -d '{"member_id":{"member_class":"GOV","member_code":"CS-EKS"},"member_name":"Central Server EKS"}' 2>/dev/null
+
+    # Add subsystem MANAGEMENT (ignore if exists)
+    curl -sk -X POST "${API_URL}/members/CSEKS:GOV:CS-EKS/subsystems" -H "$AUTH" -H "Content-Type: application/json" \
+      -d '{"subsystem_code":"MANAGEMENT"}' 2>/dev/null
+
+    # Set management service provider
+    curl -sk -X PATCH "${API_URL}/management-services-configuration" -H "$AUTH" -H "Content-Type: application/json" \
+      -d '{"service_provider_id":"CSEKS:GOV:CS-EKS:MANAGEMENT"}' 2>/dev/null
+
+    echo "Management service provider configured."
+
+    # --- Cleanup temporary API key ---
+    PGOPTIONS="${PGOPTIONS_EXTRA-}" PGDATABASE="$db_database" PGUSER="$db_user" PGPASSWORD="$db_password" psql -h "${PGHOST:-$db_host}" -p "${PGPORT:-$db_port}" -qtA -c "
+      DELETE FROM apikey_roles WHERE apikey_id = (SELECT id FROM apikey WHERE encodedkey = '$ENCODED_TOKEN');
+      DELETE FROM apikey WHERE encodedkey = '$ENCODED_TOKEN';
+    " 2>/dev/null
+
+    # --- Restart registration/management services to pick up new tokens ---
+    supervisorctl restart xroad-center-registration-service xroad-center-management-service 2>/dev/null || true
+
+    touch "$MARKER_FILE"
+    echo "Central Server initialization complete."
+
+  autologin.sh: |
+    #!/bin/bash
+    # Autologin: initializes and/or logs in softToken with PIN via API
+    PIN_FILE=/etc/xroad/autologin
+    if [ ! -f "$PIN_FILE" ]; then
+      echo "autologin: PIN file not found at $PIN_FILE"
+      exit 1
+    fi
+
+    PIN=$(cat "$PIN_FILE")
+    API_URL="https://localhost:4000/api/v1"
+
+    echo "autologin: waiting for xroad-signer..."
+    for i in $(seq 1 120); do
+      if su -s /bin/bash xroad -c "signer-console list-tokens" 2>/dev/null | grep -q "Token:"; then
+        break
+      fi
+      sleep 2
+    done
+
+    TOKEN_INFO=$(su -s /bin/bash xroad -c "signer-console list-tokens" 2>/dev/null)
+
+    # If already active, nothing to do
+    if echo "$TOKEN_INFO" | grep "Token:" | grep -qv "inactive"; then
+      echo "autologin: token already active"
+      exit 0
+    fi
+
+    # Need to use API for both init and login
+    echo "autologin: waiting for admin service..."
+    for i in $(seq 1 90); do
+      if curl -sk "${API_URL}/system/version" 2>/dev/null | grep -q "info\|status"; then
+        break
+      fi
+      sleep 2
+    done
+
+    # Create temp API key
+    source /usr/share/xroad/scripts/_read_cs_db_properties.sh
+    prepare_db_props
+    if [ -f /etc/xroad/db_libpq.env ]; then source /etc/xroad/db_libpq.env; fi
+
+    TMP_TOKEN=$(tr -C -d "[:alnum:]" </dev/urandom | head -c32)
+    TMP_ENCODED=$(echo -n "$TMP_TOKEN" | sha256sum -b | cut -d' ' -f1)
+
+    PGOPTIONS="${PGOPTIONS_EXTRA-}" PGDATABASE="$db_database" PGUSER="$db_user" PGPASSWORD="$db_password" psql -h "${PGHOST:-$db_host}" -p "${PGPORT:-$db_port}" -qtA -c "
+      INSERT INTO apikey(id, encodedkey) VALUES ((SELECT NEXTVAL('hibernate_sequence')), '$TMP_ENCODED');
+      INSERT INTO apikey_roles(apikey_id,role)
+        SELECT id, role FROM apikey, (VALUES ('XROAD_SYSTEM_ADMINISTRATOR'),('XROAD_SECURITY_OFFICER')) AS r(role)
+        WHERE encodedkey = '$TMP_ENCODED';
+    " 2>/dev/null
+
+    AUTH="Authorization: X-Road-ApiKey token=${TMP_TOKEN}"
+    for i in $(seq 1 30); do
+      RESP=$(curl -sk -o /dev/null -w "%{http_code}" "${API_URL}/tokens" -H "$AUTH" 2>/dev/null)
+      [ "$RESP" = "200" ] && break
+      sleep 2
+    done
+
+    if echo "$TOKEN_INFO" | grep -q "NOT_INITIALIZED"; then
+      echo "autologin: initializing token..."
+      INSTANCE=$(cat /etc/xroad/globalconf/instance-identifier 2>/dev/null || echo "CSEKS")
+      ADDR=$(curl -sk "${API_URL}/initialization/status" -H "$AUTH" 2>/dev/null | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('central_server_address',''))" 2>/dev/null)
+      [ -z "$ADDR" ] && ADDR="cs-eks.interno.xvia"
+      curl -sk -X POST "${API_URL}/initialization" -H "$AUTH" -H "Content-Type: application/json" \
+        -d "{\"software_token_pin\":\"$PIN\",\"instance_identifier\":\"$INSTANCE\",\"central_server_address\":\"$ADDR\"}" 2>/dev/null
+      echo ""
+      echo "autologin: token initialized and logged in"
+    else
+      echo "autologin: logging in token..."
+      curl -sk -X PUT "${API_URL}/tokens/0/login" -H "$AUTH" -H "Content-Type: application/json" \
+        -d "{\"password\":\"$PIN\"}" 2>/dev/null
+      echo ""
+      echo "autologin: login done"
+    fi
+
+    # Cleanup temp key
+    PGOPTIONS="${PGOPTIONS_EXTRA-}" PGDATABASE="$db_database" PGUSER="$db_user" PGPASSWORD="$db_password" psql -h "${PGHOST:-$db_host}" -p "${PGPORT:-$db_port}" -qtA -c "
+      DELETE FROM apikey_roles WHERE apikey_id = (SELECT id FROM apikey WHERE encodedkey = '$TMP_ENCODED');
+      DELETE FROM apikey WHERE encodedkey = '$TMP_ENCODED';
+    " 2>/dev/null
+    exit 0

--- a/sidecar/kubernetes/Central-server/leia-me
+++ b/sidecar/kubernetes/Central-server/leia-me
@@ -1,0 +1,8 @@
+Versao NIIS 
+
+Criar a versão do Central X-Road e realizar os testes
+
+versão X-Via Validado
+
+183619025107.dkr.ecr.sa-east-1.amazonaws.com/xroad-central-server:7.8.0
+

--- a/sidecar/kubernetes/Central-server/port-forward.sh
+++ b/sidecar/kubernetes/Central-server/port-forward.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+# shellcheck source=./_common.sh
+source "${BASH_SOURCE%/*}/_common.sh"
+
+ENV_NAME="dev"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--env=dev|test|eks]
+
+Start async kubectl port-forwards for the given environment. Writes child PIDs
+to .state/port-forwards-<env>.pid so delete-env.sh can reap them.
+EOF
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env=*) ENV_NAME="${1#*=}" ;;
+    -h|--help) usage 0 ;;
+    *) log_error "Unknown parameter: $1"; usage ;;
+  esac
+  shift
+done
+validate_env_arg "${ENV_NAME}" || exit 1
+
+run_ansible_playbook playbooks/port_forward.yml \
+  -i "$(inventory_path_for "${ENV_NAME}")" \
+  -e "env_name=${ENV_NAME}" \
+  -e "state_dir=${STATE_DIR}"

--- a/sidecar/kubernetes/README.md
+++ b/sidecar/kubernetes/README.md
@@ -4,11 +4,18 @@ This directory contains Kubernetes manifests for deploying the X-Road Security S
 
 ## Deployment Variants
 
-| Manifest | Database | Secrets | Use Case |
-|----------|----------|---------|----------|
-| `security-server-sidecar.yaml` | Local (embedded) | Inline values | Development / testing |
-| `security-server-sidecar-slim.yaml` | Local (embedded) | Inline values | Development / testing (slim image) |
-| `security-server-sidecar-external-db.yaml` | External (RDS, Cloud SQL, etc.) | Kubernetes Secrets | Production |
+| Manifest | Image | Database | Secrets | Use Case |
+|----------|-------|----------|---------|----------|
+| `security-server-sidecar-local.yaml` | Configurable (`{{IMAGE_TAG}}`) | External (template placeholders) | Inline values | CI / automated testing with `.yaml.template` scripts |
+| `security-server-sidecar.yaml` | Full (`8.0.0`) | External (template placeholders) | Inline values | Development / testing (full image) |
+| `security-server-sidecar-slim.yaml` | Slim (`8.0.0-slim`) | External (template placeholders) | Inline values | Development / testing (slim image) |
+| `security-server-sidecar-external-db.yaml` | Full | External (RDS, Cloud SQL, etc.) | Kubernetes Secrets | Production |
+
+> **Note:** The `security-server-sidecar.yaml`, `security-server-sidecar-slim.yaml`, and
+> `security-server-sidecar-local.yaml` manifests contain `{{...}}` template placeholders
+> that must be replaced before deployment — either manually or using the companion
+> `.yaml.template` scripts. For production use with proper secrets management, use
+> `security-server-sidecar-external-db.yaml`.
 
 ## Production Deployment with External Database
 
@@ -150,6 +157,7 @@ kubectl rollout status deployment/security-server-sidecar --timeout=300s
 
 ## Other Files
 
-- `security-server-sidecar-local.yaml` — Local database variant (for development)
+- `security-server-sidecar.yaml.template` — Shell script to render `security-server-sidecar.yaml` with provided values
+- `security-server-sidecar-slim.yaml.template` — Shell script to render the slim variant with provided values
 - `grant-user-access-to-cluster.sh` — Helper script for cluster RBAC
 - `testRequest.xml` — Sample X-Road SOAP request for testing

--- a/sidecar/kubernetes/README.md
+++ b/sidecar/kubernetes/README.md
@@ -1,0 +1,155 @@
+# X-Road Security Server Sidecar - Kubernetes Deployment
+
+This directory contains Kubernetes manifests for deploying the X-Road Security Server Sidecar.
+
+## Deployment Variants
+
+| Manifest | Database | Secrets | Use Case |
+|----------|----------|---------|----------|
+| `security-server-sidecar.yaml` | Local (embedded) | Inline values | Development / testing |
+| `security-server-sidecar-slim.yaml` | Local (embedded) | Inline values | Development / testing (slim image) |
+| `security-server-sidecar-external-db.yaml` | External (RDS, Cloud SQL, etc.) | Kubernetes Secrets | Production |
+
+## Production Deployment with External Database
+
+For production environments, use an external managed database (e.g., AWS RDS, Azure Database
+for PostgreSQL, Google Cloud SQL) for better reliability, backups, and scaling.
+
+### Prerequisites
+
+- Kubernetes 1.24+
+- External PostgreSQL 14+ with network access from the cluster
+- [External Secrets Operator](https://external-secrets.io) (recommended) or manually created Kubernetes Secrets
+
+### Quick Start
+
+1. **Set up secrets** — choose one method:
+
+   **Option A: External Secrets Operator (recommended for cloud)**
+   ```bash
+   # Edit external-secrets-example.yaml with your secret paths
+   kubectl apply -f external-secrets-example.yaml
+   ```
+
+   **Option B: Manual Kubernetes Secrets**
+   ```bash
+   kubectl create secret generic sidecar-db-credentials \
+     --from-literal=username=postgres \
+     --from-literal=password='your-db-password'
+
+   kubectl create secret generic sidecar-admin-credentials \
+     --from-literal=admin-user=xrd \
+     --from-literal=admin-password='your-admin-password' \
+     --from-literal=token-pin='your-token-pin'
+   ```
+
+2. **Edit the deployment manifest:**
+   ```bash
+   # Update XROAD_DB_HOST with your database endpoint
+   vi security-server-sidecar-external-db.yaml
+   ```
+
+3. **Deploy:**
+   ```bash
+   kubectl apply -f security-server-sidecar-external-db.yaml
+   kubectl rollout status deployment/security-server-sidecar --timeout=300s
+   ```
+
+4. **Access admin UI:**
+   ```bash
+   kubectl port-forward svc/security-server-sidecar-admin 4000:4000
+   # Open https://localhost:4000
+   ```
+
+### Database Setup
+
+The Sidecar entrypoint automatically creates the required databases and schemas on the
+external PostgreSQL instance. The user specified in `XROAD_DB_PWD` must have privileges
+to create databases and roles. Typically this is the master/admin user of the managed database.
+
+The following databases are created automatically:
+- `serverconf` (or `{XROAD_DATABASE_NAME}_serverconf`)
+- `messagelog` (if messagelog addon is installed)
+- `op-monitor` (if opmonitor addon is installed)
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `XROAD_TOKEN_PIN` | Yes | PIN code for the software token |
+| `XROAD_ADMIN_USER` | Yes | Admin UI username |
+| `XROAD_ADMIN_PASSWORD` | Yes | Admin UI password |
+| `XROAD_ADMIN_PWD_HASH` | No | Alternative: pre-hashed password (SHA-512). Overrides `XROAD_ADMIN_PASSWORD` |
+| `XROAD_DB_HOST` | Yes | External database hostname |
+| `XROAD_DB_PORT` | No | Database port (default: 5432) |
+| `XROAD_DB_PWD` | Yes | Database superuser password |
+| `XROAD_DATABASE_NAME` | No | Database name prefix (default: serverconf) |
+| `XROAD_TOKEN_<id>_PIN` | No | PIN for additional hardware tokens (v7.8+) |
+| `XROAD_PROXY_UI_API_ACME_CHALLENGE_PORT` | No | Custom ACME HTTP challenge port (v7.8+) |
+| `XROAD_LOG_LEVEL` | No | Log level: ALL, DEBUG, INFO, WARN, ERROR, OFF |
+
+### Probes Configuration
+
+The external database manifest includes readiness and liveness probes tuned for production:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /
+    port: 4000
+    scheme: HTTPS
+  initialDelaySeconds: 120    # Sidecar needs time for DB migration
+  periodSeconds: 10
+  failureThreshold: 20
+livenessProbe:
+  httpGet:
+    path: /
+    port: 4000
+    scheme: HTTPS
+  initialDelaySeconds: 200    # Allow full startup before killing
+  periodSeconds: 30
+  failureThreshold: 10
+```
+
+**Important:** The Sidecar requires significant startup time (90-180 seconds) for database
+migrations and service initialization. Setting `initialDelaySeconds` too low will cause
+restart loops.
+
+### Resource Recommendations
+
+| Workload | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|----------|-------------|-----------|----------------|--------------|
+| Light (< 10 req/s) | 250m | 1000m | 768Mi | 2Gi |
+| Medium (10-100 req/s) | 500m | 2000m | 1Gi | 3Gi |
+| Heavy (> 100 req/s) | 1000m | 4000m | 2Gi | 4Gi |
+
+### Security Considerations
+
+- **Never expose port 4000 (admin UI) to the internet.** Use `ClusterIP` service or
+  internal load balancer for admin access.
+- **Never store credentials in plain text** in manifest files. Use Kubernetes Secrets
+  or External Secrets Operator.
+- **Enable SSL** for database connections. Set `sslmode=require` in your database
+  configuration if supported.
+- **Drop NET_RAW capability** as shown in the manifests to reduce container attack surface.
+
+### Upgrading
+
+When upgrading the Sidecar image version, the entrypoint automatically runs database
+migrations. Ensure the PVC (`sidecar-config-claim`) is retained between deployments
+to preserve configuration and certificates.
+
+```bash
+# Update image version
+kubectl set image deployment/security-server-sidecar \
+  security-server-sidecar=niis/xroad-security-server-sidecar:7.8.0
+
+# Monitor rollout
+kubectl rollout status deployment/security-server-sidecar --timeout=300s
+```
+
+## Other Files
+
+- `security-server-sidecar-local.yaml` — Local database variant (for development)
+- `grant-user-access-to-cluster.sh` — Helper script for cluster RBAC
+- `testRequest.xml` — Sample X-Road SOAP request for testing

--- a/sidecar/kubernetes/ca/ca-eks.yaml
+++ b/sidecar/kubernetes/ca/ca-eks.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-ca-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=false
+spec:
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+    - "10.0.0.0/8"
+    - "192.168.0.0/16"
+  selector:
+    run: server-ca
+  ports:
+    - port: 8888
+      targetPort: 8888
+      protocol: TCP
+      name: ca
+    - port: 8899
+      targetPort: 8899
+      protocol: TCP
+      name: tsa
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ca-data-pvc
+  namespace: sidecar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-ca
+  namespace: sidecar
+spec:
+  selector:
+    matchLabels:
+      run: server-ca
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        run: server-ca
+    spec:
+      serviceAccountName: xroad-ca-sa
+      automountServiceAccountToken: false
+      initContainers:
+        - name: init-ca-data
+          image: security-server-sidecar-ca{{IMAGE_TAG}}
+          command: ['sh', '-c']
+          args:
+            - |
+              # Se já inicializado, apenas garantir permissões
+              if [ -f /ca-persistent/.init ]; then
+                echo "CA already initialized, fixing permissions..."
+                chown -R 1001:1001 /ca-persistent
+                exit 0
+              fi
+              # Primeira vez: limpar PVC e copiar scripts da imagem
+              echo "First run: initializing CA on persistent volume..."
+              rm -rf /ca-persistent/certs /ca-persistent/lost+found 2>/dev/null || true
+              cp -a /home/ca/CA/* /ca-persistent/ 2>/dev/null || true
+              chown -R 1001:1001 /ca-persistent
+              # Executar init.sh como user ca para gerar certificados
+              cd /ca-persistent && su -s /bin/bash ca -c './init.sh'
+              # Copiar certs publicados
+              mkdir -p /home/ca/certs 2>/dev/null || true
+              cp /ca-persistent/certs/ca.cert.pem /home/ca/certs/ca.pem 2>/dev/null || true
+              cp /ca-persistent/certs/ocsp.cert.pem /home/ca/certs/ocsp.pem 2>/dev/null || true
+              cp /ca-persistent/certs/tsa.cert.pem /home/ca/certs/tsa.pem 2>/dev/null || true
+              echo "CA initialization complete."
+          volumeMounts:
+            - name: ca-data
+              mountPath: /ca-persistent
+      containers:
+        - name: server-ca
+          image: 183619025107.dkr.ecr.sa-east-1.amazonaws.com/xroad-ca:7.8.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8888
+              protocol: TCP
+            - containerPort: 8899
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: ca-data
+              mountPath: /home/ca/CA
+          livenessProbe:
+            tcpSocket:
+              port: 8888
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 8888
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: ca-data
+          persistentVolumeClaim:
+            claimName: ca-data-pvc

--- a/sidecar/kubernetes/external-secrets-example.yaml
+++ b/sidecar/kubernetes/external-secrets-example.yaml
@@ -1,0 +1,108 @@
+# X-Road Security Server Sidecar - External Secrets Integration
+#
+# This manifest shows how to use the External Secrets Operator to sync
+# credentials from a cloud secrets manager into Kubernetes Secrets.
+#
+# Supported backends: AWS Secrets Manager, Azure Key Vault,
+# Google Secret Manager, HashiCorp Vault, and others.
+#
+# Prerequisites:
+# - External Secrets Operator installed (https://external-secrets.io)
+# - ClusterSecretStore configured for your secrets backend
+#
+# Install External Secrets Operator:
+#   helm repo add external-secrets https://charts.external-secrets.io
+#   helm install external-secrets external-secrets/external-secrets -n external-secrets --create-namespace
+#
+
+---
+# Example: AWS Secrets Manager with IRSA (IAM Roles for Service Accounts)
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa
+            namespace: external-secrets
+
+---
+# Database credentials (e.g., RDS managed secret)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sidecar-db-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: sidecar-db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: your/rds/secret/path
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: your/rds/secret/path
+        property: password
+
+---
+# Admin and token credentials
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sidecar-admin-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: sidecar-admin-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-user
+      remoteRef:
+        key: your/xroad/admin/secret/path
+        property: admin_user
+    - secretKey: admin-password
+      remoteRef:
+        key: your/xroad/admin/secret/path
+        property: admin_password
+    - secretKey: token-pin
+      remoteRef:
+        key: your/xroad/admin/secret/path
+        property: token_pin
+
+---
+# Alternative: plain Kubernetes Secret (for non-cloud environments)
+# Uncomment and use this instead of ExternalSecrets if you manage secrets manually.
+#
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: sidecar-db-credentials
+# type: Opaque
+# stringData:
+#   username: "postgres"
+#   password: "your-secure-password"
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: sidecar-admin-credentials
+# type: Opaque
+# stringData:
+#   admin-user: "xrd"
+#   admin-password: "your-secure-admin-password"
+#   token-pin: "your-secure-token-pin"

--- a/sidecar/kubernetes/security-server-sidecar-external-db.yaml
+++ b/sidecar/kubernetes/security-server-sidecar-external-db.yaml
@@ -1,0 +1,162 @@
+# X-Road Security Server Sidecar - External Database Deployment
+#
+# This manifest deploys the Security Server Sidecar with an external PostgreSQL
+# database (e.g., AWS RDS, Azure Database for PostgreSQL, Google Cloud SQL).
+#
+# Prerequisites:
+# - External PostgreSQL 14+ accessible from the cluster
+# - Kubernetes Secret "sidecar-db-credentials" with database credentials
+# - Kubernetes Secret "sidecar-admin-credentials" with admin and token credentials
+#
+# See external-secrets-example.yaml for automated secret management with
+# AWS Secrets Manager, Azure Key Vault, or Google Secret Manager.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sidecar-config-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: security-server-sidecar
+  labels:
+    run: security-server-sidecar
+spec:
+  type: LoadBalancer
+  selector:
+    run: security-server-sidecar
+  ports:
+    - port: 5500
+      targetPort: 5500
+      protocol: TCP
+      name: messaging
+    - port: 5577
+      targetPort: 5577
+      protocol: TCP
+      name: ocsp
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: consumer-http
+    - port: 8443
+      targetPort: 8443
+      protocol: TCP
+      name: consumer-https
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: security-server-sidecar-admin
+  labels:
+    run: security-server-sidecar
+  annotations:
+    # For AWS EKS: use internal NLB for admin UI
+    # service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    # service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+spec:
+  type: ClusterIP
+  selector:
+    run: security-server-sidecar
+  ports:
+    - port: 4000
+      targetPort: 4000
+      protocol: TCP
+      name: admin-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: security-server-sidecar
+spec:
+  selector:
+    matchLabels:
+      run: security-server-sidecar
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: security-server-sidecar
+    spec:
+      volumes:
+        - name: sidecar-config-volume
+          persistentVolumeClaim:
+            claimName: sidecar-config-claim
+      containers:
+        - name: security-server-sidecar
+          image: niis/xroad-security-server-sidecar:7.8.0
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: sidecar-config-volume
+              mountPath: /etc/xroad/
+          securityContext:
+            capabilities:
+              drop: ["NET_RAW"]
+          env:
+            # --- Token PIN (from secret) ---
+            - name: XROAD_TOKEN_PIN
+              valueFrom:
+                secretKeyRef:
+                  name: sidecar-admin-credentials
+                  key: token-pin
+            # --- Admin user credentials (from secret) ---
+            - name: XROAD_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: sidecar-admin-credentials
+                  key: admin-user
+            - name: XROAD_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sidecar-admin-credentials
+                  key: admin-password
+            # --- External database configuration ---
+            - name: XROAD_DB_HOST
+              value: "your-db-host.region.rds.amazonaws.com"
+            - name: XROAD_DB_PORT
+              value: "5432"
+            - name: XROAD_DB_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: sidecar-db-credentials
+                  key: password
+            - name: XROAD_DATABASE_NAME
+              value: "serverconf"
+            # --- Optional: log level ---
+            - name: XROAD_LOG_LEVEL
+              value: "INFO"
+          ports:
+            - containerPort: 4000
+            - containerPort: 5500
+            - containerPort: 5577
+            - containerPort: 8080
+            - containerPort: 8443
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 3Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              scheme: HTTPS
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4000
+              scheme: HTTPS
+            initialDelaySeconds: 200
+            periodSeconds: 30
+            failureThreshold: 10


### PR DESCRIPTION
## Summary

Add documentation and example manifests for deploying the Security Server Sidecar with an external PostgreSQL database (e.g., AWS RDS, Cloud SQL).

## New files

- `sidecar/kubernetes/README.md`: Comprehensive deployment guide covering external DB setup, secrets management, probes, resource recommendations, and security considerations
- `sidecar/kubernetes/security-server-sidecar-external-db.yaml`: Production-ready manifest with external DB, Kubernetes Secrets references, probes, and resources
- `sidecar/kubernetes/external-secrets-example.yaml`: Integration example with External Secrets Operator for automated secret synchronization from cloud providers (AWS Secrets Manager, Azure Key Vault, Google Secret Manager, HashiCorp Vault)

## Motivation

Production deployments of the Security Server Sidecar require an external managed database for reliability, automated backups, and scaling. The existing manifests only cover local/embedded database scenarios. This documentation fills the gap for production Kubernetes deployments.

## References

- XRDDEV-3020
- XRDDEV-2919

## Testing

- Manifests validated with `kubectl apply --dry-run=client`
- Deployed and verified against AWS RDS PostgreSQL 14+