### PR TITLE
fix(cs-admin): fix auto-approve SUBMITTED_FOR_APPROVAL requests

### DIFF
--- a/src/central-server/admin-service/api-test/src/intTest/java/org/niis/xroad/cs/test/api/managementrequests/ManagementRequestsApiTest.java
+++ b/src/central-server/admin-service/api-test/src/intTest/java/org/niis/xroad/cs/test/api/managementrequests/ManagementRequestsApiTest.java
@@ -200,7 +200,7 @@ class ManagementRequestsApiTest extends CsApiTest {
     }
 
     @Test
-    void autoApproveAuthCert(CsBaselineSeeder seeder) throws Exception {
+    void pairedAuthCertRegistrationRequiresApproval(CsBaselineSeeder seeder) throws Exception {
         var session = Step.given("admin session opened", seeder::newSession);
         var roSession = Step.given("registration officer session opened", seeder::newRegistrationOfficerSession);
         var memberId = Step.given("member seeded", () -> seeder.seedMember(session, "mr04", MEMBER_CLASS));
@@ -224,11 +224,17 @@ class ManagementRequestsApiTest extends CsApiTest {
             req.setOrigin(ManagementRequestOriginDto.SECURITY_SERVER);
             req.setSecurityServerId(serverId);
             return client.addManagementRequest(req)
-                    .statusCode(201)
+                    .statusCode(202)
                     .extract().jsonPath().getInt("id");
         });
 
-        Step.then("SECURITY_SERVER request is auto-approved", () ->
+        Step.then("SECURITY_SERVER request is SUBMITTED_FOR_APPROVAL", () ->
+                roClient.getRequest(id2).statusCode(200).body("status", equalTo("SUBMITTED FOR APPROVAL")));
+
+        Step.when("request is approved", () ->
+                client.approveRequest(id2).statusCode(200));
+
+        Step.then("SECURITY_SERVER request is APPROVED", () ->
                 roClient.getRequest(id2).statusCode(200).body("status", equalTo("APPROVED")));
 
         Step.then("server has one auth cert", () ->
@@ -447,7 +453,7 @@ class ManagementRequestsApiTest extends CsApiTest {
     }
 
     @Test
-    void autoApproveRegistrationOfMemberAsSSClient(CsBaselineSeeder seeder) {
+    void pairedRegistrationOfMemberAsSSClientRequiresApproval(CsBaselineSeeder seeder) {
         var session = Step.given("admin session opened", seeder::newSession);
         var roSession = Step.given("registration officer session opened", seeder::newRegistrationOfficerSession);
         var memberId = Step.given("owner member seeded", () -> seeder.seedMember(session, "mr11", MEMBER_CLASS));
@@ -475,10 +481,16 @@ class ManagementRequestsApiTest extends CsApiTest {
             req.setOrigin(ManagementRequestOriginDto.SECURITY_SERVER);
             req.setSecurityServerId(serverId);
             return client.addManagementRequest(req)
-                    .statusCode(201).extract().jsonPath().getInt("id");
+                    .statusCode(202).extract().jsonPath().getInt("id");
         });
 
-        Step.then("SECURITY_SERVER request is auto-approved", () ->
+        Step.then("SECURITY_SERVER request is SUBMITTED_FOR_APPROVAL", () ->
+                roClient.getRequest(id2).statusCode(200).body("status", equalTo("SUBMITTED FOR APPROVAL")));
+
+        Step.when("request is approved", () ->
+                client.approveRequest(id2).statusCode(200));
+
+        Step.then("SECURITY_SERVER request is APPROVED", () ->
                 roClient.getRequest(id2).statusCode(200).body("status", equalTo("APPROVED")));
 
         Step.then("server clients contains mr11m2", () ->
@@ -744,7 +756,7 @@ class ManagementRequestsApiTest extends CsApiTest {
     }
 
     @Test
-    void autoApproveRegistrationOfSubsystemAsSSClient(CsBaselineSeeder seeder) {
+    void pairedRegistrationOfSubsystemAsSSClientRequiresApproval(CsBaselineSeeder seeder) {
         var session = Step.given("admin session opened", seeder::newSession);
         var roSession = Step.given("registration officer session opened", seeder::newRegistrationOfficerSession);
         var memberId = Step.given("owner member seeded", () -> seeder.seedMember(session, "mr19", MEMBER_CLASS));
@@ -773,10 +785,16 @@ class ManagementRequestsApiTest extends CsApiTest {
             req.setOrigin(ManagementRequestOriginDto.SECURITY_SERVER);
             req.setSecurityServerId(serverId);
             return client.addManagementRequest(req)
-                    .statusCode(201).extract().jsonPath().getInt("id");
+                    .statusCode(202).extract().jsonPath().getInt("id");
         });
 
-        Step.then("SECURITY_SERVER request is auto-approved", () ->
+        Step.then("SECURITY_SERVER request is SUBMITTED_FOR_APPROVAL", () ->
+                roClient.getRequest(id2).statusCode(200).body("status", equalTo("SUBMITTED FOR APPROVAL")));
+
+        Step.when("request is approved", () ->
+                client.approveRequest(id2).statusCode(200));
+
+        Step.then("SECURITY_SERVER request is APPROVED", () ->
                 roClient.getRequest(id2).statusCode(200).body("status", equalTo("APPROVED")));
 
         Step.then("server clients contains member", () ->

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandler.java
@@ -163,8 +163,7 @@ public class AuthenticationCertificateRegistrationRequestHandler implements
     }
 
     public boolean canAutoApprove(AuthenticationCertificateRegistrationRequest request) {
-        return (managementServiceConfigProperties.isAutoApproveAuthCertRegRequests()
-                || request.getProcessingStatus().equals(SUBMITTED_FOR_APPROVAL))
+        return managementServiceConfigProperties.isAutoApproveAuthCertRegRequests()
                 && request.getOrigin() == SECURITY_SERVER
                 && members.count(request.getSecurityServerId().getOwner()) > 0;
     }

--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandler.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandler.java
@@ -89,8 +89,7 @@ public class ClientRegistrationRequestHandler implements RequestHandler<ClientRe
 
     @Override
     public boolean canAutoApprove(ClientRegistrationRequest request) {
-        return (managementServiceConfigProperties.isAutoApproveClientRegRequests()
-                || request.getProcessingStatus().equals(SUBMITTED_FOR_APPROVAL))
+        return managementServiceConfigProperties.isAutoApproveClientRegRequests()
                 && request.getOrigin() == SECURITY_SERVER
                 && servers.count(request.getSecurityServerId()) > 0
                 && members.findMember(request.getClientId()).isPresent();

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandlerTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/AuthenticationCertificateRegistrationRequestHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.niis.xroad.cs.admin.core.service.managementrequest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.common.identifiers.jpa.entity.SecurityServerIdEntity;
+import org.niis.xroad.cs.admin.api.domain.AuthenticationCertificateRegistrationRequest;
+import org.niis.xroad.cs.admin.api.domain.SecurityServerId;
+import org.niis.xroad.cs.admin.api.service.GlobalGroupMemberService;
+import org.niis.xroad.cs.admin.core.config.ManagementServiceConfigProperties;
+import org.niis.xroad.cs.admin.core.entity.XRoadMemberEntity;
+import org.niis.xroad.cs.admin.core.entity.mapper.RequestMapper;
+import org.niis.xroad.cs.admin.core.repository.AuthCertRepository;
+import org.niis.xroad.cs.admin.core.repository.AuthenticationCertificateRegistrationRequestRepository;
+import org.niis.xroad.cs.admin.core.repository.IdentifierRepository;
+import org.niis.xroad.cs.admin.core.repository.SecurityServerClientRepository;
+import org.niis.xroad.cs.admin.core.repository.SecurityServerRepository;
+import org.niis.xroad.globalconf.GlobalConfProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.niis.xroad.cs.admin.api.domain.ManagementRequestStatus.SUBMITTED_FOR_APPROVAL;
+import static org.niis.xroad.cs.admin.api.domain.Origin.CENTER;
+import static org.niis.xroad.cs.admin.api.domain.Origin.SECURITY_SERVER;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationCertificateRegistrationRequestHandlerTest {
+
+    private static final String INSTANCE = "CS";
+    private static final String MEMBER_CLASS = "MEMBER-CLASS";
+    private static final String MEMBER_CODE = "MEMBER-CODE";
+    private static final String SERVER_CODE = "SERVER-CODE";
+
+    private final GlobalConfProvider globalConfProvider = mock(GlobalConfProvider.class);
+    private final IdentifierRepository<SecurityServerIdEntity> serverIds = mock(IdentifierRepository.class);
+    private final SecurityServerClientRepository<XRoadMemberEntity> members = mock(SecurityServerClientRepository.class);
+    private final AuthenticationCertificateRegistrationRequestRepository authCertReqRequests =
+            mock(AuthenticationCertificateRegistrationRequestRepository.class);
+    private final AuthCertRepository authCerts = mock(AuthCertRepository.class);
+    private final SecurityServerRepository servers = mock(SecurityServerRepository.class);
+    private final GlobalGroupMemberService groupMemberService = mock(GlobalGroupMemberService.class);
+    private final RequestMapper requestMapper = mock(RequestMapper.class);
+    private final MemberHelper memberHelper = mock(MemberHelper.class);
+    private final ManagementServiceConfigProperties managementServiceConfigProperties = mock(ManagementServiceConfigProperties.class);
+
+    private final AuthenticationCertificateRegistrationRequestHandler handler = new AuthenticationCertificateRegistrationRequestHandler(
+            globalConfProvider, serverIds, members, authCertReqRequests, authCerts, servers, groupMemberService, requestMapper,
+            memberHelper, managementServiceConfigProperties);
+
+    private final SecurityServerId securityServerId = SecurityServerId.create(INSTANCE, MEMBER_CLASS, MEMBER_CODE, SERVER_CODE);
+
+    @Test
+    void canAutoApproveFalseWhenSubmittedForApprovalAndFlagDisabled() {
+        when(managementServiceConfigProperties.isAutoApproveAuthCertRegRequests()).thenReturn(false);
+        lenient().when(members.count(securityServerId.getOwner())).thenReturn(1L);
+
+        final AuthenticationCertificateRegistrationRequest request =
+                new AuthenticationCertificateRegistrationRequest(SECURITY_SERVER, securityServerId);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isFalse();
+    }
+
+    @Test
+    void canAutoApproveTrueWhenFlagEnabledAndPreconditionsMet() {
+        when(managementServiceConfigProperties.isAutoApproveAuthCertRegRequests()).thenReturn(true);
+        when(members.count(securityServerId.getOwner())).thenReturn(1L);
+
+        final AuthenticationCertificateRegistrationRequest request =
+                new AuthenticationCertificateRegistrationRequest(SECURITY_SERVER, securityServerId);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isTrue();
+    }
+
+    @Test
+    void canAutoApproveFalseWhenOriginIsCenter() {
+        when(managementServiceConfigProperties.isAutoApproveAuthCertRegRequests()).thenReturn(true);
+
+        final AuthenticationCertificateRegistrationRequest request =
+                new AuthenticationCertificateRegistrationRequest(CENTER, securityServerId);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isFalse();
+    }
+}

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandlerTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/managementrequest/ClientRegistrationRequestHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.niis.xroad.cs.admin.core.service.managementrequest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.common.identifiers.jpa.entity.ClientIdEntity;
+import org.niis.xroad.common.identifiers.jpa.entity.SecurityServerIdEntity;
+import org.niis.xroad.cs.admin.api.domain.ClientId;
+import org.niis.xroad.cs.admin.api.domain.ClientRegistrationRequest;
+import org.niis.xroad.cs.admin.api.domain.MemberId;
+import org.niis.xroad.cs.admin.api.domain.SecurityServerId;
+import org.niis.xroad.cs.admin.core.config.ManagementServiceConfigProperties;
+import org.niis.xroad.cs.admin.core.entity.SecurityServerClientEntity;
+import org.niis.xroad.cs.admin.core.entity.XRoadMemberEntity;
+import org.niis.xroad.cs.admin.core.entity.mapper.RequestMapper;
+import org.niis.xroad.cs.admin.core.repository.ClientRegistrationRequestRepository;
+import org.niis.xroad.cs.admin.core.repository.IdentifierRepository;
+import org.niis.xroad.cs.admin.core.repository.SecurityServerClientRepository;
+import org.niis.xroad.cs.admin.core.repository.SecurityServerRepository;
+import org.niis.xroad.cs.admin.core.repository.ServerClientRepository;
+import org.niis.xroad.cs.admin.core.repository.XRoadMemberRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.niis.xroad.cs.admin.api.domain.ManagementRequestStatus.SUBMITTED_FOR_APPROVAL;
+import static org.niis.xroad.cs.admin.api.domain.Origin.CENTER;
+import static org.niis.xroad.cs.admin.api.domain.Origin.SECURITY_SERVER;
+
+@ExtendWith(MockitoExtension.class)
+class ClientRegistrationRequestHandlerTest {
+
+    private static final String INSTANCE = "CS";
+    private static final String MEMBER_CLASS = "MEMBER-CLASS";
+    private static final String MEMBER_CODE = "MEMBER-CODE";
+    private static final String SERVER_CODE = "SERVER-CODE";
+
+    private final IdentifierRepository<SecurityServerIdEntity> serverIds = mock(IdentifierRepository.class);
+    private final IdentifierRepository<ClientIdEntity> clientIds = mock(IdentifierRepository.class);
+    private final XRoadMemberRepository members = mock(XRoadMemberRepository.class);
+    private final SecurityServerClientRepository<SecurityServerClientEntity> clients = mock(SecurityServerClientRepository.class);
+    private final ClientRegistrationRequestRepository clientRegRequests = mock(ClientRegistrationRequestRepository.class);
+    private final SecurityServerRepository servers = mock(SecurityServerRepository.class);
+    private final ServerClientRepository serverClientRepository = mock(ServerClientRepository.class);
+    private final RequestMapper requestMapper = mock(RequestMapper.class);
+    private final MemberHelper memberHelper = mock(MemberHelper.class);
+    private final ManagementServiceConfigProperties managementServiceConfigProperties = mock(ManagementServiceConfigProperties.class);
+
+    private final ClientRegistrationRequestHandler handler = new ClientRegistrationRequestHandler(
+            serverIds, clientIds, members, clients, clientRegRequests, servers, serverClientRepository, requestMapper,
+            memberHelper, managementServiceConfigProperties);
+
+    private final SecurityServerId securityServerId = SecurityServerId.create(INSTANCE, MEMBER_CLASS, MEMBER_CODE, SERVER_CODE);
+    private final ClientId clientId = MemberId.create(INSTANCE, "OTHER-MEMBER-CLASS", "OTHER-MEMBER-CODE");
+
+    @Test
+    void canAutoApproveFalseWhenSubmittedForApprovalAndFlagDisabled() {
+        when(managementServiceConfigProperties.isAutoApproveClientRegRequests()).thenReturn(false);
+        lenient().when(servers.count(securityServerId)).thenReturn(1L);
+        lenient().when(members.findMember(clientId)).thenReturn(Optional.of(mock(XRoadMemberEntity.class)));
+
+        final ClientRegistrationRequest request = new ClientRegistrationRequest(SECURITY_SERVER, securityServerId, clientId, null);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isFalse();
+    }
+
+    @Test
+    void canAutoApproveTrueWhenFlagEnabledAndPreconditionsMet() {
+        when(managementServiceConfigProperties.isAutoApproveClientRegRequests()).thenReturn(true);
+        when(servers.count(securityServerId)).thenReturn(1L);
+        when(members.findMember(clientId)).thenReturn(Optional.of(mock(XRoadMemberEntity.class)));
+
+        final ClientRegistrationRequest request = new ClientRegistrationRequest(SECURITY_SERVER, securityServerId, clientId, null);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isTrue();
+    }
+
+    @Test
+    void canAutoApproveFalseWhenOriginIsCenter() {
+        when(managementServiceConfigProperties.isAutoApproveClientRegRequests()).thenReturn(true);
+
+        final ClientRegistrationRequest request = new ClientRegistrationRequest(CENTER, securityServerId, clientId, null);
+        request.setProcessingStatus(SUBMITTED_FOR_APPROVAL);
+
+        assertThat(handler.canAutoApprove(request)).isFalse();
+    }
+}


### PR DESCRIPTION
CS registration handlers no longer treat a paired (SUBMITTED_FOR_APPROVAL) CENTER + SECURITY_SERVER request as auto-approvable — auto-approval now always requires the corresponding auto-approve-*-reg-requests flag

Refs: XRDDEV-3266