### PR TITLE
chore: map DSP errors to common error codes

### DIFF
--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/grpc/AssetAccessGrpcService.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/grpc/AssetAccessGrpcService.java
@@ -45,6 +45,7 @@ import org.niis.xroad.edc.assetaccess.proto.AcquireAssetAccessResp;
 import org.niis.xroad.edc.assetaccess.proto.AssetAccessServiceGrpc;
 import org.niis.xroad.edc.extension.assetaccess.AssetAccessRequest;
 import org.niis.xroad.edc.extension.assetaccess.service.AssetAccessOrchestrator;
+import org.niis.xroad.edc.extension.assetaccess.util.DspExceptionWrapper;
 
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
@@ -81,7 +82,7 @@ class AssetAccessGrpcService extends AssetAccessServiceGrpc.AssetAccessServiceIm
     @Override
     @WithSpan("dsp-asset-acquire")
     public void acquire(AcquireAssetAccessReq request, StreamObserver<AcquireAssetAccessResp> responseObserver) {
-        responseHandler.handleRequest(responseObserver, () -> acquireInternal(request));
+        responseHandler.handleRequest(responseObserver, DspExceptionWrapper.wrap(() -> acquireInternal(request)));
     }
 
     private AcquireAssetAccessResp acquireInternal(AcquireAssetAccessReq request) {

--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionMapper.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionMapper.java
@@ -24,7 +24,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.niis.xroad.proxy.controlplane;
+package org.niis.xroad.edc.extension.assetaccess.util;
 
 import lombok.experimental.UtilityClass;
 import org.niis.xroad.common.core.exception.ErrorCode;
@@ -52,19 +52,17 @@ import static org.niis.xroad.common.core.exception.ErrorCode.SERVICE_FAILED;
 import static org.niis.xroad.common.core.exception.ErrorCode.UNKNOWN_MEMBER;
 
 /**
- * Translates DSP-origin {@link XrdRuntimeException}s into legacy XRoad error codes.
+ * Translates DSP-origin {@link XrdRuntimeException}s into common XRoad error codes.
  *
- * <p>Needed because {@code AbstractRpcClient} overwrites the structured {@code origin} field and
- * double-prefixes the wire code (e.g. {@code proxy.dataspace.dsp_catalog_fetch_failed}). The mapper
- * identifies DSP exceptions by scanning the {@code errorCode} string for a {@code dataspace.} segment
- * rather than relying on the structured origin enum.
+ * <p>The mapper identifies DSP exceptions by scanning the {@code errorCode} string for a {@code dataspace.}
+ * segment rather than relying on the structured origin enum.</p>
  */
 @UtilityClass
-class DspLegacyErrorMapper {
+class DspExceptionMapper {
 
     private static final String DATASPACE_SEGMENT = "dataspace.";
 
-    private static final Map<ErrorCode, ErrorCode> DSP_TO_LEGACY = Map.ofEntries(
+    private static final Map<ErrorCode, ErrorCode> DSP_TO_COMMON = Map.ofEntries(
             entry(DSP_CATALOG_FETCH_FAILED, IO_ERROR),
             entry(DSP_CATALOG_PARSE_FAILED, IO_ERROR),
             entry(DSP_ACQUISITION_TIMEOUT, IO_ERROR),
@@ -77,7 +75,7 @@ class DspLegacyErrorMapper {
             entry(DSP_TRANSFER_FAILED, SERVICE_FAILED),
             entry(DSP_PARTICIPANT_CONTEXT_FAILED, INTERNAL_ERROR));
 
-    static XrdRuntimeException toLegacy(XrdRuntimeException ex) {
+    static XrdRuntimeException toCommon(XrdRuntimeException ex) {
         var dspCode = extractDspCode(ex.getErrorCode());
         if (dspCode == null) {
             return ex;
@@ -86,16 +84,16 @@ class DspLegacyErrorMapper {
         if (dspErrorCode == null) {
             return ex;
         }
-        var legacyCode = DSP_TO_LEGACY.get(dspErrorCode);
-        if (legacyCode == null) {
+        var errorCode = DSP_TO_COMMON.get(dspErrorCode);
+        if (errorCode == null) {
             return ex;
         }
         var metadata = Stream.concat(
                 Stream.of("originalCode=" + dspCode),
                 ex.getErrorCodeMetadata().stream()).toArray();
-        return new XrdRuntimeExceptionBuilder<>(legacyCode)
+        return new XrdRuntimeExceptionBuilder<>(errorCode)
                 .identifier(ex.getIdentifier())
-                .cause(ex.getCause())
+                .cause(ex)
                 .details(ex.getDetails())
                 .metadataItems(metadata)
                 .build();

--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionWrapper.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/main/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionWrapper.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.assetaccess.util;
+
+import lombok.experimental.UtilityClass;
+import org.niis.xroad.common.core.exception.XrdRuntimeException;
+
+import java.util.function.Supplier;
+
+/**
+ * Utility for wrapping operations that may throw DSP-specific exceptions.
+ *
+ * <p>The wrapper intercepts {@link XrdRuntimeException} instances thrown by the delegated operation and
+ * converts DSP-specific error codes into common error codes using {@link DspExceptionMapper}.
+ * Non-Xrd exceptions are propagated unchanged.</p>
+ */
+@UtilityClass
+public class DspExceptionWrapper {
+
+    public static <T> Supplier<T> wrap(Supplier<T> delegate) {
+        return () -> {
+            try {
+                return delegate.get();
+            } catch (XrdRuntimeException ex) {
+                throw DspExceptionMapper.toCommon(ex);
+            }
+        };
+    }
+
+}

--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/grpc/AssetAccessGrpcServiceTest.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/grpc/AssetAccessGrpcServiceTest.java
@@ -67,6 +67,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_ACQUISITION_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_ACQUISITION_TIMEOUT;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_CATALOG_FETCH_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_CATALOG_PARSE_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_DATAADDRESS_INVALID;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_DATASET_NOT_FOUND;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_NEGOTIATION_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_OFFERS_NOT_FOUND;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_PARTICIPANT_CONTEXT_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_PULL_DISTRIBUTION_MISSING;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_TRANSFER_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.INTERNAL_ERROR;
+import static org.niis.xroad.common.core.exception.ErrorCode.IO_ERROR;
+import static org.niis.xroad.common.core.exception.ErrorCode.SERVICE_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.UNKNOWN_MEMBER;
 
 @ExtendWith(MockitoExtension.class)
 class AssetAccessGrpcServiceTest {
@@ -231,23 +246,23 @@ class AssetAccessGrpcServiceTest {
 
     static Stream<Arguments> dspErrorCodes() {
         return Stream.of(
-                Arguments.of(ErrorCode.DSP_CATALOG_FETCH_FAILED),
-                Arguments.of(ErrorCode.DSP_CATALOG_PARSE_FAILED),
-                Arguments.of(ErrorCode.DSP_ACQUISITION_TIMEOUT),
-                Arguments.of(ErrorCode.DSP_DATASET_NOT_FOUND),
-                Arguments.of(ErrorCode.DSP_OFFERS_NOT_FOUND),
-                Arguments.of(ErrorCode.DSP_PULL_DISTRIBUTION_MISSING),
-                Arguments.of(ErrorCode.DSP_DATAADDRESS_INVALID),
-                Arguments.of(ErrorCode.DSP_NEGOTIATION_FAILED),
-                Arguments.of(ErrorCode.DSP_TRANSFER_FAILED),
-                Arguments.of(ErrorCode.DSP_ACQUISITION_FAILED),
-                Arguments.of(ErrorCode.DSP_PARTICIPANT_CONTEXT_FAILED)
+                Arguments.of(DSP_CATALOG_FETCH_FAILED, IO_ERROR),
+                Arguments.of(DSP_CATALOG_PARSE_FAILED, IO_ERROR),
+                Arguments.of(DSP_ACQUISITION_TIMEOUT, IO_ERROR),
+                Arguments.of(DSP_ACQUISITION_FAILED, IO_ERROR),
+                Arguments.of(DSP_DATASET_NOT_FOUND, UNKNOWN_MEMBER),
+                Arguments.of(DSP_OFFERS_NOT_FOUND, UNKNOWN_MEMBER),
+                Arguments.of(DSP_PULL_DISTRIBUTION_MISSING, SERVICE_FAILED),
+                Arguments.of(DSP_DATAADDRESS_INVALID, SERVICE_FAILED),
+                Arguments.of(DSP_NEGOTIATION_FAILED, SERVICE_FAILED),
+                Arguments.of(DSP_TRANSFER_FAILED, SERVICE_FAILED),
+                Arguments.of(DSP_PARTICIPANT_CONTEXT_FAILED, INTERNAL_ERROR)
         );
     }
 
     @ParameterizedTest
     @MethodSource("dspErrorCodes")
-    void dspExceptionPropagatesWithDataspacePrefixedWireCode(ErrorCode dspCode) {
+    void dspExceptionMappedToCommonException(ErrorCode dspCode, ErrorCode expectedErrorCode) {
         stubParticipantContext();
         var dspException = XrdRuntimeException.systemException(dspCode)
                 .origin(ErrorOrigin.DATASPACE)
@@ -261,7 +276,8 @@ class AssetAccessGrpcServiceTest {
             stub.acquire(request);
             throw new AssertionError("Expected StatusRuntimeException");
         } catch (StatusRuntimeException ex) {
-            assertThat(extractErrorCode(ex)).isEqualTo(ErrorOrigin.DATASPACE.toPrefix() + dspCode.code());
+            assertThat(extractErrorCode(ex)).isEqualTo(expectedErrorCode.code());
+            assertThat(extractMetadata(ex)).containsExactly("originalCode=" + dspCode.code());
         }
     }
 
@@ -282,7 +298,7 @@ class AssetAccessGrpcServiceTest {
             throw new AssertionError("Expected StatusRuntimeException");
         } catch (StatusRuntimeException ex) {
             assertThat(extractMetadata(ex))
-                    .containsExactly("my-asset-id", "extra-context");
+                    .containsExactly("originalCode=" + DSP_DATASET_NOT_FOUND.code(), "my-asset-id", "extra-context");
         }
     }
 
@@ -326,7 +342,7 @@ class AssetAccessGrpcServiceTest {
     }
 
     @Test
-    void plainRuntimeExceptionFromFutureBecomesDspAcquisitionFailed() {
+    void plainRuntimeExceptionFromFutureBecomesDspAcquisitionFailedMappedToIoError() {
         stubParticipantContext();
         when(assetAccessOrchestrator.acquireAssetAccess(any(), any()))
                 .thenReturn(CompletableFuture.failedFuture(new RuntimeException("unexpected")));
@@ -335,8 +351,8 @@ class AssetAccessGrpcServiceTest {
             stub.acquire(baseRequest().build());
             throw new AssertionError("Expected StatusRuntimeException");
         } catch (StatusRuntimeException ex) {
-            assertThat(extractErrorCode(ex))
-                    .isEqualTo(ErrorOrigin.DATASPACE.toPrefix() + ErrorCode.DSP_ACQUISITION_FAILED.code());
+            assertThat(extractErrorCode(ex)).isEqualTo(IO_ERROR.code());
+            assertThat(extractMetadata(ex)).containsExactly("originalCode=" + ErrorCode.DSP_ACQUISITION_FAILED.code());
         }
     }
 

--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionMapperTest.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionMapperTest.java
@@ -24,14 +24,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.niis.xroad.proxy.controlplane;
+package org.niis.xroad.edc.extension.assetaccess.util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.niis.xroad.common.core.exception.ErrorCode;
-import org.niis.xroad.common.core.exception.ErrorOrigin;
 import org.niis.xroad.common.core.exception.XrdRuntimeException;
 
 import java.util.stream.Stream;
@@ -53,10 +52,11 @@ import static org.niis.xroad.common.core.exception.ErrorCode.IO_ERROR;
 import static org.niis.xroad.common.core.exception.ErrorCode.NETWORK_ERROR;
 import static org.niis.xroad.common.core.exception.ErrorCode.SERVICE_FAILED;
 import static org.niis.xroad.common.core.exception.ErrorCode.UNKNOWN_MEMBER;
+import static org.niis.xroad.common.core.exception.ErrorOrigin.DATASPACE;
 
-class DspLegacyErrorMapperTest {
+class DspExceptionMapperTest {
 
-    static Stream<Arguments> dspToLegacyMappings() {
+    static Stream<Arguments> dspToCommonMappings() {
         return Stream.of(
                 Arguments.of(DSP_CATALOG_FETCH_FAILED, IO_ERROR),
                 Arguments.of(DSP_CATALOG_PARSE_FAILED, IO_ERROR),
@@ -73,21 +73,21 @@ class DspLegacyErrorMapperTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dspToLegacyMappings")
-    void dspCodeMapsToExpectedLegacyCode(ErrorCode dspCode, ErrorCode expectedLegacy) {
-        var ex = dspExceptionWithDoublePrefix(dspCode);
+    @MethodSource("dspToCommonMappings")
+    void dspCodeMapsToExpectedCommonCode(ErrorCode dspCode, ErrorCode expectedCode) {
+        var ex = dspException(dspCode);
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
-        assertThat(result.isCausedBy(expectedLegacy)).isTrue();
+        assertThat(result.isCausedBy(expectedCode)).isTrue();
     }
 
     @ParameterizedTest
-    @MethodSource("dspToLegacyMappings")
-    void dspCodeOriginalCodePrependedToMetadata(ErrorCode dspCode, ErrorCode ignoredLegacy) {
-        var ex = dspExceptionWithDoublePrefix(dspCode, "existing-meta");
+    @MethodSource("dspToCommonMappings")
+    void dspCodeOriginalCodePrependedToMetadata(ErrorCode dspCode) {
+        var ex = dspException(dspCode, "existing-meta");
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result.getErrorCodeMetadata().getFirst())
                 .isEqualTo("originalCode=" + dspCode.code());
@@ -95,22 +95,22 @@ class DspLegacyErrorMapperTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dspToLegacyMappings")
-    void dspCodeOriginalMetadataOrderPreserved(ErrorCode dspCode, ErrorCode ignoredLegacy) {
-        var ex = dspExceptionWithDoublePrefix(dspCode, "meta-a", "meta-b");
+    @MethodSource("dspToCommonMappings")
+    void dspCodeOriginalMetadataOrderPreserved(ErrorCode dspCode) {
+        var ex = dspException(dspCode, "meta-a", "meta-b");
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result.getErrorCodeMetadata())
                 .containsExactly("originalCode=" + dspCode.code(), "meta-a", "meta-b");
     }
 
     @ParameterizedTest
-    @MethodSource("dspToLegacyMappings")
-    void dspCodeIdentifierAndDetailsSurviveMapping(ErrorCode dspCode, ErrorCode ignoredLegacy) {
-        var doublePrefix = buildDoublePrefixException(dspCode, "some detail", "fixed-uuid");
+    @MethodSource("dspToCommonMappings")
+    void dspCodeIdentifierAndDetailsSurviveMapping(ErrorCode dspCode) {
+        var ex = buildDspException(dspCode, "some detail", "fixed-uuid");
 
-        var result = DspLegacyErrorMapper.toLegacy(doublePrefix);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result.getIdentifier()).isEqualTo("fixed-uuid");
         assertThat(result.getDetails()).isEqualTo("some detail");
@@ -120,7 +120,7 @@ class DspLegacyErrorMapperTest {
     void nonDspExceptionPassesThroughUnchanged() {
         var ex = XrdRuntimeException.systemException(NETWORK_ERROR, "plain network error");
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result).isSameAs(ex);
     }
@@ -130,7 +130,7 @@ class DspLegacyErrorMapperTest {
         var ex = XrdRuntimeException.systemException(ErrorCode.withCode("dataspace.dsp_unknown_future_code"))
                 .build();
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result).isSameAs(ex);
     }
@@ -139,16 +139,16 @@ class DspLegacyErrorMapperTest {
     void errorCodeWithNoDataspaceSegmentPassesThroughUnchanged() {
         var ex = XrdRuntimeException.systemException(NETWORK_ERROR, "no dataspace segment at all");
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result).isSameAs(ex);
     }
 
     @Test
     void emptyOriginalMetadataResultsInOnlyOriginalCodeEntry() {
-        var ex = dspExceptionWithDoublePrefix(DSP_CATALOG_FETCH_FAILED);
+        var ex = dspException(DSP_CATALOG_FETCH_FAILED);
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result.getErrorCodeMetadata()).hasSize(1);
         assertThat(result.getErrorCodeMetadata().getFirst())
@@ -161,25 +161,21 @@ class DspLegacyErrorMapperTest {
                         ErrorCode.withCode("proxy.dataspace." + DSP_CATALOG_FETCH_FAILED.code()))
                 .build();
 
-        var result = DspLegacyErrorMapper.toLegacy(ex);
+        var result = DspExceptionMapper.toCommon(ex);
 
         assertThat(result.isCausedBy(IO_ERROR)).isTrue();
     }
 
-    private static XrdRuntimeException dspExceptionWithDoublePrefix(ErrorCode dspCode, String... metadata) {
-        return buildDoublePrefixException(dspCode, null, null, metadata);
+    private static XrdRuntimeException dspException(ErrorCode dspCode, String... metadata) {
+        return buildDspException(dspCode, null, null, metadata);
     }
 
-    private static XrdRuntimeException buildDoublePrefixException(ErrorCode dspCode, String details, String identifier,
-                                                                   String... metadata) {
-        var builder = XrdRuntimeException.systemException(
-                ErrorCode.withCode("proxy." + ErrorOrigin.DATASPACE.toPrefix() + dspCode.code()));
-        if (details != null) {
-            builder.details(details);
-        }
-        if (identifier != null) {
-            builder.identifier(identifier);
-        }
+    private static XrdRuntimeException buildDspException(ErrorCode dspCode, String details, String identifier,
+                                                         String... metadata) {
+        var builder = XrdRuntimeException.systemException(dspCode)
+                .origin(DATASPACE)
+                .details(details)
+                .identifier(identifier);
         if (metadata.length > 0) {
             builder.metadataItems((Object[]) metadata);
         }

--- a/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionWrapperTest.java
+++ b/src/service/ds-control-plane/ds-xroad-asset-access-api/src/test/java/org/niis/xroad/edc/extension/assetaccess/util/DspExceptionWrapperTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.edc.extension.assetaccess.util;
+
+import org.junit.jupiter.api.Test;
+import org.niis.xroad.common.core.exception.ErrorOrigin;
+import org.niis.xroad.common.core.exception.XrdRuntimeException;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.niis.xroad.common.core.exception.ErrorCode.DSP_CATALOG_FETCH_FAILED;
+import static org.niis.xroad.common.core.exception.ErrorCode.IO_ERROR;
+import static org.niis.xroad.common.core.exception.ErrorCode.NETWORK_ERROR;
+
+class DspExceptionWrapperTest {
+
+    @Test
+    void returnsResultWhenDelegateSucceeds() {
+        final Supplier<String> delegate = () -> "success";
+
+        var result = DspExceptionWrapper.wrap(delegate).get();
+
+        assertThat(result).isEqualTo("success");
+    }
+
+    @Test
+    void mapsDspExceptionToCommonException() {
+        final Supplier<String> delegate = () -> {
+            throw XrdRuntimeException.systemException(DSP_CATALOG_FETCH_FAILED)
+                    .origin(ErrorOrigin.DATASPACE)
+                    .build();
+        };
+
+        assertThatExceptionOfType(XrdRuntimeException.class)
+                .isThrownBy(() -> DspExceptionWrapper.wrap(delegate).get())
+                .satisfies(e -> {
+                    assertThat(e.getErrorCode()).isEqualTo(IO_ERROR.code());
+                    assertThat(e.getOrigin()).isNull();
+                });
+    }
+
+    @Test
+    void propagateNonDspException() {
+        final Supplier<String> delegate = () -> {
+            throw XrdRuntimeException.systemException(NETWORK_ERROR, "plain network error");
+        };
+
+        assertThatExceptionOfType(XrdRuntimeException.class)
+                .isThrownBy(() -> DspExceptionWrapper.wrap(delegate).get())
+                .satisfies(e -> {
+                    assertThat(e.getErrorCode()).isEqualTo("network_error");
+                });
+    }
+}

--- a/src/service/proxy/proxy-dsp-core/src/main/java/org/niis/xroad/proxy/controlplane/ConsumerSideDspProcessor.java
+++ b/src/service/proxy/proxy-dsp-core/src/main/java/org/niis/xroad/proxy/controlplane/ConsumerSideDspProcessor.java
@@ -50,11 +50,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.niis.xroad.common.core.exception.ErrorCode.DSP_ACQUISITION_FAILED;
-import static org.niis.xroad.common.core.exception.ErrorCode.DSP_CATALOG_FETCH_FAILED;
-import static org.niis.xroad.common.core.exception.ErrorCode.DSP_DATASET_NOT_FOUND;
-import static org.niis.xroad.common.core.exception.ErrorCode.DSP_OFFERS_NOT_FOUND;
-import static org.niis.xroad.common.core.exception.ErrorOrigin.DATASPACE;
+import static org.niis.xroad.common.core.exception.ErrorCode.IO_ERROR;
+import static org.niis.xroad.common.core.exception.ErrorCode.UNKNOWN_MEMBER;
 
 /**
  * Consumer-side implementation of {@link DspRequestProcessor}. Resolves candidate provider security
@@ -72,8 +69,6 @@ import static org.niis.xroad.common.core.exception.ErrorOrigin.DATASPACE;
  *       error (fail fast; no silent fallback).</li>
  * </ul>
  *
- * <p>Exhaustion of all candidates is translated to a legacy error code at the execute boundary
- * via {@link DspLegacyErrorMapper#toLegacy(XrdRuntimeException)}.
  */
 @Slf4j
 @ApplicationScoped
@@ -103,12 +98,7 @@ public class ConsumerSideDspProcessor implements DspRequestProcessor {
     @Nonnull
     public AssetAccessResponse execute(DspRequest request) {
         log.trace("execute({})", request);
-
-        try {
-            return acquireAssetAccessForService(request, request.serviceId());
-        } catch (XrdRuntimeException ex) {
-            throw DspLegacyErrorMapper.toLegacy(ex);
-        }
+        return acquireAssetAccessForService(request, request.serviceId());
     }
 
     private AssetAccessResponse acquireAssetAccessForService(DspRequest request, ServiceId serviceId) {
@@ -122,8 +112,7 @@ public class ConsumerSideDspProcessor implements DspRequestProcessor {
                 serviceId, assetId, request.managementSubsystem(), candidates.size());
 
         if (candidates.isEmpty()) {
-            throw XrdRuntimeException.systemException(DSP_DATASET_NOT_FOUND)
-                    .origin(DATASPACE)
+            throw XrdRuntimeException.systemException(UNKNOWN_MEMBER)
                     .details("No candidate security servers found for service %s".formatted(serviceId))
                     .build();
         }
@@ -138,9 +127,8 @@ public class ConsumerSideDspProcessor implements DspRequestProcessor {
             var targets = useMgmtCtx ? mgmtCounterPartyTargets : counterPartyTargets;
             var target = targets.get(candidate.hostAddress());
             if (target == null) {
-                var ex = XrdRuntimeException.systemException(DSP_CATALOG_FETCH_FAILED)
-                        .origin(DATASPACE)
-                        .details("No DSP counter-party target configured for provider host-address \"%s\""
+                var ex = XrdRuntimeException.systemException(IO_ERROR)
+                        .details("No counter-party target configured for provider host-address \"%s\""
                                 .formatted(candidate.hostAddress()))
                         .build();
                 log.warn("No counter-party target for SS {} (address {}), trying next",
@@ -206,21 +194,15 @@ public class ConsumerSideDspProcessor implements DspRequestProcessor {
                     .map(XrdRuntimeException.class::cast)
                     .map(XrdRuntimeException::getCode)
                     .collect(Collectors.toSet());
-            if (xrdCodes.size() == 1 && !isRemoteNotFoundCode(xrdCodes.iterator().next())) {
+            if (xrdCodes.size() == 1) {
                 return remoteFailures.getFirst();
             }
         }
         var last = !remoteFailures.isEmpty() ? remoteFailures.getLast() : localFailures.getLast();
-        return XrdRuntimeException.systemException(DSP_ACQUISITION_FAILED)
-                .origin(DATASPACE)
+        return XrdRuntimeException.systemException(IO_ERROR)
                 .cause(last)
                 .details("All %d candidate security servers failed to acquire asset access for service %s"
                         .formatted(candidateCount, serviceId))
                 .build();
-    }
-
-    private static boolean isRemoteNotFoundCode(String errorCode) {
-        return errorCode != null
-                && (errorCode.endsWith(DSP_DATASET_NOT_FOUND.code()) || errorCode.endsWith(DSP_OFFERS_NOT_FOUND.code()));
     }
 }

--- a/src/service/proxy/proxy-dsp-core/src/test/java/org/niis/xroad/proxy/controlplane/ConsumerSideDspProcessorTest.java
+++ b/src/service/proxy/proxy-dsp-core/src/test/java/org/niis/xroad/proxy/controlplane/ConsumerSideDspProcessorTest.java
@@ -471,18 +471,25 @@ class ConsumerSideDspProcessorTest {
     }
 
     @Test
-    void remoteDatasetNotFoundFromReachedProviderMapsToIoError() {
+    void remoteDatasetNotFoundFromReachedProviderMapsToUnknownMember() {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of(new ProviderAddress(null, HOST_A)));
         var dspException = XrdRuntimeException.systemException(
-                        ErrorCode.withCode("proxy.dataspace." + ErrorCode.DSP_DATASET_NOT_FOUND.code()))
+                        ErrorCode.withCode("proxy." + ErrorCode.UNKNOWN_MEMBER.code()))
+                .metadataItems("originalCode=" + ErrorCode.DSP_DATASET_NOT_FOUND.code())
                 .build();
         when(assetAccessAcquisitionService.acquireAssetAccess(any(), eq(DID_A), eq(URL_A)))
                 .thenThrow(dspException);
 
         assertThatThrownBy(() -> processor.execute(new DspRequest(serviceId, null, false)))
                 .isInstanceOf(XrdRuntimeException.class)
-                .satisfies(ex -> assertThat(((XrdRuntimeException) ex).isCausedBy(ErrorCode.IO_ERROR)).isTrue());
+                .satisfies(ex -> {
+                    var xrd = (XrdRuntimeException) ex;
+                    assertThat(xrd.isCausedBy(ErrorCode.UNKNOWN_MEMBER)).isTrue();
+                    assertThat(xrd.getErrorCodeMetadata()).hasSize(1);
+                    assertThat(xrd.getErrorCodeMetadata().getFirst())
+                            .isEqualTo("originalCode=" + ErrorCode.DSP_DATASET_NOT_FOUND.code());
+                });
     }
 
     @Test
@@ -492,7 +499,8 @@ class ConsumerSideDspProcessorTest {
                         new ProviderAddress(null, HOST_A),
                         new ProviderAddress(null, HOST_B)));
         var dspException = XrdRuntimeException.systemException(
-                        ErrorCode.withCode("proxy.dataspace." + ErrorCode.DSP_CATALOG_FETCH_FAILED.code()))
+                        ErrorCode.withCode("proxy." + ErrorCode.IO_ERROR.code()))
+                .metadataItems("originalCode=" + ErrorCode.DSP_CATALOG_FETCH_FAILED.code())
                 .build();
         when(assetAccessAcquisitionService.acquireAssetAccess(any(), eq(DID_A), eq(URL_A)))
                 .thenThrow(dspException);
@@ -509,7 +517,8 @@ class ConsumerSideDspProcessorTest {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of(new ProviderAddress(null, HOST_A)));
         var dspException = XrdRuntimeException.systemException(
-                        ErrorCode.withCode("proxy.dataspace." + ErrorCode.DSP_NEGOTIATION_FAILED.code()))
+                        ErrorCode.withCode("proxy." + ErrorCode.SERVICE_FAILED.code()))
+                .metadataItems("originalCode=" + ErrorCode.DSP_NEGOTIATION_FAILED.code())
                 .details("negotiation timed out")
                 .build();
         when(assetAccessAcquisitionService.acquireAssetAccess(any(), eq(DID_A), eq(URL_A)))
@@ -526,7 +535,7 @@ class ConsumerSideDspProcessorTest {
                 });
     }
     @Test
-    void emptyCandidatesYieldsUnknownMemberWithOriginalDspCode() {
+    void emptyCandidatesYieldsUnknownMember() {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of());
         assertThatThrownBy(() -> processor.execute(new DspRequest(serviceId, null, false)))
@@ -534,13 +543,11 @@ class ConsumerSideDspProcessorTest {
                 .satisfies(ex -> {
                     var xrd = (XrdRuntimeException) ex;
                     assertThat(xrd.isCausedBy(ErrorCode.UNKNOWN_MEMBER)).isTrue();
-                    assertThat(xrd.getErrorCodeMetadata()).hasSize(1);
-                    assertThat(xrd.getErrorCodeMetadata().getFirst())
-                            .isEqualTo("originalCode=" + ErrorCode.DSP_DATASET_NOT_FOUND.code());
+                    assertThat(xrd.getErrorCodeMetadata()).isEmpty();
                 });
     }
     @Test
-    void missingCounterPartyTargetYieldsIoErrorWithOriginalDspCode() {
+    void missingCounterPartyTargetYieldsIoError() {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of(new ProviderAddress(null, UNKNOWN_HOST)));
         assertThatThrownBy(() -> processor.execute(new DspRequest(serviceId, null, false)))
@@ -548,13 +555,11 @@ class ConsumerSideDspProcessorTest {
                 .satisfies(ex -> {
                     var xrd = (XrdRuntimeException) ex;
                     assertThat(xrd.isCausedBy(ErrorCode.IO_ERROR)).isTrue();
-                    assertThat(xrd.getErrorCodeMetadata()).hasSize(1);
-                    assertThat(xrd.getErrorCodeMetadata().getFirst())
-                            .isEqualTo("originalCode=" + ErrorCode.DSP_ACQUISITION_FAILED.code());
+                    assertThat(xrd.getErrorCodeMetadata()).isEmpty();
                 });
     }
     @Test
-    void allCandidatesFailedAggregationYieldsIoErrorWithOriginalDspCode() {
+    void allCandidatesFailedAggregationYieldsIoError() {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of(
                         new ProviderAddress(null, HOST_A),
@@ -568,9 +573,7 @@ class ConsumerSideDspProcessorTest {
                 .satisfies(ex -> {
                     var xrd = (XrdRuntimeException) ex;
                     assertThat(xrd.isCausedBy(ErrorCode.IO_ERROR)).isTrue();
-                    assertThat(xrd.getErrorCodeMetadata()).hasSize(1);
-                    assertThat(xrd.getErrorCodeMetadata().getFirst())
-                            .isEqualTo("originalCode=" + ErrorCode.DSP_ACQUISITION_FAILED.code());
+                    assertThat(xrd.getErrorCodeMetadata()).isEmpty();
                 });
     }
     @Test
@@ -578,7 +581,8 @@ class ConsumerSideDspProcessorTest {
         when(providerSecurityServerResolver.resolve(serviceId, null))
                 .thenReturn(List.of(new ProviderAddress(null, HOST_A)));
         var dspException = XrdRuntimeException.systemException(
-                        ErrorCode.withCode("proxy.dataspace." + ErrorCode.DSP_CATALOG_FETCH_FAILED.code()))
+                        ErrorCode.withCode("proxy." + ErrorCode.IO_ERROR.code()))
+                .metadataItems("originalCode=" + ErrorCode.DSP_CATALOG_FETCH_FAILED.code())
                 .build();
         when(assetAccessAcquisitionService.acquireAssetAccess(any(), eq(DID_A), eq(URL_A)))
                 .thenThrow(dspException);


### PR DESCRIPTION
Map DSP failures to common XRD error codes on the server side to avoid exposing DSP/EDC-specific error codes to consumers.

- Refs: XRDDEV-3207