### PR TITLE
fix: recover original-case ACME account key aliases during migration

### DIFF
--- a/deployment/security-server/xroad-installer/tasks/migration/run_migration_cli.sh
+++ b/deployment/security-server/xroad-installer/tasks/migration/run_migration_cli.sh
@@ -299,7 +299,9 @@ main() {
   # keystore (X-Road 7 default path) into OpenBao, carrying each alias's
   # certificate expiry forward as its rotation-due timestamp. Password comes
   # from acme.yml, falling back to ACCOUNT_KEYSTORE_PASSWORD — same order
-  # X-Road 7 used.
+  # X-Road 7 used. PKCS12 lowercases aliases at write time, so the CLI
+  # recovers the original case by matching client identifiers configured in
+  # the serverconf database — hence the trailing db.properties argument.
   local acme_p12="/etc/xroad/ssl/acme.p12"
   if [[ -f "$acme_p12" ]]; then
     local acme_keystore_password=""
@@ -319,7 +321,7 @@ main() {
     export XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD="$acme_keystore_password"
     run_migration_step "acme-account-keys" \
       --description "Migrate ACME account key pairs (all aliases)\n  from: $acme_p12\n  into: OpenBao secret store" \
-      "$acme_p12"
+      "$acme_p12" "/etc/xroad/db.properties"
     unset XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD
   else
     log_info "ACME account keystore not found at $acme_p12 — skipping acme-account-keys migration"

--- a/doc/Manuals/ig-ss_x-road_v8_security_server_upgrade_guide.md
+++ b/doc/Manuals/ig-ss_x-road_v8_security_server_upgrade_guide.md
@@ -230,7 +230,7 @@ Step 11 invokes `migration-cli.jar` for the sub-commands listed below. Each sub-
 | `keyconf`                                 | The signer keyconf (keys, certificates, soft token credentials) from `/etc/xroad/signer` into the configuration database. Prompts for the soft token PIN; in unattended mode `XROAD_MIGRATION_SOFTTOKEN_PIN` must be set.                    |
 | `signer-token-pins`                       | Soft token PINs from `xroad-autologin` fetch-pin scripts into the OpenBao secret store. Skipped if `xroad-autologin` is not installed.                                                                                                       |
 | `file-to-db` (acme)                       | The contents of `/etc/xroad/conf.d/acme.yml` into the configuration database under key `xroad.acme` (proxy-ui-api scope), with the `account-keystore-password` line stripped first.                                                         |
-| `acme-account-keys`                       | Every alias in the X-Road 7 ACME account keystore (`acme.p12`) into the OpenBao secret store: the key pair plus the alias's existing certificate expiry, carried forward as the rotation-due timestamp. The certificate itself is discarded. |
+| `acme-account-keys`                       | Every alias in the X-Road 7 ACME account keystore (`acme.p12`) into the OpenBao secret store: the key pair plus the alias's existing certificate expiry, carried forward as the rotation-due timestamp. The certificate itself is discarded. PKCS12 lowercases aliases at write time, so the original case is recovered by matching client identifiers configured in the configuration database; an alias with no matching client is skipped (logged), the rest of the batch still migrates. |
 | `file-to-db` (mail)                       | The contents of `/etc/xroad/conf.d/mail.yml` into the configuration database under key `xroad.mail-notification` (proxy-ui-api scope).                                                                                                       |
 | `pgp-keys`                                | Message-log archive PGP keys from the GPG home directory (per `message-log.archive-gpg-home-directory` in `local.ini`, default `/etc/xroad/gpghome`) into the OpenBao secret store.                                                          |
 | `messagelog-key-mappings`                 | The message-log archive encryption key mapping file (path from `local.ini` `message-log.archive-encryption-keys-config`; no default) into the configuration database.                                                                        |
@@ -443,7 +443,7 @@ java -jar /var/tmp/migration-cli.jar file-to-db /etc/xroad/conf.d/mail.yml /etc/
 
 # Only if an ACME account keystore exists
 XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD='<pw>' \
-  java -jar /var/tmp/migration-cli.jar acme-account-keys /etc/xroad/ssl/acme.p12
+  java -jar /var/tmp/migration-cli.jar acme-account-keys /etc/xroad/ssl/acme.p12 /etc/xroad/db.properties
 
 java -jar /var/tmp/migration-cli.jar pgp-keys                /etc/xroad/conf.d/local.ini
 java -jar /var/tmp/migration-cli.jar messagelog-key-mappings <mapping-file>  /etc/xroad/db.properties

--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/configuration/migration/LegacyConfigMigrationCLI.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/configuration/migration/LegacyConfigMigrationCLI.java
@@ -30,12 +30,14 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.niis.xroad.common.core.exception.XrdRuntimeException;
+import org.niis.xroad.migration.acme.AcmeAccountKeyAliasResolver;
 import org.niis.xroad.migration.acme.AcmeAccountKeyMigrator;
 import org.niis.xroad.migration.messagelog.MessageLogKeyMigrator;
 import org.niis.xroad.migration.pgp.PgpKeyMigrator;
 import org.niis.xroad.migration.signer.KeyConfMigrator;
 import org.niis.xroad.migration.tokenpin.AutoLoginScriptExecutor;
 import org.niis.xroad.migration.tokenpin.TokenPinMigrator;
+import org.niis.xroad.migration.utils.DbPropertiesReader;
 
 import java.io.File;
 import java.io.IOException;
@@ -211,12 +213,16 @@ public class LegacyConfigMigrationCLI {
                       <db.properties path> Path to database properties file
 
                 ACME Account Key Migration:
-                  migration-cli acme-account-keys <acme.p12>
+                  migration-cli acme-account-keys <acme.p12> <db.properties path>
                     Migrates every ACME account key pair alias from a PKCS12 keystore to Vault,
                     carrying each alias's certificate expiry forward as its rotation-due timestamp.
                     The certificate itself is discarded; only its expiry date is migrated.
+                    PKCS12 lowercases aliases at write time, so the original case is recovered by
+                    matching against the client identifiers configured in the serverconf database;
+                    an alias with no matching client is skipped, not fatal to the rest of the batch.
                     Arguments:
-                      <acme.p12>  Path to PKCS12 keystore holding the ACME account key pair(s)
+                      <acme.p12>            Path to PKCS12 keystore holding the ACME account key pair(s)
+                      <db.properties path>  Path to database properties file (serverconf)
                     Env vars:
                       XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD  Keystore password (required)
 
@@ -277,7 +283,7 @@ public class LegacyConfigMigrationCLI {
                     migration-cli messagelog-db-encryption-keys /etc/xroad/messagelog/keystore.p12 key1
                   migration-cli messagelog-key-mappings /etc/xroad/messagelog/archive-encryption-mapping.ini /etc/xroad/db.properties
                   XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD=secret \\
-                    migration-cli acme-account-keys /etc/xroad/ssl/acme.p12
+                    migration-cli acme-account-keys /etc/xroad/ssl/acme.p12 /etc/xroad/db.properties
                   migration-cli keyconf /etc/xroad/signer /etc/xroad/db.properties
                   migration-cli configuration-anchor /etc/xroad/configuration-anchor.xml /etc/xroad/db.properties
                   migration-cli signer-devices /etc/xroad/devices.ini /etc/xroad/db.properties
@@ -361,16 +367,18 @@ public class LegacyConfigMigrationCLI {
     private static final String ACME_KEYSTORE_PASSWORD_ENV = "XROAD_MIGRATION_ACME_KEYSTORE_PASSWORD";
 
     private static void migrateAcmeAccountKeys(String[] args) throws IOException {
-        if (args.length != 1) {
-            log.error("ACME account key migration requires 1 argument");
-            log.error("Usage: migration-cli acme-account-keys <acme.p12>");
-            log.error("  <acme.p12>  Path to PKCS12 keystore holding the ACME account key pair(s)");
+        if (args.length != 2) {
+            log.error("ACME account key migration requires 2 arguments");
+            log.error("Usage: migration-cli acme-account-keys <acme.p12> <db.properties path>");
+            log.error("  <acme.p12>            Path to PKCS12 keystore holding the ACME account key pair(s)");
+            log.error("  <db.properties path>  Path to database properties file (serverconf)");
             log.error("Env vars:");
             log.error("  {}  Keystore password (required)", ACME_KEYSTORE_PASSWORD_ENV);
             System.exit(1);
         }
 
         String keystorePath = args[0];
+        String dbPropertiesPath = args[1];
 
         String password = System.getenv(ACME_KEYSTORE_PASSWORD_ENV);
         if (password == null || password.isBlank()) {
@@ -380,6 +388,7 @@ public class LegacyConfigMigrationCLI {
         }
 
         validateFilePath(keystorePath, "keystore");
+        validateFilePath(dbPropertiesPath, "database properties");
 
         if (!new File(keystorePath).exists()) {
             throw new IllegalArgumentException("Keystore file does not exist: " + keystorePath);
@@ -387,7 +396,14 @@ public class LegacyConfigMigrationCLI {
 
         log.info("Starting ACME account key migration");
         var vaultClient = MigrationVaultClient.createAndPreflight();
-        var migrator = new AcmeAccountKeyMigrator(vaultClient);
+        var dbCredentials = DbPropertiesReader.readDbCredentials(Paths.get(dbPropertiesPath), "serverconf");
+        AcmeAccountKeyAliasResolver aliasResolver;
+        try {
+            aliasResolver = AcmeAccountKeyAliasResolver.fromServerconfDatabase(dbCredentials);
+        } catch (Exception e) {
+            throw new MigrationException("Failed to load client identifiers from serverconf database", e);
+        }
+        var migrator = new AcmeAccountKeyMigrator(vaultClient, aliasResolver);
         var result = migrator.migrateFromKeystore(Paths.get(keystorePath), password.toCharArray());
         log.info("ACME account key migration result: {}", result);
     }

--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
@@ -1,0 +1,161 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.migration.acme;
+
+import ee.ria.xroad.common.identifier.ClientId;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.niis.xroad.migration.utils.DbCredentials;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Recovers the original-case form of a PKCS12 keystore alias that Java's {@link java.security.KeyStore}
+ * has irreversibly lowercased at write time, by matching it against the case-sensitive client identifiers
+ * configured in the serverconf database.
+ */
+@Slf4j
+public final class AcmeAccountKeyAliasResolver {
+
+    private static final List<String> ALIAS_PREFIXES = List.of("auth_", "sign_");
+
+    private static final String SELECT_CLIENT_IDENTIFIERS =
+            "SELECT i.xroad_instance, i.member_class, i.member_code, i.subsystem_code "
+                    + "FROM client c JOIN identifier i ON c.identifier = i.id";
+
+    private final Map<String, String> lowercaseToOriginalCase;
+
+    private AcmeAccountKeyAliasResolver(Map<String, String> lowercaseToOriginalCase) {
+        this.lowercaseToOriginalCase = lowercaseToOriginalCase;
+    }
+
+    /**
+     * An empty resolver that never recovers original casing. Used when no serverconf database is available.
+     */
+    public static AcmeAccountKeyAliasResolver identity() {
+        return new AcmeAccountKeyAliasResolver(Map.of());
+    }
+
+    /**
+     * Builds a resolver from every client identifier configured in the serverconf database.
+     */
+    public static AcmeAccountKeyAliasResolver fromServerconfDatabase(DbCredentials dbCredentials) throws SQLException {
+        return fromKnownClientIds(loadClientIdentifiers(dbCredentials));
+    }
+
+    /**
+     * Builds a resolver directly from a collection of encoded client IDs, bypassing the database.
+     *
+     * <p>Two distinct client identifiers that differ only by case fold to the same PKCS12 alias and
+     * cannot be told apart from an enumerated (lowercased) alias alone. Rather than picking an
+     * arbitrary winner between them - which would silently misattribute a decrypted key to the wrong
+     * client's Vault entry - any such colliding identifier is excluded so it resolves to
+     * {@link Optional#empty()} for every client sharing that lowercase form.
+     */
+    static AcmeAccountKeyAliasResolver fromKnownClientIds(Collection<String> encodedClientIds) {
+        Map<String, String> lowercaseToOriginalCase = new HashMap<>();
+        Set<String> ambiguousLowercaseIds = new HashSet<>();
+        for (String encodedClientId : encodedClientIds) {
+            String lowercaseId = encodedClientId.toLowerCase(Locale.ROOT);
+            String existing = lowercaseToOriginalCase.putIfAbsent(lowercaseId, encodedClientId);
+            if (existing != null && !existing.equals(encodedClientId)) {
+                ambiguousLowercaseIds.add(lowercaseId);
+            }
+        }
+        for (String ambiguousLowercaseId : ambiguousLowercaseIds) {
+            log.warn("Multiple client identifiers in serverconf differ only by case and both fold to '{}' - "
+                    + "their ACME account key aliases cannot be told apart from an enumerated PKCS12 alias, so "
+                    + "none of them will be resolved and their keys will be skipped during migration",
+                    ambiguousLowercaseId);
+            lowercaseToOriginalCase.remove(ambiguousLowercaseId);
+        }
+        return new AcmeAccountKeyAliasResolver(lowercaseToOriginalCase);
+    }
+
+    /**
+     * Recovers the original-case alias for a lowercased alias enumerated from a PKCS12 keystore.
+     *
+     * @param enumeratedAlias the lowercased alias as returned by {@link java.security.KeyStore#aliases()}
+     * @return the original-case alias, or {@link Optional#empty()} if no matching client identifier was found
+     */
+    public Optional<String> resolveOriginalCaseAlias(String enumeratedAlias) {
+        return lookup(enumeratedAlias).or(() -> resolvePrefixedAlias(enumeratedAlias));
+    }
+
+    private Optional<String> resolvePrefixedAlias(String enumeratedAlias) {
+        return ALIAS_PREFIXES.stream()
+                .filter(enumeratedAlias::startsWith)
+                .findFirst()
+                .flatMap(prefix -> lookup(enumeratedAlias.substring(prefix.length())).map(prefix::concat));
+    }
+
+    private Optional<String> lookup(String alias) {
+        return Optional.ofNullable(lowercaseToOriginalCase.get(alias.toLowerCase(Locale.ROOT)));
+    }
+
+    private static Collection<String> loadClientIdentifiers(DbCredentials dbCredentials) throws SQLException {
+        PGSimpleDataSource dataSource = new PGSimpleDataSource();
+        dataSource.setUrl(dbCredentials.jdbcUrl());
+        dataSource.setUser(dbCredentials.username());
+        dataSource.setPassword(new String(dbCredentials.password()));
+        if (StringUtils.isNotBlank(dbCredentials.schema())) {
+            dataSource.setCurrentSchema(dbCredentials.schema());
+        }
+
+        List<String> encodedClientIds = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(SELECT_CLIENT_IDENTIFIERS)) {
+            while (resultSet.next()) {
+                String encodedId = ClientId.Conf.create(
+                        resultSet.getString("xroad_instance"),
+                        resultSet.getString("member_class"),
+                        resultSet.getString("member_code"),
+                        resultSet.getString("subsystem_code")
+                ).asEncodedId();
+                encodedClientIds.add(encodedId);
+            }
+        }
+
+        log.info("Loaded {} client identifier(s) from serverconf database for ACME alias resolution", encodedClientIds.size());
+        return encodedClientIds;
+    }
+}

--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
@@ -40,17 +40,18 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
- * Recovers the original-case form of a PKCS12 keystore alias that Java's {@link java.security.KeyStore}
- * has irreversibly lowercased at write time, by matching it against the case-sensitive client identifiers
- * configured in the serverconf database.
+ * Recovers the candidate original-case form(s) of a PKCS12 keystore alias that Java's
+ * {@link java.security.KeyStore} has irreversibly lowercased at write time, by matching it against the
+ * case-sensitive client identifiers configured in the serverconf database. Case-insensitive matching means
+ * more than one client identifier can plausibly explain the same enumerated alias; this resolver surfaces
+ * every such candidate rather than guessing, leaving disambiguation to the caller.
  */
 @Slf4j
 public final class AcmeAccountKeyAliasResolver {
@@ -61,10 +62,10 @@ public final class AcmeAccountKeyAliasResolver {
             "SELECT i.xroad_instance, i.member_class, i.member_code, i.subsystem_code "
                     + "FROM client c JOIN identifier i ON c.identifier = i.id";
 
-    private final Map<String, String> lowercaseToOriginalCase;
+    private final Map<String, Set<String>> candidatesByLowercaseId;
 
-    private AcmeAccountKeyAliasResolver(Map<String, String> lowercaseToOriginalCase) {
-        this.lowercaseToOriginalCase = lowercaseToOriginalCase;
+    private AcmeAccountKeyAliasResolver(Map<String, Set<String>> candidatesByLowercaseId) {
+        this.candidatesByLowercaseId = candidatesByLowercaseId;
     }
 
     /**
@@ -84,51 +85,61 @@ public final class AcmeAccountKeyAliasResolver {
     /**
      * Builds a resolver directly from a collection of encoded client IDs, bypassing the database.
      *
-     * <p>Two distinct client identifiers that differ only by case fold to the same PKCS12 alias and
-     * cannot be told apart from an enumerated (lowercased) alias alone. Rather than picking an
-     * arbitrary winner between them - which would silently misattribute a decrypted key to the wrong
-     * client's Vault entry - any such colliding identifier is excluded so it resolves to
-     * {@link Optional#empty()} for every client sharing that lowercase form.
+     * <p>Two distinct client identifiers that differ only by case fold to the same PKCS12 alias, so an
+     * enumerated (lowercased) alias alone cannot tell them apart - both are kept as candidates and left
+     * for {@link #resolveOriginalCaseAliasCandidates(String)}'s caller to disambiguate, e.g. by testing
+     * each one as a PKCS12 entry password: password matching is exact-byte, so at most one candidate can
+     * ever actually decrypt a given entry.
      */
     static AcmeAccountKeyAliasResolver fromKnownClientIds(Collection<String> encodedClientIds) {
-        Map<String, String> lowercaseToOriginalCase = new HashMap<>();
-        Set<String> ambiguousLowercaseIds = new HashSet<>();
+        return new AcmeAccountKeyAliasResolver(groupByLowercaseId(encodedClientIds));
+    }
+
+    private static Map<String, Set<String>> groupByLowercaseId(Collection<String> encodedClientIds) {
+        Map<String, Set<String>> candidatesByLowercaseId = new HashMap<>();
         for (String encodedClientId : encodedClientIds) {
-            String lowercaseId = encodedClientId.toLowerCase(Locale.ROOT);
-            String existing = lowercaseToOriginalCase.putIfAbsent(lowercaseId, encodedClientId);
-            if (existing != null && !existing.equals(encodedClientId)) {
-                ambiguousLowercaseIds.add(lowercaseId);
-            }
+            candidatesByLowercaseId
+                    .computeIfAbsent(encodedClientId.toLowerCase(Locale.ROOT), id -> new LinkedHashSet<>())
+                    .add(encodedClientId);
         }
-        for (String ambiguousLowercaseId : ambiguousLowercaseIds) {
-            log.warn("Multiple client identifiers in serverconf differ only by case and both fold to '{}' - "
-                    + "their ACME account key aliases cannot be told apart from an enumerated PKCS12 alias, so "
-                    + "none of them will be resolved and their keys will be skipped during migration",
-                    ambiguousLowercaseId);
-            lowercaseToOriginalCase.remove(ambiguousLowercaseId);
-        }
-        return new AcmeAccountKeyAliasResolver(lowercaseToOriginalCase);
+        return candidatesByLowercaseId;
     }
 
     /**
-     * Recovers the original-case alias for a lowercased alias enumerated from a PKCS12 keystore.
+     * Returns every original-case client identifier that could plausibly be the enumerated (lowercased)
+     * PKCS12 alias, given both its bare and its auth_/sign_-prefixed encodings.
+     *
+     * <p>Usually zero or one candidate. More than one means the enumerated alias is genuinely ambiguous
+     * between multiple case-colliding clients; the caller must disambiguate rather than assume any one
+     * candidate is correct (e.g. only one can be the real PKCS12 entry password).
      *
      * @param enumeratedAlias the lowercased alias as returned by {@link java.security.KeyStore#aliases()}
-     * @return the original-case alias, or {@link Optional#empty()} if no matching client identifier was found
+     * @return every matching original-case candidate, possibly empty
      */
-    public Optional<String> resolveOriginalCaseAlias(String enumeratedAlias) {
-        return lookup(enumeratedAlias).or(() -> resolvePrefixedAlias(enumeratedAlias));
+    public List<String> resolveOriginalCaseAliasCandidates(String enumeratedAlias) {
+        Set<String> candidates = new LinkedHashSet<>(lookup(enumeratedAlias));
+        candidates.addAll(prefixedCandidates(enumeratedAlias));
+        return List.copyOf(candidates);
     }
 
-    private Optional<String> resolvePrefixedAlias(String enumeratedAlias) {
+    private Set<String> prefixedCandidates(String enumeratedAlias) {
         return ALIAS_PREFIXES.stream()
                 .filter(enumeratedAlias::startsWith)
                 .findFirst()
-                .flatMap(prefix -> lookup(enumeratedAlias.substring(prefix.length())).map(prefix::concat));
+                .map(prefix -> withPrefix(prefix, lookup(enumeratedAlias.substring(prefix.length()))))
+                .orElse(Set.of());
     }
 
-    private Optional<String> lookup(String alias) {
-        return Optional.ofNullable(lowercaseToOriginalCase.get(alias.toLowerCase(Locale.ROOT)));
+    private static Set<String> withPrefix(String prefix, Set<String> memberIds) {
+        Set<String> prefixed = new LinkedHashSet<>();
+        for (String memberId : memberIds) {
+            prefixed.add(prefix + memberId);
+        }
+        return prefixed;
+    }
+
+    private Set<String> lookup(String alias) {
+        return candidatesByLowercaseId.getOrDefault(alias.toLowerCase(Locale.ROOT), Set.of());
     }
 
     private static Collection<String> loadClientIdentifiers(DbCredentials dbCredentials) throws SQLException {

--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigrator.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigrator.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ import java.util.Optional;
 public final class AcmeAccountKeyMigrator {
 
     private final VaultClient vaultClient;
+    private final AcmeAccountKeyAliasResolver aliasResolver;
 
     /**
      * Migrates every alias found in the given PKCS12 keystore into its own Vault entry.
@@ -99,18 +101,27 @@ public final class AcmeAccountKeyMigrator {
         return migratedAliases;
     }
 
-    private Optional<String> migrateAlias(KeyStore keyStore, String alias) throws GeneralSecurityException {
-        X509Certificate certificate = (X509Certificate) keyStore.getCertificate(alias);
-        PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, alias.toCharArray());
+    private Optional<String> migrateAlias(KeyStore keyStore, String enumeratedAlias) throws GeneralSecurityException {
+        String resolvedAlias = aliasResolver.resolveOriginalCaseAlias(enumeratedAlias).orElse(enumeratedAlias);
+
+        X509Certificate certificate = (X509Certificate) keyStore.getCertificate(enumeratedAlias);
+        PrivateKey privateKey;
+        try {
+            privateKey = (PrivateKey) keyStore.getKey(enumeratedAlias, resolvedAlias.toCharArray());
+        } catch (UnrecoverableKeyException e) {
+            log.warn("Skipping alias '{}': could not recover the private key using the resolved alias '{}' "
+                    + "as password (no matching client identifier in serverconf, or a stale entry)", enumeratedAlias, resolvedAlias);
+            return Optional.empty();
+        }
 
         if (certificate == null || privateKey == null) {
-            log.warn("Skipping alias '{}': keystore entry is missing a certificate or private key", alias);
+            log.warn("Skipping alias '{}': keystore entry is missing a certificate or private key", enumeratedAlias);
             return Optional.empty();
         }
 
         Instant expiresAt = certificate.getNotAfter().toInstant();
-        vaultClient.createAcmeAccountKey(alias, new AcmeAccountKey(privateKey, certificate.getPublicKey(), expiresAt));
-        log.info("Migrated ACME account key for alias '{}', rotation due {}", alias, expiresAt);
-        return Optional.of(alias);
+        vaultClient.createAcmeAccountKey(resolvedAlias, new AcmeAccountKey(privateKey, certificate.getPublicKey(), expiresAt));
+        log.info("Migrated ACME account key for alias '{}', rotation due {}", resolvedAlias, expiresAt);
+        return Optional.of(resolvedAlias);
     }
 }

--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigrator.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigrator.java
@@ -102,26 +102,50 @@ public final class AcmeAccountKeyMigrator {
     }
 
     private Optional<String> migrateAlias(KeyStore keyStore, String enumeratedAlias) throws GeneralSecurityException {
-        String resolvedAlias = aliasResolver.resolveOriginalCaseAlias(enumeratedAlias).orElse(enumeratedAlias);
-
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate(enumeratedAlias);
-        PrivateKey privateKey;
+        if (certificate == null) {
+            log.warn("Skipping alias '{}': keystore entry is missing a certificate", enumeratedAlias);
+            return Optional.empty();
+        }
+
+        List<String> passwordCandidates = passwordCandidatesFor(enumeratedAlias);
+        for (String candidate : passwordCandidates) {
+            Optional<PrivateKey> privateKey = tryDecrypt(keyStore, enumeratedAlias, candidate);
+            if (privateKey.isPresent()) {
+                storeInVault(candidate, privateKey.get(), certificate);
+                return Optional.of(candidate);
+            }
+        }
+
+        log.warn("Skipping alias '{}': none of the {} candidate password(s) tried could recover the private key "
+                + "(no matching client identifier in serverconf, or a stale entry)", enumeratedAlias, passwordCandidates.size());
+        return Optional.empty();
+    }
+
+    /**
+     * Every original-case client identifier the resolver considers plausible for this enumerated alias,
+     * plus the enumerated alias itself as a fallback - the real password whenever it was already lowercase.
+     */
+    private List<String> passwordCandidatesFor(String enumeratedAlias) {
+        List<String> candidates = new ArrayList<>(aliasResolver.resolveOriginalCaseAliasCandidates(enumeratedAlias));
+        if (!candidates.contains(enumeratedAlias)) {
+            candidates.add(enumeratedAlias);
+        }
+        return candidates;
+    }
+
+    private Optional<PrivateKey> tryDecrypt(KeyStore keyStore, String enumeratedAlias, String passwordCandidate)
+            throws GeneralSecurityException {
         try {
-            privateKey = (PrivateKey) keyStore.getKey(enumeratedAlias, resolvedAlias.toCharArray());
-        } catch (UnrecoverableKeyException e) {
-            log.warn("Skipping alias '{}': could not recover the private key using the resolved alias '{}' "
-                    + "as password (no matching client identifier in serverconf, or a stale entry)", enumeratedAlias, resolvedAlias);
+            return Optional.ofNullable((PrivateKey) keyStore.getKey(enumeratedAlias, passwordCandidate.toCharArray()));
+        } catch (UnrecoverableKeyException _) {
             return Optional.empty();
         }
+    }
 
-        if (certificate == null || privateKey == null) {
-            log.warn("Skipping alias '{}': keystore entry is missing a certificate or private key", enumeratedAlias);
-            return Optional.empty();
-        }
-
+    private void storeInVault(String alias, PrivateKey privateKey, X509Certificate certificate) {
         Instant expiresAt = certificate.getNotAfter().toInstant();
-        vaultClient.createAcmeAccountKey(resolvedAlias, new AcmeAccountKey(privateKey, certificate.getPublicKey(), expiresAt));
-        log.info("Migrated ACME account key for alias '{}', rotation due {}", resolvedAlias, expiresAt);
-        return Optional.of(resolvedAlias);
+        vaultClient.createAcmeAccountKey(alias, new AcmeAccountKey(privateKey, certificate.getPublicKey(), expiresAt));
+        log.info("Migrated ACME account key for alias '{}', rotation due {}", alias, expiresAt);
     }
 }

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/configuration/migration/LegacyConfigMigrationCLIVaultTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/configuration/migration/LegacyConfigMigrationCLIVaultTest.java
@@ -131,7 +131,8 @@ class LegacyConfigMigrationCLIVaultTest {
         assertThatThrownBy(() ->
                 LegacyConfigMigrationCLI.main(new String[]{
                         "acme-account-keys",
-                        stubKeystore.toString()
+                        stubKeystore.toString(),
+                        tempDir.resolve("stub-db.properties").toString()
                 }))
                 .isInstanceOf(MigrationException.class)
                 .hasMessageContaining("Migration failed")
@@ -152,7 +153,8 @@ class LegacyConfigMigrationCLIVaultTest {
         assertThatThrownBy(() ->
                 LegacyConfigMigrationCLI.main(new String[]{
                         "acme-account-keys",
-                        stubKeystore.toString()
+                        stubKeystore.toString(),
+                        tempDir.resolve("stub-db.properties").toString()
                 }))
                 .isInstanceOf(MigrationException.class)
                 .hasMessageContaining("Migration failed")

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.migration.acme;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AcmeAccountKeyAliasResolverTest {
+
+    @Test
+    void identityResolverNeverResolvesAnything() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.identity();
+
+        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).isEmpty();
+    }
+
+    @Test
+    void resolvesBareMemberIdAlias() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).contains("DEV:COM:1234");
+    }
+
+    @Test
+    void resolvesAuthPrefixedAlias() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("auth_dev:com:1234")).contains("auth_DEV:COM:1234");
+    }
+
+    @Test
+    void resolvesSignPrefixedAlias() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DEV:COM:1234");
+    }
+
+    @Test
+    void resolvesAliasWithMixedCaseWithinASingleSegment() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DeV:com:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DeV:com:1234");
+    }
+
+    @Test
+    void resolvesSubsystemAlias() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234:SUB"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234:sub")).contains("sign_DEV:COM:1234:SUB");
+    }
+
+    @Test
+    void returnsEmptyWhenNoClientMatches() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+
+        Optional<String> resolved = resolver.resolveOriginalCaseAlias("sign_dev:com:9999");
+
+        assertThat(resolved).isEmpty();
+    }
+
+    @Test
+    void doesNotMatchAnUnknownPrefix() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("other_dev:com:1234")).isEmpty();
+    }
+
+    @Test
+    void neverResolvesClientIdentifiersThatDifferOnlyByCase() {
+        AcmeAccountKeyAliasResolver resolver =
+                AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "dev:com:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).isEmpty();
+    }
+
+    @Test
+    void aCaseCollisionDoesNotAffectResolutionOfUnrelatedClients() {
+        AcmeAccountKeyAliasResolver resolver =
+                AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "dev:com:1234", "DEV:COM:5678"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:5678")).contains("sign_DEV:COM:5678");
+    }
+
+    @Test
+    void aRepeatedIdenticalClientIdentifierIsNotTreatedAsACollision() {
+        AcmeAccountKeyAliasResolver resolver =
+                AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DEV:COM:1234");
+    }
+}

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
@@ -29,7 +29,6 @@ package org.niis.xroad.migration.acme;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,68 +38,68 @@ class AcmeAccountKeyAliasResolverTest {
     void identityResolverNeverResolvesAnything() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.identity();
 
-        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).isEmpty();
     }
 
     @Test
     void resolvesBareMemberIdAlias() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).contains("DEV:COM:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("dev:com:1234")).containsExactly("DEV:COM:1234");
     }
 
     @Test
     void resolvesAuthPrefixedAlias() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("auth_dev:com:1234")).contains("auth_DEV:COM:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("auth_dev:com:1234")).containsExactly("auth_DEV:COM:1234");
     }
 
     @Test
     void resolvesSignPrefixedAlias() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DEV:COM:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).containsExactly("sign_DEV:COM:1234");
     }
 
     @Test
     void resolvesAliasWithMixedCaseWithinASingleSegment() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DeV:com:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DeV:com:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).containsExactly("sign_DeV:com:1234");
     }
 
     @Test
     void resolvesSubsystemAlias() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234:SUB"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234:sub")).contains("sign_DEV:COM:1234:SUB");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234:sub")).containsExactly("sign_DEV:COM:1234:SUB");
     }
 
     @Test
     void returnsEmptyWhenNoClientMatches() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
 
