### PR TITLE
fix: derive member id from subsystem clients during ACME key migration

### DIFF
--- a/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
+++ b/src/tool/migration-cli/src/main/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolver.java
@@ -37,7 +37,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -151,22 +150,30 @@ public final class AcmeAccountKeyAliasResolver {
             dataSource.setCurrentSchema(dbCredentials.schema());
         }
 
-        List<String> encodedClientIds = new ArrayList<>();
+        Set<String> encodedClientIds = new LinkedHashSet<>();
         try (Connection connection = dataSource.getConnection();
                 Statement statement = connection.createStatement();
                 ResultSet resultSet = statement.executeQuery(SELECT_CLIENT_IDENTIFIERS)) {
             while (resultSet.next()) {
-                String encodedId = ClientId.Conf.create(
+                ClientId.Conf clientId = ClientId.Conf.create(
                         resultSet.getString("xroad_instance"),
                         resultSet.getString("member_class"),
                         resultSet.getString("member_code"),
                         resultSet.getString("subsystem_code")
-                ).asEncodedId();
-                encodedClientIds.add(encodedId);
+                );
+                encodedClientIds.addAll(candidateEncodedIdsFor(clientId));
             }
         }
 
-        log.info("Loaded {} client identifier(s) from serverconf database for ACME alias resolution", encodedClientIds.size());
+        log.info("Loaded {} distinct member identifier(s) from serverconf database for ACME alias resolution",
+                encodedClientIds.size());
         return encodedClientIds;
+    }
+
+    static Set<String> candidateEncodedIdsFor(ClientId clientId) {
+        if (clientId.getSubsystemCode() == null) {
+            return Set.of(clientId.asEncodedId());
+        }
+        return Set.of(clientId.asEncodedId(), clientId.getMemberId().asEncodedId());
     }
 }

--- a/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
+++ b/src/tool/migration-cli/src/test/java/org/niis/xroad/migration/acme/AcmeAccountKeyAliasResolverTest.java
@@ -26,6 +26,8 @@
  */
 package org.niis.xroad.migration.acme;
 
+import ee.ria.xroad.common.identifier.ClientId;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -116,6 +118,26 @@ class AcmeAccountKeyAliasResolverTest {
     void aRepeatedIdenticalClientIdentifierIsNotTreatedAsACollision() {
         AcmeAccountKeyAliasResolver resolver =
                 AcmeAccountKeyAliasResolver.fromKnownClientIds(List.of("DEV:COM:1234", "DEV:COM:1234"));
+
+        assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).containsExactly("sign_DEV:COM:1234");
+    }
+
+    @Test
+    void candidateEncodedIdsForAMemberClientIsJustItself() {
+        assertThat(AcmeAccountKeyAliasResolver.candidateEncodedIdsFor(ClientId.Conf.create("DEV", "COM", "1234")))
+                .containsExactly("DEV:COM:1234");
+    }
+
+    @Test
+    void candidateEncodedIdsForASubsystemClientAlsoDerivesItsMember() {
+        assertThat(AcmeAccountKeyAliasResolver.candidateEncodedIdsFor(ClientId.Conf.create("DEV", "COM", "1234", "SUB")))
+                .containsExactlyInAnyOrder("DEV:COM:1234:SUB", "DEV:COM:1234");
+    }
+
+    @Test
+    void resolvesMemberAliasWhenOnlyItsSubsystemIsAKnownClient() {
+        AcmeAccountKeyAliasResolver resolver = AcmeAccountKeyAliasResolver.fromKnownClientIds(
+                AcmeAccountKeyAliasResolver.candidateEncodedIdsFor(ClientId.Conf.create("DEV", "COM", "1234", "test-consumer")));
 
         assertThat(resolver.resolveOriginalCaseAliasCandidates("sign_dev:com:1234")).containsExactly("sign_DEV:COM:1234");
     }


### PR DESCRIPTION
A sign_ alias can be a bare member id, but that member may appear in serverconf.client only through a subsystem row; derive it too.

Refs: XRDDEV-3070