### PR TITLE
fix(security-server): validate ACME HTTP-01 challenge token to prevent path-traversal file writes

### DIFF
--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeConfig.java
@@ -30,11 +30,30 @@ package org.niis.xroad.securityserver.restapi.acme;
 import ee.ria.xroad.common.FilePaths;
 
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 public interface AcmeConfig {
 
     Path ACME_ACCOUNT_KEYSTORE_PATH =   FilePaths.BASE_CONF_PATH.resolve("ssl/acme.p12");
     Path ACME_CHALLENGE_PATH = FilePaths.BASE_CONF_PATH.resolve("acme-challenge");
+
+    Pattern ACME_CHALLENGE_TOKEN_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+$");
+
+    /**
+     * Validates an ACME HTTP-01 challenge token received from an (untrusted) ACME server before it is used
+     * to build a file path under {@link #ACME_CHALLENGE_PATH}.
+     * <p>
+     * Rejects anything that is not a plain RFC 8555 base64url token, and, as defense in depth, verifies that
+     * resolving the token under {@link #ACME_CHALLENGE_PATH} does not escape that directory.
+     */
+    static boolean isValidChallengeToken(String token) {
+        if (token == null || !ACME_CHALLENGE_TOKEN_PATTERN.matcher(token).matches()) {
+            return false;
+        }
+        Path normalizedBase = ACME_CHALLENGE_PATH.normalize();
+        Path resolved = normalizedBase.resolve(token).normalize();
+        return resolved.startsWith(normalizedBase);
+    }
 
     /**
      * raw usage with default in org.niis.xroad.securityserver.restapi.config.AcmeBeanConfig.IsAcmeCertRenewalJobsActive

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeDeviationMessage.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeDeviationMessage.java
@@ -45,6 +45,7 @@ public enum AcmeDeviationMessage implements DeviationBuilder.ErrorDeviationBuild
     HTTP_CHALLENGE_FILE_CREATION("acme.http_challenge_file_creation"),
     HTTP_CHALLENGE_FILE_DELETION("acme.http_challenge_file_deletion"),
     HTTP_CHALLENGE_MISSING("acme.http_challenge_missing"),
+    HTTP_CHALLENGE_TOKEN_INVALID("acme.http_challenge_token_invalid"),
     CHALLENGE_TRIGGER_FAILURE("acme.challenge_trigger_failure"),
     AUTHORIZATION_FAILURE("acme.authorization_failure"),
     AUTHORIZATION_WAIT_FAILURE("acme.authorization_wait_failure"),

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeService.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/acme/AcmeService.java
@@ -307,6 +307,9 @@ public final class AcmeService {
                 Http01Challenge httpChallenge = auth.findChallenge(Http01Challenge.class)
                         .orElseThrow(() -> new AcmeServiceException(AcmeDeviationMessage.HTTP_CHALLENGE_MISSING.build()));
                 String token = httpChallenge.getToken();
+                if (!AcmeConfig.isValidChallengeToken(token)) {
+                    throw new AcmeServiceException(AcmeDeviationMessage.HTTP_CHALLENGE_TOKEN_INVALID.build());
+                }
                 String content = httpChallenge.getAuthorization();
                 var acmeChallenge = AcmeConfig.ACME_CHALLENGE_PATH.resolve(token);
                 try {

--- a/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/acme/AcmeChallengeTokenValidationTest.java
+++ b/src/security-server/admin-service/application/src/test/java/org/niis/xroad/securityserver/restapi/acme/AcmeChallengeTokenValidationTest.java
@@ -1,5 +1,6 @@
 /*
  * The MIT License
+ *
  * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
  * Copyright (c) 2018 Estonian Information System Authority (RIA),
  * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
@@ -23,32 +24,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.niis.xroad.securityserver.restapi.controller;
+package org.niis.xroad.securityserver.restapi.acme;
 
-import org.niis.xroad.common.exception.BadRequestException;
-import org.niis.xroad.securityserver.restapi.acme.AcmeConfig;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
-import static org.niis.xroad.common.core.exception.ErrorCode.INVALID_URL;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RestController
-public class AcmeChallengeController {
+class AcmeChallengeTokenValidationTest {
 
-    @GetMapping(value = "/.well-known/acme-challenge/{token}")
-    public ResponseEntity<String> getChallenge(@PathVariable("token") String token) throws IOException {
-        if (!AcmeConfig.isValidChallengeToken(token)) {
-            throw new BadRequestException(INVALID_URL.build());
-        }
-        FileSystemResource fileSystemResource = new FileSystemResource(AcmeConfig.ACME_CHALLENGE_PATH.resolve(token));
-        return new ResponseEntity<>(fileSystemResource.getContentAsString(StandardCharsets.UTF_8), HttpStatus.OK);
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "..",
+            "../evil",
+            "../../etc/xroad/conf.d/local.ini",
+            "/tmp/evil",
+            "foo/bar",
+            "foo\\bar",
+            "foo.bar"
+    })
+    void rejectsUnsafeTokens(String token) {
+        assertThat(AcmeConfig.isValidChallengeToken(token)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "xK3_-yZ9abcDEF01",
+            "AbCd1234_-efGH",
+            "a"
+    })
+    void acceptsRealisticBase64UrlTokens(String token) {
+        assertThat(AcmeConfig.isValidChallengeToken(token)).isTrue();
+    }
+
+    @Test
+    void validTokenResolvesUnderChallengePath() {
+        String token = "xK3_-yZ9abcDEF01";
+
+        assertThat(AcmeConfig.isValidChallengeToken(token)).isTrue();
+
+        Path base = AcmeConfig.ACME_CHALLENGE_PATH.normalize();
+        Path resolved = AcmeConfig.ACME_CHALLENGE_PATH.resolve(token).normalize();
+        assertThat(resolved.startsWith(base)).isTrue();
     }
 
 }

--- a/src/security-server/admin-service/ui/src/locales/en.json
+++ b/src/security-server/admin-service/ui/src/locales/en.json
@@ -401,6 +401,7 @@
       "http_challenge_file_creation": "Creating ACME HTTP challenge file failed",
       "http_challenge_file_deletion": "Deleting ACME HTTP challenge file failed",
       "http_challenge_missing": "Currently X-Road only supports HTTP challenge, but is missing from the possible options from the ACME server",
+      "http_challenge_token_invalid": "ACME server returned an invalid HTTP challenge token",
       "order_creation_failure": "Creating new Order on ACME server failed",
       "order_finalization_failure": "Finalizing the Order on ACME server failed"
     },

--- a/src/security-server/admin-service/ui/src/locales/es.json
+++ b/src/security-server/admin-service/ui/src/locales/es.json
@@ -343,6 +343,7 @@
       "http_challenge_file_creation": "Error al crear el archivo de desafío HTTP de ACME",
       "http_challenge_file_deletion": "Error al eliminar el archivo de desafío HTTP de ACME",
       "http_challenge_missing": "Actualmente, X-Road solo admite el desafío HTTP, pero este no está disponible entre las opciones posibles del servidor ACME",
+      "http_challenge_token_invalid": "El servidor ACME devolvió un token de desafío HTTP no válido",
       "order_creation_failure": "Error al crear un nuevo pedido en el servidor ACME",
       "order_finalization_failure": "Error al finalizar el pedido en el servidor ACME"
     },

--- a/src/security-server/admin-service/ui/src/locales/et.json
+++ b/src/security-server/admin-service/ui/src/locales/et.json
@@ -390,6 +390,7 @@
       "http_challenge_file_creation": "ACME HTTP pretensioonifaili loomine ebaõnnestus",
       "http_challenge_file_deletion": "ACME HTTP pretensioonifaili kustutamine ebaõnnestus",
       "http_challenge_missing": "Praegu toetab X-Road tarkvara ainult HTTP pretensiooni, kuid see puudub ACME serveri võimalikes valikutes",
+      "http_challenge_token_invalid": "ACME server tagastas kehtetu HTTP pretensiooni tunnusmärgi",
       "order_creation_failure": "Uue tellimuse loomine ACME serveris ebaõnnestus",
       "order_finalization_failure": "Tellimuse lõpule viimine ACME serveris ebaõnnestus"
     },

--- a/src/security-server/admin-service/ui/src/locales/pt-BR.json
+++ b/src/security-server/admin-service/ui/src/locales/pt-BR.json
@@ -390,6 +390,7 @@
       "http_challenge_file_creation": "Falha ao criar arquivo de desafio HTTP do ACME",
       "http_challenge_file_deletion": "Falha ao excluir arquivo de desafio HTTP do ACME",
       "http_challenge_missing": "Atualmente o X-Road só suporta desafio HTTP, mas essa opção está ausente no servidor ACME",
+      "http_challenge_token_invalid": "O servidor ACME retornou um token de desafio HTTP inválido",
       "order_creation_failure": "Falha ao criar nova ordem no servidor ACME",
       "order_finalization_failure": "Falha ao finalizar ordem no servidor ACME"
     },

--- a/src/security-server/admin-service/ui/src/locales/ru.json
+++ b/src/security-server/admin-service/ui/src/locales/ru.json
@@ -319,6 +319,7 @@
       "http_challenge_file_creation": "Не удалось создать файл HTTP-запроса для ACME",
       "http_challenge_file_deletion": "Не удалось удалить файл HTTP-запроса для ACME",
       "http_challenge_missing": "В данный момент X-Road поддерживает только HTTP-запрос, но он отсутствует в возможных опциях ACME сервера",
+      "http_challenge_token_invalid": "Сервер ACME вернул недопустимый токен HTTP-запроса",
       "order_creation_failure": "Не удалось создать новый заказ на сервере ACME",
       "order_finalization_failure": "Не удалось завершить заказ на сервере ACME"
     },

--- a/src/security-server/admin-service/ui/src/locales/tk.json
+++ b/src/security-server/admin-service/ui/src/locales/tk.json
@@ -319,6 +319,7 @@
       "http_challenge_file_creation": "ACME HTTP talap faýlyny döredip bolmady",
       "http_challenge_file_deletion": "ACME HTTP talap faýlyny pozup bolmady",
       "http_challenge_missing": "Häzirki wagtda X-Road diňe HTTP birikmäni goldaýar, ýöne ACME serwerinden mümkin bolan opsiýalarda ýok",
+      "http_challenge_token_invalid": "ACME serweri nädogry HTTP talap tokenini gaýtardy",
       "order_creation_failure": "ACME serwerinde täze Sargyt döredip bolmady",
       "order_finalization_failure": "ACME serwerinde sargydy tamamlap bolamdy"
     },


### PR DESCRIPTION

Refs: XRDDEV-3281