### PR TITLE
chore: minor bugfixes found during HA analysis

### DIFF
--- a/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/_backup_restore_common.sh
+++ b/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/_backup_restore_common.sh
@@ -54,7 +54,7 @@ check_central_ha_node_name () {
   CONFIG_FILE="/etc/xroad/conf.d/local.yaml"
   local node_name=""
   if [ -f "$CONFIG_FILE" ]; then
-    node_name=get_prop "$CONFIG_FILE" "xroad.admin-service.ha-node-name"
+    node_name=$(get_prop "$CONFIG_FILE" "xroad.admin-service.ha-node-name")
   fi
   if [[ $USE_BASE_64 = true ]] ; then
     CENTRAL_SERVER_HA_NODE_NAME=$(echo "$CENTRAL_SERVER_HA_NODE_NAME" | base64 --decode)

--- a/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/_setup_db.sh
+++ b/deployment/native-packages/src/xroad/common/base/usr/share/xroad/scripts/_setup_db.sh
@@ -41,7 +41,7 @@ setup_database() {
   else
     local -r root_properties=/etc/xroad.properties
   fi
-  get_db_prop() { get_prop "$db_properties" "$db_name.hibernate.connection.$1" "$2"; }
+  get_db_prop() { get_prop "$db_properties" "xroad.db.$db_name.hibernate.connection.$1" "$2"; }
 
   local db_host="${3:-127.0.0.1:5432}"
   local db_master_conn_user="$(get_prop ${root_properties} postgres.connection.user 'postgres')"
@@ -50,7 +50,7 @@ setup_database() {
 
   local db_conn_user=$(get_db_prop 'username' "${db_default_user}${suffix}")
   local db_user="${db_conn_user%%@*}"
-  local db_schema=$(get_prop ${db_properties} "$db_name.hibernate.hikari.dataSource.currentSchema" 'public')
+  local db_schema=$(get_prop ${db_properties} "xroad.db.$db_name.hibernate.hikari.dataSource.currentSchema" 'public')
   db_schema="${db_schema%%,*}"
   local db_password=$(get_db_prop 'password' "$(gen_pw)")
   local db_url=$(get_db_prop 'url' "jdbc:postgresql://$db_host/$db_name")

--- a/deployment/native-packages/src/xroad/common/center/usr/share/xroad/scripts/autobackup_xroad_center_configuration.sh
+++ b/deployment/native-packages/src/xroad/common/center/usr/share/xroad/scripts/autobackup_xroad_center_configuration.sh
@@ -4,5 +4,10 @@ BACKUP_SCRIPT="/usr/share/xroad/scripts/backup_xroad_center_configuration.sh"
 INSTANCE="$(source /usr/share/xroad/scripts/get_central_server_instance_id.sh)"
 if [[ -n "${INSTANCE}" ]] ; then
   FILENAME="/var/lib/xroad/backup/cs-automatic-backup-$(date +%Y_%m_%d_%H%M%S).gpg"
-  ${BACKUP_SCRIPT} -i ${INSTANCE} -f ${FILENAME}
+  HA_NODE_NAME="$(/usr/share/xroad/scripts/yaml_helper.sh get /etc/xroad/conf.d/local.yaml "xroad.admin-service.ha-node-name" 2>/dev/null)"
+  if [[ -n "${HA_NODE_NAME}" ]] ; then
+    ${BACKUP_SCRIPT} -i ${INSTANCE} -n ${HA_NODE_NAME} -f ${FILENAME}
+  else
+    ${BACKUP_SCRIPT} -i ${INSTANCE} -f ${FILENAME}
+  fi
 fi

--- a/deployment/native-packages/src/xroad/common/center/usr/share/xroad/scripts/backup_xroad_center_configuration.sh
+++ b/deployment/native-packages/src/xroad/common/center/usr/share/xroad/scripts/backup_xroad_center_configuration.sh
@@ -23,8 +23,25 @@ OPTIONS:
 EOF
 }
 
-get_prop() {
-  /usr/share/xroad/scripts/yaml_helper.sh get "$1" "$2" 2>/dev/null
+read_backup_encryption_settings () {
+  # shellcheck source=/dev/null
+  source /usr/share/xroad/scripts/_read_cs_db_properties.sh
+  prepare_db_props
+
+  if [ -f /etc/xroad/db_libpq.env ]; then
+    # shellcheck source=/dev/null
+    source /etc/xroad/db_libpq.env
+  fi
+
+  export PGPASSWORD="$db_password"
+  export PGOPTIONS="-c client-min-messages=warning -c search_path=${db_schema},public ${PGOPTIONS_EXTRA:-}"
+
+  local psql_q=(psql -v ON_ERROR_STOP=1 -qAt -h "${PGHOST:-$db_host}" -p "${PGPORT:-$db_port}" -U "$db_user" -d "$db_database")
+
+  ENCRYPT_BACKUP=$("${psql_q[@]}" -v k="xroad.backups.backup-encryption-enabled" \
+    -c "SELECT property_value FROM configuration_properties WHERE property_key = :'k';")
+  GPG_KEYIDS=$("${psql_q[@]}" -v k="xroad.backups.backup-encryption-keyids" \
+    -c "SELECT property_value FROM configuration_properties WHERE property_key = :'k';")
 }
 
 execute_backup () {
@@ -97,10 +114,9 @@ check_instance_id
 check_central_ha_node_name
 check_backup_file_name
 
-ENCRYPT_BACKUP=$(get_prop xroad.backups.backup-encryption-enabled)
+read_backup_encryption_settings
 ENCRYPT_BACKUP=${ENCRYPT_BACKUP:-false}
 echo "ENCRYPT_BACKUP=$ENCRYPT_BACKUP"
-GPG_KEYIDS=$(get_prop xroad.backups.backup-encryption-keyids)
 echo "GPG_KEYIDS=$GPG_KEYIDS"
 
 execute_backup

--- a/deployment/native-packages/src/xroad/common/ds-control-plane/usr/share/xroad/scripts/setup_ds_controlplane_db.sh
+++ b/deployment/native-packages/src/xroad/common/ds-control-plane/usr/share/xroad/scripts/setup_ds_controlplane_db.sh
@@ -9,7 +9,7 @@ source /usr/share/xroad/scripts/_setup_db.sh
 
 default_host=$1
 if [[ -z "$default_host" ]]; then
-    url=$(get_prop '/etc/xroad/db.properties' 'ds-control-plane.hibernate.connection.url' '')
+    url=$(get_prop '/etc/xroad/db.properties' 'xroad.db.ds-control-plane.hibernate.connection.url' '')
     pat='^jdbc:postgresql://([^/]*).*'
     if [[ "$url" =~ $pat ]]; then
         default_host="${BASH_REMATCH[1]}"

--- a/deployment/native-packages/src/xroad/common/ds-identity-hub/usr/share/xroad/scripts/setup_ds_identityhub_db.sh
+++ b/deployment/native-packages/src/xroad/common/ds-identity-hub/usr/share/xroad/scripts/setup_ds_identityhub_db.sh
@@ -9,7 +9,7 @@ source /usr/share/xroad/scripts/_setup_db.sh
 
 default_host=$1
 if [[ -z "$default_host" ]]; then
-    url=$(get_prop '/etc/xroad/db.properties' 'ds-identity-hub.hibernate.connection.url' '')
+    url=$(get_prop '/etc/xroad/db.properties' 'xroad.db.ds-identity-hub.hibernate.connection.url' '')
     pat='^jdbc:postgresql://([^/]*).*'
     if [[ "$url" =~ $pat ]]; then
         default_host="${BASH_REMATCH[1]}"

--- a/deployment/native-packages/src/xroad/common/ds-issuer-service/usr/share/xroad/scripts/setup_ds_issuerservice_db.sh
+++ b/deployment/native-packages/src/xroad/common/ds-issuer-service/usr/share/xroad/scripts/setup_ds_issuerservice_db.sh
@@ -23,9 +23,37 @@ DB_PROPS="/etc/xroad/db.properties"
 
 prepare_db_props
 
-issuer_pw=$(crudini --get "$ROOT_PROPS" '' "${DB_NAME}.database.admin_password" 2>/dev/null || true)
-if [[ -z "$issuer_pw" ]]; then
-  issuer_pw="$(gen_pw)"
+stored_pw=$(crudini --get "$ROOT_PROPS" '' "${DB_NAME}.database.admin_password" 2>/dev/null || true)
+
+# Role login is probed over TCP with the role's own credentials, not via the
+# (possibly socket-based) master connection used for provisioning.
+role_probe() {
+  PGCONNECT_TIMEOUT=5 PGPASSWORD="$stored_pw" psql -h "$db_host" -p "$db_port" -U "$ROLE_NAME" -d "$db_database" -qtA -c "\q" &>/dev/null
+}
+
+if [[ -n "$stored_pw" ]] && role_probe; then
+  log "Database role $ROLE_NAME already exists and stored credentials are valid, skipping database setup."
+  issuer_pw="$stored_pw"
+else
+  master_user=$(crudini --get "$ROOT_PROPS" '' postgres.connection.user 2>/dev/null || echo "postgres")
+  master_pw=$(crudini --get "$ROOT_PROPS" '' postgres.connection.password 2>/dev/null || true)
+
+  if [[ -n "$master_pw" ]]; then
+    psql_master() {
+      PGPASSWORD="$master_pw" psql -h "$db_host" -p "$db_port" -U "$master_user" -v ON_ERROR_STOP=1 -qtA "$@"
+    }
+  else
+    psql_master() {
+      su -l -c "psql -p $db_port -v ON_ERROR_STOP=1 -qtA $*" postgres
+    }
+  fi
+
+  issuer_pw="${stored_pw:-$(gen_pw)}"
+
+  psql_master -d postgres <<SQL || die "Failed to create role $ROLE_NAME. If the role already exists on a shared database, preseed ${DB_NAME}.database.admin_user and ${DB_NAME}.database.admin_password in $ROOT_PROPS (copy from the first node), or set XROAD_IGNORE_DATABASE_SETUP to skip database setup."
+CREATE ROLE "$ROLE_NAME" LOGIN PASSWORD '$issuer_pw';
+SQL
+
   if [[ ! -f "$ROOT_PROPS" ]]; then
     touch "$ROOT_PROPS"
     chown root:root "$ROOT_PROPS"
@@ -33,38 +61,13 @@ if [[ -z "$issuer_pw" ]]; then
   fi
   crudini --set --inplace "$ROOT_PROPS" '' "${DB_NAME}.database.admin_user" "$ROLE_NAME"
   crudini --set --inplace "$ROOT_PROPS" '' "${DB_NAME}.database.admin_password" "$issuer_pw"
-fi
 
-master_user=$(crudini --get "$ROOT_PROPS" '' postgres.connection.user 2>/dev/null || echo "postgres")
-master_pw=$(crudini --get "$ROOT_PROPS" '' postgres.connection.password 2>/dev/null || true)
-
-if [[ -n "$master_pw" ]]; then
-  psql_master() {
-    PGPASSWORD="$master_pw" psql -h "$db_host" -p "$db_port" -U "$master_user" -v ON_ERROR_STOP=1 -qtA "$@"
-  }
-else
-  psql_master() {
-    su -l -c "psql -p $db_port -v ON_ERROR_STOP=1 -qtA $*" postgres
-  }
-fi
-
-psql_master -d postgres <<SQL || die "Failed to provision role $ROLE_NAME"
-DO \$do\$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '$ROLE_NAME') THEN
-    CREATE ROLE "$ROLE_NAME" LOGIN PASSWORD '$issuer_pw';
-  ELSE
-    ALTER ROLE "$ROLE_NAME" WITH LOGIN PASSWORD '$issuer_pw';
-  END IF;
-END
-\$do\$;
-SQL
-
-psql_master -d "$db_database" <<SQL || die "Failed to provision schema $SCHEMA_NAME in $db_database"
+  psql_master -d "$db_database" <<SQL || die "Failed to provision schema $SCHEMA_NAME in $db_database"
 CREATE SCHEMA IF NOT EXISTS "$SCHEMA_NAME" AUTHORIZATION "$ROLE_NAME";
 GRANT USAGE ON SCHEMA "$SCHEMA_NAME" TO "$ROLE_NAME";
 GRANT CONNECT ON DATABASE "$db_database" TO "$ROLE_NAME";
 SQL
+fi
 
 if [[ ! -f "$DB_PROPS" ]]; then
   touch "$DB_PROPS"

--- a/deployment/native-packages/src/xroad/common/op-monitor/usr/share/xroad/scripts/setup_opmonitor_db.sh
+++ b/deployment/native-packages/src/xroad/common/op-monitor/usr/share/xroad/scripts/setup_opmonitor_db.sh
@@ -8,7 +8,7 @@ source /usr/share/xroad/scripts/_setup_db.sh
 
 default_host=$1
 if [[ -z "$default_host" ]]; then
-    url=$(get_prop '/etc/xroad/db.properties' 'serverconf.hibernate.connection.url' '')
+    url=$(get_prop '/etc/xroad/db.properties' 'xroad.db.serverconf.hibernate.connection.url' '')
     pat='^jdbc:postgresql://([^/]*).*'
     if [[ "$url" =~ $pat ]]; then
         default_host="${BASH_REMATCH[1]}"

--- a/deployment/native-packages/src/xroad/common/proxy/usr/share/xroad/scripts/setup_messagelog_db.sh
+++ b/deployment/native-packages/src/xroad/common/proxy/usr/share/xroad/scripts/setup_messagelog_db.sh
@@ -8,7 +8,7 @@ source /usr/share/xroad/scripts/_setup_db.sh
 
 default_host=$1
 if [[ -z "$default_host" ]]; then
-    url=$(get_prop '/etc/xroad/db.properties' 'serverconf.hibernate.connection.url' '')
+    url=$(get_prop '/etc/xroad/db.properties' 'xroad.db.serverconf.hibernate.connection.url' '')
     pat='^jdbc:postgresql://([^/]*).*'
     if [[ "$url" =~ $pat ]]; then
         default_host="${BASH_REMATCH[1]}"

--- a/deployment/native-packages/src/xroad/common/proxy/usr/share/xroad/scripts/setup_serverconf_db.sh
+++ b/deployment/native-packages/src/xroad/common/proxy/usr/share/xroad/scripts/setup_serverconf_db.sh
@@ -21,8 +21,8 @@ gen_pw() {
 setup_database() {
 
   node_type=$(crudini --get '/etc/xroad/conf.d/node.ini' node type 2>/dev/null || echo standalone)
-  if [[ "$node_type" == "slave" ]]; then
-    log "Skipping database setup on cluster slave node"
+  if [[ "$node_type" == "secondary" || "$node_type" == "slave" ]]; then
+    log "Skipping database setup on cluster secondary node"
     return 0
   fi
 

--- a/src/security-server/admin-service/ui/src/store/modules/system.ts
+++ b/src/security-server/admin-service/ui/src/store/modules/system.ts
@@ -82,14 +82,13 @@ export const useSystem = defineStore('system', {
       this.$reset();
     },
     async fetchSecurityServerNodeType() {
-      return api.get<VersionInfo>('/system/version').then((res) => {
-        this.securityServerVersion = res.data;
+      return api.get<NodeTypeResponse>('/system/node-type').then((res) => {
+        this.securityServerNodeType = res.data.node_type;
       });
     },
     async fetchSecurityServerVersion() {
-      // Fetch tokens from backend
-      return api.get<NodeTypeResponse>('/system/node-type').then((res) => {
-        this.securityServerNodeType = res.data.node_type;
+      return api.get<VersionInfo>('/system/version').then((res) => {
+        this.securityServerVersion = res.data;
       });
     },
     async fetchAuthenticationProviderType() {

--- a/src/security-server/admin-service/ui/tests/unit/systemStore.spec.ts
+++ b/src/security-server/admin-service/ui/tests/unit/systemStore.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+import { useSystem } from '@/store/modules/system';
+import { NodeType, NodeTypeResponse, VersionInfo } from '@/openapi-types';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AxiosHeaders, type AxiosResponse } from 'axios';
+import * as api from '@/util/api';
+
+vi.mock('@/util/api');
+
+function mockAxiosResponse<T>(data: T): AxiosResponse<T> {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+}
+
+describe('System store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.resetAllMocks();
+  });
+
+  it('fetchSecurityServerNodeType calls /system/node-type and stores the node type', async () => {
+    const nodeTypeResponse: NodeTypeResponse = { node_type: NodeType.SECONDARY };
+    vi.mocked(api.get).mockResolvedValueOnce(mockAxiosResponse(nodeTypeResponse));
+
+    const store = useSystem();
+    await store.fetchSecurityServerNodeType();
+
+    expect(api.get).toHaveBeenCalledWith('/system/node-type');
+    expect(store.securityServerNodeType).toEqual(NodeType.SECONDARY);
+    expect(store.securityServerVersion).toEqual({});
+  });
+
+  it('fetchSecurityServerVersion calls /system/version and stores the version info', async () => {
+    const versionInfo: VersionInfo = {
+      info: 'Security Server',
+      java_version: 21,
+      min_java_version: 21,
+      max_java_version: 25,
+      using_supported_java_version: true,
+      java_vendor: 'Eclipse Adoptium',
+      java_runtime_version: '21.0.1+12',
+    };
+    vi.mocked(api.get).mockResolvedValueOnce(mockAxiosResponse(versionInfo));
+
+    const store = useSystem();
+    await store.fetchSecurityServerVersion();
+
+    expect(api.get).toHaveBeenCalledWith('/system/version');
+    expect(store.securityServerVersion).toEqual(versionInfo);
+    expect(store.securityServerNodeType).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- _setup_db.sh now accepts the secondary node type when skipping serverconf DB setup, and reads db.properties via the prefixed keys the setup scripts write
- setup_ds_issuerservice_db.sh no longer rotates the ds-issuer-service role password on (re)install, which broke secondaries sharing the DB
- CS backup scripts: HA node-name guard restored, node name included in automatic backups, encryption settings read from configuration_properties
- SS admin UI: node-type and version fetch actions were swapped in the system store; added unit tests

Refs: XRDDEV-3333