### PR TITLE
fix: migrate xroad-secret-store-local to OpenBao 2.6.x (fix current pins)

### DIFF
--- a/deployment/.scripts/configure-mirror-openbao-deb.sh
+++ b/deployment/.scripts/configure-mirror-openbao-deb.sh
@@ -60,11 +60,13 @@ configure_openbao_deb() {
     echo "deb [signed-by=$OPENBAO_KEYRING] $OPENBAO_MIRROR_URL/ stable main" \
         > /etc/apt/sources.list.d/openbao.list
 
-    # Keeps the apt candidate below xroad-secret-store-local's `openbao (<< 2.6.0)` control-file
-    # cap; must be raised together with that cap.
+    # Keeps the apt candidate below xroad-secret-store-local's `openbao (<< 2.7.0)` control-file cap;
+    # must be raised together with that cap.
+    # Patch releases within 2.6.* are trusted without
+    # an individual validation pass — only a new minor/major raises this pin.
     cat <<'EOF' > /etc/apt/preferences.d/openbao.pref
 Package: openbao
-Pin: version 2.5.*
+Pin: version 2.6.*
 Pin-Priority: 1001
 EOF
 

--- a/deployment/.scripts/configure-mirror-openbao-rpm.sh
+++ b/deployment/.scripts/configure-mirror-openbao-rpm.sh
@@ -65,6 +65,11 @@ EOF
   rpm --import "$GPG_KEY_FILE"
   echo "OpenBao GPG key imported."
 
+  # dnf/rpm cannot enforce xroad-secret-store-local's `openbao < 2.7.0` "Requires:"
+  # — both `openbao` and `openbao-hsm` carry an unversioned `Provides: openbao`,
+  # which satisfies any version comparison on that capability regardless of the
+  # actual installed version, for any operator.
+  # Here `includepkgs` is what actually gates the version; it must be raised together with the spec's `Requires:`
   cat >/etc/yum.repos.d/openbao.repo <<EOF
 [openbao]
 name=openbao
@@ -72,6 +77,8 @@ baseurl=${OPENBAO_MIRROR_URL}
 repo_gpgcheck=0
 gpgcheck=1
 enabled=1
+includepkgs=openbao-2.6.*
+excludepkgs=openbao-hsm*
 gpgkey=file://${GPG_KEY_FILE}
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-secret-store-local.spec
@@ -10,7 +10,7 @@ Release:            %{rel}%{?snapshot}%{?dist}
 Summary:            Meta-package for local secret store dependencies
 Group:              Applications/Internet
 License:            MIT
-Requires:           jq, openbao < 2.6.0
+Requires:           jq, openbao < 2.7.0
 Requires:           xroad-database >= %version-%release, xroad-database <= %version-%{release}.1
 Conflicts:          xroad-secret-store-remote
 
@@ -35,7 +35,6 @@ cp -p %{_sourcedir}/secret-store-local/xroad-secret-store-local.service %{buildr
 cp -p %{srcdir}/common/secret-store-local/etc/xroad/services/secret-store-local.conf %{buildroot}/etc/xroad/services/
 cp -p %{srcdir}/common/secret-store-local/etc/xroad/backup.d/??_openbao %{buildroot}/etc/xroad/backup.d/
 cp -p %{srcdir}/common/secret-store-local/usr/share/xroad/scripts/* %{buildroot}/usr/share/xroad/scripts/
-cp -p %{srcdir}/../../../.scripts/configure-mirror-openbao-rpm.sh %{buildroot}/usr/share/xroad/scripts/configure-mirror-openbao.sh
 cp -p %{srcdir}/../../../../src/LICENSE.txt %{buildroot}/usr/share/doc/%{name}/LICENSE.txt
 cp -p %{srcdir}/../../../../src/3RD-PARTY-NOTICES.txt %{buildroot}/usr/share/doc/%{name}/3RD-PARTY-NOTICES.txt
 
@@ -48,18 +47,12 @@ cp -p %{srcdir}/../../../../src/3RD-PARTY-NOTICES.txt %{buildroot}/usr/share/doc
 %attr(554,root,xroad) /usr/share/xroad/scripts/_openbao.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/secret-store-init.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/secret-store-init-db.sh
-%attr(554,root,xroad) /usr/share/xroad/scripts/configure-mirror-openbao.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/backup_openbao_db.sh
 %attr(554,root,xroad) /usr/share/xroad/scripts/restore_openbao_db.sh
 %doc /usr/share/doc/%{name}/LICENSE.txt
 %doc /usr/share/doc/%{name}/3RD-PARTY-NOTICES.txt
 
-%pre -p /bin/bash
-# Configure OpenBao DNF repository if not already configured
-CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao.sh"
-if [ ! -f /etc/yum.repos.d/openbao.repo ] && [ -x "$CONFIGURE_OPENBAO_REPO" ]; then
-    "$CONFIGURE_OPENBAO_REPO"
-fi
+%pre
 
 %upgrade_check
 

--- a/deployment/native-packages/src/xroad/ubuntu/generic/control
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/control
@@ -160,9 +160,9 @@ Package: xroad-secret-store-local
 Architecture: all
 Conflicts: xroad-secret-store-remote
 Pre-Depends: xroad-database-local (=${binary:Version}) | xroad-database-remote (=${binary:Version})
-Depends: jq, gpg, openbao (<< 2.6.0), xroad-base (=${binary:Version})
+Depends: jq, gpg, openbao (<< 2.7.0), xroad-base (=${binary:Version})
 Description: Meta-package for X-Road local secret store dependencies
- 
+
 Package: xroad-secret-store-remote
 Architecture: all
 Conflicts: xroad-secret-store-local

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.install
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.install
@@ -1,5 +1,4 @@
 ../../../../src/xroad/common/secret-store-local/usr/share/xroad/scripts/* usr/share/xroad/scripts
-../../../../../.scripts/configure-mirror-openbao-deb.sh usr/share/xroad/scripts/configure-mirror-openbao.sh
 ../../../../src/xroad/common/secret-store-local/etc/* etc/
 ../../../../../../src/LICENSE.txt usr/share/doc/xroad-secret-store-local/
 ../../../../../../src/3RD-PARTY-NOTICES.txt usr/share/doc/xroad-secret-store-local/

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.preinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-secret-store-local.preinst
@@ -7,11 +7,5 @@ if [ "$1" = "upgrade" ]; then
   fi
 fi
 
-# Configure OpenBao APT repository if not already configured
-CONFIGURE_OPENBAO_REPO="/usr/share/xroad/scripts/configure-mirror-openbao.sh"
-if [ ! -f /etc/apt/sources.list.d/openbao.list ] && [ -x "$CONFIGURE_OPENBAO_REPO" ]; then
-    "$CONFIGURE_OPENBAO_REPO"
-fi
-
 #DEBHELPER#
 exit 0

--- a/development/docker/security-server/openbao/Dockerfile
+++ b/development/docker/security-server/openbao/Dockerfile
@@ -1,5 +1,6 @@
-FROM openbao/openbao:2.5.1
+FROM openbao/openbao:2.6.1
 
+USER root
 RUN apk add --no-progress jq bash curl openssl > /dev/null 2>&1
 # creating xroad user and folder to reuse the secret-store-init.sh script
 RUN addgroup -S xroad && \

--- a/development/docker/security-server/openbao/files/entrypoint.sh
+++ b/development/docker/security-server/openbao/files/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-bao server -dev \
-  -dev-root-token-id="$BAO_TOKEN" \
-  -dev-listen-address="${BAO_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" &
+# Drops to the unprivileged openbao user for the network-reachable server
+# process; secret-store-init.sh below still needs root for the chown calls it
+# makes on the generated token/key files.
+su -s /bin/sh -c 'exec bao server -dev -dev-root-token-id="$BAO_TOKEN" -dev-listen-address="${BAO_DEV_LISTEN_ADDRESS:-0.0.0.0:8200}"' openbao &
 
 ./usr/share/xroad/scripts/secret-store-init.sh
 


### PR DESCRIPTION
Refs: XRDDEV-3284

1. The openbao version cap is now 2.7.0

2. The pin version for .deb is now increased to 2.6.*

3. A pin is introduced for .rpm and is configured to install openbao package. Both openbao and openbao-hsm have `Provides: openbao` and dnf picks openbao-hsm. The openbao-hsm is just openbao with additional libraries.

4. The mirror configuration scripts are taken out from .deb and .rpm packages. The mirrors should configured before `xroad-secret-store-local` resolves openbao. The .deb and .rpm packages should not be responsible for configuring the openbao mirrors.