### PR TITLE
fix: preserve full IPv6 addresses in TLS certificate SAN extraction

### DIFF
--- a/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/write_tls_config.sh
+++ b/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/write_tls_config.sh
@@ -41,15 +41,20 @@ EOF
   exit 1
 }
 
-# Split combined IP and DNS alternative names into separate lists
-# Input format: IP:1.1.1.1,DNS:example.com,IP:2.2.2.2,DNS:example.org
-# Output: Two space-separated values: "ip_list" "dns_list"
-split_ip_dns() {
-  local input="$1"
-  local ip_list dns_list
-  ip_list=$(echo "$input" | tr ',' '\n' | grep '^IP:' | cut -d: -f2 | paste -sd,)
-  dns_list=$(echo "$input" | tr ',' '\n' | grep '^DNS:' | cut -d: -f2 | paste -sd,)
-  echo "$ip_list" "$dns_list"
+# Extract the IP alternative names (IPv4 and IPv6) from a combined IP/DNS list.
+# Input format:
+#   IP:1.1.1.1,DNS:example.com,IP:2.2.2.2,DNS:example.org
+#   IP:10.0.2.15,IP:fd17:625c:f037:2:a00:27ff:fe7f:dfb6,DNS:example.org,DNS:example.org
+extract_ip_list() {
+  echo "$1" | tr ',' '\n' | grep '^IP:' | sed 's/^IP://' | paste -sd,
+}
+
+# Extract the DNS alternative names from a combined IP/DNS list.
+# Input format:
+#   IP:1.1.1.1,DNS:example.com,IP:2.2.2.2,DNS:example.org
+#   IP:10.0.2.15,IP:fd17:625c:f037:2:a00:27ff:fe7f:dfb6,DNS:example.org,DNS:example.org
+extract_dns_list() {
+  echo "$1" | tr ',' '\n' | grep '^DNS:' | sed 's/^DNS://' | paste -sd,
 }
 
 # Write TLS certificate provisioning settings to configuration file
@@ -64,7 +69,9 @@ write_tls_settings() {
   local cn="$3"
   local altn="$4"
 
-  read ip_list dns_list < <(split_ip_dns "$altn")
+  local ip_list dns_list
+  ip_list=$(extract_ip_list "$altn")
+  dns_list=$(extract_dns_list "$altn")
 
   log "Writing ${module_name} TLS settings to ${config_file}"
   /usr/share/xroad/scripts/yaml_helper.sh set "$config_file" "xroad.${module_name}.tls.certificate-provisioning.common-name" "$cn"

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
@@ -198,12 +198,12 @@ EOF
     fi
 }
 
-split_ip_dns() {
-  local input="$1"
-  local ip_list dns_list
-  ip_list=$(echo "$input" | tr ',' '\n' | grep '^IP:' | cut -d: -f2 | paste -sd,)
-  dns_list=$(echo "$input" | tr ',' '\n' | grep '^DNS:' | cut -d: -f2 | paste -sd,)
-  echo "$ip_list" "$dns_list"
+extract_ip_list() {
+  echo "$1" | tr ',' '\n' | grep '^IP:' | sed 's/^IP://' | paste -sd,
+}
+
+extract_dns_list() {
+  echo "$1" | tr ',' '\n' | grep '^DNS:' | sed 's/^DNS://' | paste -sd,
 }
 
 prepare_certificates_settings() {
@@ -240,7 +240,9 @@ prepare_certificates_settings() {
     db_get xroad-common/admin-altsubject
     altn="$RET"
 
-    read ip_list dns_list < <(split_ip_dns "$altn")
+    local ip_list dns_list
+    ip_list=$(extract_ip_list "$altn")
+    dns_list=$(extract_dns_list "$altn")
 
     /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.common-name" "$subj"
     /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.alt-names" "$dns_list"
@@ -276,7 +278,9 @@ prepare_certificates_settings() {
     db_get xroad-common/service-altsubject
     altn="$RET"
 
-    read ip_list dns_list < <(split_ip_dns "$altn")
+    local ip_list dns_list
+    ip_list=$(extract_ip_list "$altn")
+    dns_list=$(extract_dns_list "$altn")
 
     /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.common-name" "$subj"
     /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.alt-names" "$dns_list"

--- a/deployment/security-server/xroad-installer/tasks/configure_tls.sh
+++ b/deployment/security-server/xroad-installer/tasks/configure_tls.sh
@@ -11,13 +11,14 @@ source "$SCRIPT_DIR/../lib/common.sh"
 CONFIG_FILE="/etc/xroad/conf.d/local-tls.yaml"
 YAML_HELPER="$SCRIPT_DIR/../lib/yaml_helper.sh"
 
-# Function to split IP and DNS entries from comma-separated list
-split_ip_dns() {
-  local input="$1"
-  local ip_list dns_list
-  ip_list=$(echo "$input" | tr ',' '\n' | grep '^IP:' | sed 's/^IP://' | paste -sd,)
-  dns_list=$(echo "$input" | tr ',' '\n' | grep '^DNS:' | sed 's/^DNS://' | paste -sd,)
-  echo "$ip_list" "$dns_list"
+# Extract the IP alternative names (IPv4 and IPv6) from a combined IP/DNS list.
+extract_ip_list() {
+  echo "$1" | tr ',' '\n' | grep '^IP:' | sed 's/^IP://' | paste -sd,
+}
+
+# Extract the DNS alternative names from a combined IP/DNS list.
+extract_dns_list() {
+  echo "$1" | tr ',' '\n' | grep '^DNS:' | sed 's/^DNS://' | paste -sd,
 }
 
 # Function to get YAML value
@@ -46,7 +47,8 @@ configure_service_tls() {
 
   # Split IP and DNS entries
   local ip_list dns_list
-  read ip_list dns_list < <(split_ip_dns "$altn")
+  ip_list=$(extract_ip_list "$altn")
+  dns_list=$(extract_dns_list "$altn")
 
   log_message "  Common Name: $cn"
   log_message "  DNS Alternative Names: $dns_list"

--- a/deployment/security-server/xroad-installer/tasks/configure_tls.sh
+++ b/deployment/security-server/xroad-installer/tasks/configure_tls.sh
@@ -47,8 +47,8 @@ configure_service_tls() {
 
   # Split IP and DNS entries
   local ip_list dns_list
-  ip_list=$(extract_ip_list "$altn")
-  dns_list=$(extract_dns_list "$altn")
+  ip_list=$(extract_ip_list "$altn") || true
+  dns_list=$(extract_dns_list "$altn") || true
 
   log_message "  Common Name: $cn"
   log_message "  DNS Alternative Names: $dns_list"


### PR DESCRIPTION
Refs: XRDDEV-3132