### PR TITLE
fix(cs-admin): resolve subsystem registration status from latest request

### DIFF
--- a/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImpl.java
+++ b/src/central-server/admin-service/core/src/main/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImpl.java
@@ -127,7 +127,7 @@ public class SecurityServerServiceImpl implements SecurityServerService {
                                 .serverId(serverId)
                                 .clientId(clientId)
                                 .types(List.of(ManagementRequestType.CLIENT_REGISTRATION_REQUEST))
-                                .build(), PageRequestDto.unpaged())
+                                .build(), latestRequestPage())
                 .stream()
                 .map(ManagementRequestView::getStatus)
                 .findFirst()
@@ -147,6 +147,15 @@ public class SecurityServerServiceImpl implements SecurityServerService {
         }
 
         return managementRequestStatus;
+    }
+
+    private static PageRequestDto latestRequestPage() {
+        return PageRequestDto.builder()
+                .jpaSort("id")
+                .desc(true)
+                .limit(1)
+                .offset(0)
+                .build();
     }
 
     @Override

--- a/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImplTest.java
+++ b/src/central-server/admin-service/core/src/test/java/org/niis/xroad/cs/admin/core/service/SecurityServerServiceImplTest.java
@@ -53,6 +53,7 @@ import org.niis.xroad.cs.admin.api.domain.Request;
 import org.niis.xroad.cs.admin.api.domain.SecurityServer;
 import org.niis.xroad.cs.admin.api.dto.SecurityServerAuthenticationCertificateDetails;
 import org.niis.xroad.cs.admin.api.paging.Page;
+import org.niis.xroad.cs.admin.api.paging.PageRequestDto;
 import org.niis.xroad.cs.admin.api.service.ClientService;
 import org.niis.xroad.cs.admin.api.service.GlobalGroupMemberService;
 import org.niis.xroad.cs.admin.api.service.SubsystemService;
@@ -138,6 +139,9 @@ class SecurityServerServiceImplTest implements WithInOrder {
     @DisplayName("findSecurityServerRegistrationStatus(SecurityServerId serverId)")
     class SecurityServerRegStatusMethod implements WithInOrder {
 
+        @Captor
+        private ArgumentCaptor<PageRequestDto> pageRequestCaptor;
+
         @Test
         @DisplayName("should find management status approved")
         void shouldReturnStatusApproved() {
@@ -150,6 +154,24 @@ class SecurityServerServiceImplTest implements WithInOrder {
 
             assertNotNull(result);
             assertEquals(ManagementRequestStatus.APPROVED, result);
+        }
+
+        @Test
+        @DisplayName("should query only the latest registration request so stale revoked requests are ignored")
+        void shouldQueryOnlyLatestRegistrationRequest() {
+            Page<ManagementRequestView> managementRequestViews = new PageDto<>(new PageImpl<>(List.of(managementRequestView)));
+            doReturn(managementRequestViews).when(managementRequestService)
+                    .findRequests(any(), pageRequestCaptor.capture());
+            doReturn(ManagementRequestStatus.APPROVED).when(managementRequestView).getStatus();
+
+            ManagementRequestStatus result = securityServerService.findSecurityServerClientRegistrationStatus(serverId, clientId);
+
+            assertEquals(ManagementRequestStatus.APPROVED, result);
+            PageRequestDto pageRequest = pageRequestCaptor.getValue();
+            assertEquals("id", pageRequest.getJpaSort());
+            assertEquals(Boolean.TRUE, pageRequest.getDesc());
+            assertEquals(1, pageRequest.getLimit());
+            assertEquals(0, pageRequest.getOffset());
         }
 
         @Test


### PR DESCRIPTION
The Subsystems view resolved a client's registration status by taking the first CLIENT_REGISTRATION_REQUEST row matching the (server, client) pair from an unordered, unpaged query. When the pair had request history (a registration revoked before approval, then re-registered), the stale REVOKED row could be returned instead of the final APPROVED one, showing a registered subsystem as unregistered.

Query only the newest request (order by id desc, limit 1) so the latest status always wins.

Refs: XRDDEV-3277