### PR TITLE
fix: migrate xroad-secret-store-local to OpenBao 2.6.x (version pin)

### DIFF
--- a/deployment/.scripts/configure-mirror-openbao-deb.sh
+++ b/deployment/.scripts/configure-mirror-openbao-deb.sh
@@ -60,11 +60,13 @@ configure_openbao_deb() {
     echo "deb [signed-by=$OPENBAO_KEYRING] $OPENBAO_MIRROR_URL/ stable main" \
         > /etc/apt/sources.list.d/openbao.list
 
-    # Keeps the apt candidate below xroad-secret-store-local's `openbao (<< 2.6.0)` control-file
-    # cap; must be raised together with that cap.
+    # Keeps the apt candidate below xroad-secret-store-local's `openbao (<< 2.7.0)` control-file cap;
+    # must be raised together with that cap.
+    # Patch releases within 2.6.* are trusted without
+    # an individual validation pass — only a new minor/major raises this pin.
     cat <<'EOF' > /etc/apt/preferences.d/openbao.pref
 Package: openbao
-Pin: version 2.5.*
+Pin: version 2.6.*
 Pin-Priority: 1001
 EOF
 

--- a/deployment/.scripts/configure-mirror-openbao-rpm.sh
+++ b/deployment/.scripts/configure-mirror-openbao-rpm.sh
@@ -65,6 +65,15 @@ EOF
   rpm --import "$GPG_KEY_FILE"
   echo "OpenBao GPG key imported."
 
+  # dnf/rpm cannot enforce xroad-secret-store-local's `openbao < 2.7.0` "Requires:"
+  # — both `openbao` and `openbao-hsm` carry an unversioned `Provides: openbao`,
+  # which satisfies any version comparison on that capability regardless of the
+  # actual installed version, for any operator.
+  # Here `includepkgs` is what actually gates the version; it must be raised together with the spec's `Requires:`.
+  # Patch releases within 2.6.* are trusted without an individual validation pass — only a new minor/major raises this.
+  # The `excludepkgs` is a second, version-independent layer specifically for the
+  # variant: even if includepkgs is ever widened carelessly, this keeps
+  # openbao-hsm out regardless.
   cat >/etc/yum.repos.d/openbao.repo <<EOF
 [openbao]
 name=openbao
@@ -72,6 +81,8 @@ baseurl=${OPENBAO_MIRROR_URL}
 repo_gpgcheck=0
 gpgcheck=1
 enabled=1
+includepkgs=openbao-2.6.*
+excludepkgs=openbao-hsm*
 gpgkey=file://${GPG_KEY_FILE}
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/deployment/.scripts/update-openbao-version-deb.sh
+++ b/deployment/.scripts/update-openbao-version-deb.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Refresh OpenBao's Version/Pin on an Already-Configured APT Repository
+# (Container Side)
+#
+# Rewrites the APT preferences pin unconditionally. Safe regardless of
+# whether the repo points at the official repo or a custom mirror, since the
+# pin file carries no mirror-specific content at all.
+#
+# Usage:
+#   ./update-mirror-openbao-deb.sh
+#
+# No-ops if the repo isn't configured yet — callers should run
+# configure-mirror-openbao-deb.sh instead in that case.
+
+update_openbao_version() {
+  local OPENBAO_REPO_FILE="/etc/apt/sources.list.d/openbao.list"
+  local OPENBAO_PIN_FILE="/etc/apt/preferences.d/openbao.pref"
+
+  if [ ! -f "$OPENBAO_REPO_FILE" ]; then
+    echo "OpenBao repository not configured yet; nothing to update."
+    return 0
+  fi
+
+  # Keep this value in sync with configure-mirror-openbao-deb.sh.
+  cat <<'EOF' > "$OPENBAO_PIN_FILE"
+Package: openbao
+Pin: version 2.6.*
+Pin-Priority: 1001
+EOF
+
+  echo "OpenBao APT pin refreshed."
+}
+
+# EXECUTION GUARD
+update_openbao_version

--- a/deployment/.scripts/update-openbao-version-rpm.sh
+++ b/deployment/.scripts/update-openbao-version-rpm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Refresh OpenBao's Version/Variant Gate on an Already-Configured DNF
+# Repository (Container Side)
+#
+# Patches includepkgs/excludepkgs in place on an existing openbao.repo,
+# leaving baseurl/username/password untouched. Safe to run regardless of
+# whether the repo points at the official repo or a custom mirror, since
+# these two lines never depend on which repo is configured.
+#
+# Usage:
+#   ./update-mirror-openbao-rpm.sh
+#
+# No-ops if the repo file doesn't exist yet — callers should run
+# configure-mirror-openbao-rpm.sh instead in that case.
+
+update_openbao_version() {
+  local OPENBAO_REPO_FILE="/etc/yum.repos.d/openbao.repo"
+
+  if [ ! -f "$OPENBAO_REPO_FILE" ]; then
+    echo "OpenBao repository not configured yet; nothing to update."
+    return 0
+  fi
+
+  # Keep these values in sync with configure-mirror-openbao-rpm.sh.
+  if grep -q '^includepkgs=' "$OPENBAO_REPO_FILE"; then
+    sed -i 's/^includepkgs=.*/includepkgs=openbao-2.6.*/' "$OPENBAO_REPO_FILE"
+  else
+    echo 'includepkgs=openbao-2.6.*' >> "$OPENBAO_REPO_FILE"
+  fi
+  if grep -q '^excludepkgs=' "$OPENBAO_REPO_FILE"; then
+    sed -i 's/^excludepkgs=.*/excludepkgs=openbao-hsm*/' "$OPENBAO_REPO_FILE"
+  else
+    echo 'excludepkgs=openbao-hsm*' >> "$OPENBAO_REPO_FILE"
+  fi
+
+  echo "OpenBao repository gate refreshed."
+}
+
+# EXECUTION GUARD
+update_openbao_version

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local-repo.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local-repo.spec
@@ -1,0 +1,51 @@
+%include %{_specdir}/common.inc
+# produce .elX dist tag on both centos and redhat
+%define dist %(/usr/lib/rpm/redhat/dist.sh)
+
+Name:               xroad-secret-store-local-repo
+BuildArch:          noarch
+Version:            %{xroad_version}
+# release tag, e.g. 0.201508070816.el7 for snapshots and 1.el7 (for final releases)
+Release:            %{rel}%{?snapshot}%{?dist}
+Summary:            OpenBao DNF repository and version gate for X-Road
+Group:              Applications/Internet
+License:            MIT
+Requires:           xroad-base = %version-%release
+Conflicts:          xroad-secret-store-remote
+
+%description
+Configures the OpenBao DNF repository and version gate.
+
+%clean
+rm -rf %{buildroot}
+
+%prep
+
+%build
+
+%install
+mkdir -p %{buildroot}/usr/share/xroad/scripts/
+
+cp -p %{srcdir}/../../../.scripts/configure-mirror-openbao-rpm.sh %{buildroot}/usr/share/xroad/scripts/configure-mirror-openbao.sh
+cp -p %{srcdir}/../../../.scripts/update-openbao-version-rpm.sh %{buildroot}/usr/share/xroad/scripts/update-openbao-version.sh
+
+%files
+%defattr(0640,xroad,xroad,0751)
+%attr(554,root,xroad) /usr/share/xroad/scripts/configure-mirror-openbao.sh
+%attr(554,root,xroad) /usr/share/xroad/scripts/update-openbao-version.sh
+
+%pre
+
+%upgrade_check
+
+%post -p /bin/bash
+OPENBAO_REPO_FILE="/etc/yum.repos.d/openbao.repo"
+if [ -f "$OPENBAO_REPO_FILE" ]; then
+    # Repo exists — just refresh the version gate, leave baseurl/creds as-is.
+    UPDATE_OPENBAO_VERSION="/usr/share/xroad/scripts/update-openbao-version.sh"
+    [ -x "$UPDATE_OPENBAO_VERSION" ] && "$UPDATE_OPENBAO_VERSION"
+else
+    # No repo yet — full first-time configuration.
+    CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao.sh"
+    [ -x "$CONFIGURE_OPENBAO_REPO" ] && "$CONFIGURE_OPENBAO_REPO"
+fi

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local.spec
@@ -10,7 +10,8 @@ Release:            %{rel}%{?snapshot}%{?dist}
 Summary:            Meta-package for local secret store dependencies
 Group:              Applications/Internet
 License:            MIT
-Requires:           jq, openbao < 2.6.0
+Requires:           jq, openbao < 2.7.0
+Requires:           xroad-secret-store-local-repo = %version-%release
 Requires:           xroad-database >= %version-%release, xroad-database <= %version-%{release}.1
 Conflicts:          xroad-secret-store-remote
 
@@ -35,7 +36,6 @@ cp -p %{_sourcedir}/secret-store-local/xroad-secret-store-local.service %{buildr
 cp -p %{srcdir}/common/secret-store-local/etc/xroad/services/secret-store-local.conf %{buildroot}/etc/xroad/services/
 cp -p %{srcdir}/common/secret-store-local/etc/xroad/backup.d/??_openbao %{buildroot}/etc/xroad/backup.d/
 cp -p %{srcdir}/common/secret-store-local/usr/share/xroad/scripts/* %{buildroot}/usr/share/xroad/scripts/
-cp -p %{srcdir}/../../../.scripts/configure-mirror-openbao-rpm.sh %{buildroot}/usr/share/xroad/scripts/configure-mirror-openbao.sh
 cp -p %{srcdir}/../../../../src/LICENSE.txt %{buildroot}/usr/share/doc/%{name}/LICENSE.txt
 cp -p %{srcdir}/../../../../src/3RD-PARTY-NOTICES.txt %{buildroot}/usr/share/doc/%{name}/3RD-PARTY-NOTICES.txt
 
@@ -48,18 +48,12 @@ cp -p %{srcdir}/../../../../src/3RD-PARTY-NOTICES.txt %{buildroot}/usr/share/doc
 %attr(554,root,xroad) /usr/share/xroad/scripts/_openbao.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/secret-store-init.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/secret-store-init-db.sh
-%attr(554,root,xroad) /usr/share/xroad/scripts/configure-mirror-openbao.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/backup_openbao_db.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/restore_openbao_db.sh
 %doc /usr/share/doc/%{name}/LICENSE.txt
 %doc /usr/share/doc/%{name}/3RD-PARTY-NOTICES.txt
 
-%pre -p /bin/bash
-# Configure OpenBao DNF repository if not already configured
-CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao.sh"
-if [ ! -f /etc/yum.repos.d/openbao.repo ] && [ -x "$CONFIGURE_OPENBAO_REPO" ]; then
-    "$CONFIGURE_OPENBAO_REPO"
-fi
+%pre
 
 %upgrade_check
 

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-remote.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-remote.spec
@@ -11,7 +11,7 @@ Summary:            Meta-package for remote secret store dependencies
 Group:              Applications/Internet
 License:            MIT
 Requires:           xroad-base = %version-%release
-Conflicts:          xroad-secret-store-local
+Conflicts:          xroad-secret-store-local, xroad-secret-store-local-repo
 
 %description
 Prevents local installation of OpenBao when it is hosted remotely

--- a/deployment/native-packages/src/xroad/ubuntu/generic/control
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/control
@@ -156,16 +156,22 @@ Pre-Depends: xroad-base (=${binary:Version}), xroad-center (=${binary:Version})
 Description: X-Road Central Server Management Service
  X-Road Central Server management service component
 
+Package: xroad-secret-store-local-repo
+Architecture: all
+Conflicts: xroad-secret-store-remote
+Depends: xroad-base (=${binary:Version})
+Description: OpenBao APT repository and version gate for X-Road.
+
 Package: xroad-secret-store-local
 Architecture: all
 Conflicts: xroad-secret-store-remote
 Pre-Depends: xroad-database-local (=${binary:Version}) | xroad-database-remote (=${binary:Version})
-Depends: jq, gpg, openbao (<< 2.6.0), xroad-base (=${binary:Version})
+Depends: jq, gpg, openbao (<< 2.7.0), xroad-secret-store-local-repo (=${binary:Version}), xroad-base (=${binary:Version})
 Description: Meta-package for X-Road local secret store dependencies
- 
+
 Package: xroad-secret-store-remote
 Architecture: all
-Conflicts: xroad-secret-store-local
+Conflicts: xroad-secret-store-local, xroad-secret-store-local-repo
 Description: Meta-package for X-Road remote secret store dependencies
 
 Package: xroad-auxiliary-service

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local-repo.install
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local-repo.install
@@ -1,0 +1,2 @@
+../../../../../.scripts/configure-mirror-openbao-deb.sh usr/share/xroad/scripts
+../../../../../.scripts/update-openbao-version-deb.sh usr/share/xroad/scripts

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local-repo.postinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local-repo.postinst
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" = "configure" ]; then
+  OPENBAO_REPO_FILE="/etc/apt/sources.list.d/openbao.list"
+  if [ -f "$OPENBAO_REPO_FILE" ]; then
+    # Repo exists — just refresh the version gate, leave baseurl/creds as-is.
+    UPDATE_OPENBAO_VERSION="/usr/share/xroad/scripts/update-openbao-version-deb.sh"
+    [ -x "$UPDATE_OPENBAO_VERSION" ] && "$UPDATE_OPENBAO_VERSION"
+  else
+    # No repo yet — full first-time configuration.
+    CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao-deb.sh"
+    [ -x "$CONFIGURE_OPENBAO_REPO" ] && "$CONFIGURE_OPENBAO_REPO"
+  fi
+fi

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.install
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.install
@@ -1,5 +1,4 @@
 ../../../../src/xroad/common/secret-store-local/usr/share/xroad/scripts/* usr/share/xroad/scripts
-../../../../../.scripts/configure-mirror-openbao-deb.sh usr/share/xroad/scripts/configure-mirror-openbao.sh
 ../../../../src/xroad/common/secret-store-local/etc/* etc/
 ../../../../../../src/LICENSE.txt usr/share/doc/xroad-secret-store-local/
 ../../../../../../src/3RD-PARTY-NOTICES.txt usr/share/doc/xroad-secret-store-local/

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.preinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.preinst
@@ -7,11 +7,5 @@ if [ "$1" = "upgrade" ]; then
   fi
 fi
 
-# Configure OpenBao APT repository if not already configured
-CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao.sh"
-if [ ! -f /etc/apt/sources.list.d/openbao.list ] && [ -x "$CONFIGURE_OPENBAO_REPO" ]; then
-    "$CONFIGURE_OPENBAO_REPO"
-fi
-
 #DEBHELPER#
 exit 0

--- a/development/ansible/roles/xroad-cs/tasks/ubuntu.yml
+++ b/development/ansible/roles/xroad-cs/tasks/ubuntu.yml
@@ -30,6 +30,13 @@
     name: xroad-database-remote
   when: (database_admin_password is defined) and (database_admin_password != "")
 
+- name: configure OpenBao repository gate ahead of openbao resolution
+  apt:
+    name: xroad-secret-store-local-repo
+    state: latest
+  tags:
+    - install-xroad-cs-packages
+
 - name: install xroad central server
   apt:
     name: xroad-centralserver

--- a/development/ansible/roles/xroad-ss/tasks/rhel.yml
+++ b/development/ansible/roles/xroad-ss/tasks/rhel.yml
@@ -58,6 +58,13 @@
   tags:
     - install-xroad-ss-packages
 
+- name: configure OpenBao repository gate ahead of openbao resolution
+  yum:
+    name: xroad-secret-store-local-repo
+    state: latest
+  tags:
+    - install-xroad-ss-packages
+
 - name: install xroad packages and dependencies from set up repository
   yum:
     name: "{{ vars['xroad_varpkg_' + variant] }}"

--- a/development/ansible/roles/xroad-ss/tasks/ubuntu.yml
+++ b/development/ansible/roles/xroad-ss/tasks/ubuntu.yml
@@ -34,6 +34,13 @@
   tags:
     - install-xroad-ss-packages
 
+- name: configure OpenBao repository gate ahead of openbao resolution
+  apt:
+    name: xroad-secret-store-local-repo
+    state: latest
+  tags:
+    - install-xroad-ss-packages
+
 - name: install xroad security server packages
   apt:
     name: "{{ vars['xroad_varpkg_' + variant] }}"

--- a/development/docker/security-server/openbao/Dockerfile
+++ b/development/docker/security-server/openbao/Dockerfile
@@ -1,5 +1,6 @@
-FROM openbao/openbao:2.5.1
+FROM openbao/openbao:2.6.1
 
+USER root
 RUN apk add --no-progress jq bash curl openssl > /dev/null 2>&1
 # creating xroad user and folder to reuse the secret-store-init.sh script
 RUN addgroup -S xroad && \

--- a/development/docker/security-server/openbao/files/entrypoint.sh
+++ b/development/docker/security-server/openbao/files/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-bao server -dev \
-  -dev-root-token-id="$BAO_TOKEN" \
-  -dev-listen-address="${BAO_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" &
+# Drops to the unprivileged openbao user for the network-reachable server
+# process; secret-store-init.sh below still needs root for the chown calls it
+# makes on the generated token/key files.
+su -s /bin/sh -c 'exec bao server -dev -dev-root-token-id="$BAO_TOKEN" -dev-listen-address="${BAO_DEV_LISTEN_ADDRESS:-0.0.0.0:8200}"' openbao &
 
 ./usr/share/xroad/scripts/secret-store-init.sh
 


### PR DESCRIPTION
Refs: XRDDEV-3284

This is complex approach where openbao version pins are installed and versioned with each installation of xroad. 

The `xroad-secret-store-local-repo` is introduced to place the pin before `xroad-secret-store-local` is installed. The idea is that `xroad-secret-store-local` when tries to install openbao, it is aware which approved version to install. 

The cap in `openbao < 2.7.0` and the pin installed with `xroad-secret-store-local-repo` should be enough.

This should have solved the problem of automated versioning of the pin but it doesn't. The `*-local-repo` just moved the problem in the sequence.

**Example"** running `apt install xroad-securityserver` or `dnf install xroad-securityserver`
APT/DNF picks versions for the WHOLE transaction at once including which openbao build satisfies xroad-secret-store-local `Depends/Requires` Decided here, using whatever gate is on disk right now.

Meaning the %pre or .postinst in `xroad-secret-store-local-repo` will run after the transaction has finished. On first run, the pin is not present on the machine so a version of openbao is installed based on xroad-secret-store-local `Depends/Requires` resolved by APT/DNF. Then the the end the pin will be placed on the machine. On an update the pin is present with a stale version.

TLDR: This is by design. The mirrors and pins (if really needed) must be configured before installing the .deb or .rpm packages. 