-        Optional<String> resolved = resolver.resolveOriginalCaseAlias("sign_dev:com:9999");
-
-        assertThat(resolved).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:9999")).isEmpty();
     }
 
     @Test
     void doesNotMatchAnUnknownPrefix() {
         AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("other_dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("other_dev:com:1234")).isEmpty();
     }
 
     @Test
-    void neverResolvesClientIdentifiersThatDifferOnlyByCase() {
+    void returnsEveryCandidateWhenClientIdentifiersDifferOnlyByCase() {
         AcmeAccountKeyAliasResolver resolver =
                 AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "dev:com:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).isEmpty();
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("dev:com:1234"))
+                .containsExactlyInAnyOrder("DEV:COM:1234", "dev:com:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234"))
+                .containsExactlyInAnyOrder("sign_DEV:COM:1234", "sign_dev:com:1234");
     }
 
     @Test
@@ -108,8 +107,9 @@ class AcmeAccountKeyAliasResolverTest {
         AcmeAccountKeyAliasResolver resolver =
                 AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "dev:com:1234", "DEV:COM:5678"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("dev:com:1234")).isEmpty();
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:5678")).contains("sign_DEV:COM:5678");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("dev:com:1234"))
+                .containsExactlyInAnyOrder("DEV:COM:1234", "dev:com:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:5678")).containsExactly("sign_DEV:COM:5678");
     }
 
     @Test
@@ -117,6 +117,6 @@ class AcmeAccountKeyAliasResolverTest {
         AcmeAccountKeyAliasResolver resolver =
                 AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "DEV:COM:1234"));
 
-        assertThat(resolver.resolveOriginalCaseAlias("sign_dev:com:1234")).contains("sign_DEV:COM:1234");
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).containsExactly("sign_DEV:COM:1234");
     }
 }

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigratorTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigratorTest.java
@@ -183,6 +183,24 @@ class AcmeAccountKeyMigratorTest {
     }
 
     @Test
+    void shouldDisambiguateACaseCollisionByTestingEachCandidateAsTheDecryptPassword() throws Exception {
+        String realAlias = "sign_DEV:COM:1234";
+        Path keystorePath = buildKeystore(realAlias);
+
+        // "dev:COM:1234" only differs by case from the real client, and neither client's
+        // identifier alone can be preferred - only the real one will actually decrypt the entry.
+        AcmeAccountKeyAliasResolver resolver =
+                AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "dev:COM:1234"));
+        migrator = new AcmeAccountKeyMigrator(vaultClient, resolver);
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.migratedAliases()).containsExactly(realAlias);
+        assertThat(storedKeys).containsOnlyKeys(realAlias);
+    }
+
+    @Test
     void shouldSkipUnresolvableAliasWithoutAbortingTheRestOfTheBatch() throws Exception {
         String resolvableAlias = "sign_DEV:COM:1234";
         String unresolvableAlias = "sign_XYZ:ORG:9999";
@@ -196,6 +214,23 @@ class AcmeAccountKeyMigratorTest {
         assertThat(result.success()).isTrue();
         assertThat(result.migratedAliases()).containsExactly(resolvableAlias);
         assertThat(storedKeys).containsOnlyKeys(resolvableAlias);
+    }
+
+    @Test
+    void shouldSkipWhenNoCaseCollisionCandidateDecryptsTheEntry() throws Exception {
+        String staleAlias = "sign_DEV:COM:1234";
+        Path keystorePath = buildKeystore(staleAlias);
+
+        // Neither known candidate matches the entry's real (stale/removed) original-case password.
+        AcmeAccountKeyAliasResolver resolver =
+                AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("Dev:COM:1234", "dEV:COM:1234"));
+        migrator = new AcmeAccountKeyMigrator(vaultClient, resolver);
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isFalse();
+        assertThat(result.skipped()).isTrue();
+        verifyNoInteractions(vaultClient);
     }
 
     @Test

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigratorTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyMigratorTest.java
@@ -46,6 +46,7 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,7 +84,7 @@ class AcmeAccountKeyMigratorTest {
             storedKeys.put(alias, key);
             return null;
         }).when(vaultClient).createAcmeAccountKey(any(), any());
-        migrator = new AcmeAccountKeyMigrator(vaultClient);
+        migrator = new AcmeAccountKeyMigrator(vaultClient, AcmeAccountKeyAliasResolver.identity());
     }
 
     @Test
@@ -147,6 +148,68 @@ class AcmeAccountKeyMigratorTest {
         assertThatThrownBy(() -> migrator.migrateFromKeystore(missing, password))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("not found");
+    }
+
+    @Test
+    void shouldMigrateMixedCaseAliasUnderItsOriginalCase() throws Exception {
+        String originalCaseAlias = "sign_DEV:COM:1234";
+        Path keystorePath = buildKeystore(originalCaseAlias);
+
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+        migrator = new AcmeAccountKeyMigrator(vaultClient, resolver);
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.migratedAliases()).containsExactly(originalCaseAlias);
+        assertThat(storedKeys).containsOnlyKeys(originalCaseAlias);
+        assertThat(storedKeys.get(originalCaseAlias).privateKey())
+                .isEqualTo(generatedKeyPairs.get(originalCaseAlias).getPrivate());
+    }
+
+    @Test
+    void shouldMigrateAliasWithMixedCaseWithinASingleSegment() throws Exception {
+        String originalCaseAlias = "sign_DeV:com:1234";
+        Path keystorePath = buildKeystore(originalCaseAlias);
+
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DeV:com:1234"));
+        migrator = new AcmeAccountKeyMigrator(vaultClient, resolver);
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.migratedAliases()).containsExactly(originalCaseAlias);
+        assertThat(storedKeys).containsOnlyKeys(originalCaseAlias);
+    }
+
+    @Test
+    void shouldSkipUnresolvableAliasWithoutAbortingTheRestOfTheBatch() throws Exception {
+        String resolvableAlias = "sign_DEV:COM:1234";
+        String unresolvableAlias = "sign_XYZ:ORG:9999";
+        Path keystorePath = buildKeystore(resolvableAlias, unresolvableAlias);
+
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234"));
+        migrator = new AcmeAccountKeyMigrator(vaultClient, resolver);
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.migratedAliases()).containsExactly(resolvableAlias);
+        assertThat(storedKeys).containsOnlyKeys(resolvableAlias);
+    }
+
+    @Test
+    void shouldReportNoMigratableAliasesWhenTheOnlyAliasIsUnresolvable() throws Exception {
+        String originalCaseAlias = "sign_DEV:COM:1234";
+        Path keystorePath = buildKeystore(originalCaseAlias);
+
+        migrator = new AcmeAccountKeyMigrator(vaultClient, AcmeAccountKeyAliasResolver.identity());
+
+        AcmeAccountKeyMigrationResult result = migrator.migrateFromKeystore(keystorePath, KEYSTORE_PASSWORD.clone());
+
+        assertThat(result.success()).isFalse();
+        assertThat(result.skipped()).isTrue();
+        verifyNoInteractions(vaultClient);
     }
 
     @Test


### PR DESCRIPTION
PKCS12 lowercases keystore aliases at write time. Recover the original case from serverconf client identifiers for both the decrypt password and the Vault storage key, skip unresolvable aliases instead of aborting the batch, and update the CLI arg + upgrade wizard to match.

Refs: XRDDEV-3070