### PR TITLE
fix: unblock Initial Configuration wizard on already-initialized servers

### DIFF
--- a/src/security-server/admin-service/ui/src/views/InitialConfiguration/InitialConfigurationView.vue
+++ b/src/security-server/admin-service/ui/src/views/InitialConfiguration/InitialConfigurationView.vue
@@ -49,7 +49,7 @@
         </v-stepper-window-item>
 
         <v-stepper-window-item :value="memberStep">
-          <OwnerMemberStep :value="memberStep" @previous="previousStep" @done="nextStep" />
+          <OwnerMemberStep :value="memberStep" :show-previous-button="!!anchorStep" @previous="previousStep" @done="nextStep" />
         </v-stepper-window-item>
         <v-stepper-window-item :value="pinStep">
           <TokenPinStep :save-busy="pinSaveBusy" @previous="previousStep" @done="tokenPinReady" />
@@ -128,6 +128,9 @@ export default defineComponent({
     this.fetchInitializationStatus().catch((error) => {
       this.addError(error);
     });
+    // The current security server only exists once the owner member is set up,
+    // so this fails silently on a server that has not been initialized yet.
+    this.fetchCurrentSecurityServer().catch(() => undefined);
   },
   methods: {
     ...mapActions(useAlerts, ['checkAlertStatus']),

--- a/src/security-server/admin-service/ui/src/views/InitialConfiguration/InitialConfigurationView.vue
+++ b/src/security-server/admin-service/ui/src/views/InitialConfiguration/InitialConfigurationView.vue
@@ -49,7 +49,7 @@
         </v-stepper-window-item>
 
         <v-stepper-window-item :value="memberStep">
-          <OwnerMemberStep :value="memberStep" :show-previous-button="!!anchorStep" @previous="previousStep" @done="nextStep" />
+          <OwnerMemberStep :value="memberStep" :show-previous-button="hasAnchorStep" @previous="previousStep" @done="nextStep" />
         </v-stepper-window-item>
         <v-stepper-window-item :value="pinStep">
           <TokenPinStep :save-busy="pinSaveBusy" @previous="previousStep" @done="tokenPinReady" />
@@ -116,6 +116,9 @@ export default defineComponent({
     anchorStep() {
       return this.isAnchorImported ? 0 : 1;
     },
+    hasAnchorStep() {
+      return this.anchorStep > 0;
+    },
     memberStep() {
       return this.anchorStep + 1;
     },
@@ -125,12 +128,16 @@ export default defineComponent({
   },
 
   created() {
-    this.fetchInitializationStatus().catch((error) => {
-      this.addError(error);
-    });
-    // The current security server only exists once the owner member is set up,
-    // so this fails silently on a server that has not been initialized yet.
-    this.fetchCurrentSecurityServer().catch(() => undefined);
+    this.fetchInitializationStatus()
+      .then(() => {
+        // The current security server only exists once the owner member is set up.
+        if (this.isServerOwnerInitialized || this.isServerCodeInitialized) {
+          return this.fetchCurrentSecurityServer();
+        }
+      })
+      .catch((error) => {
+        this.addError(error);
+      });
   },
   methods: {
     ...mapActions(useAlerts, ['checkAlertStatus']),

--- a/src/security-server/admin-service/ui/src/views/InitialConfiguration/OwnerMemberStep.vue
+++ b/src/security-server/admin-service/ui/src/views/InitialConfiguration/OwnerMemberStep.vue
@@ -174,6 +174,18 @@ export default defineComponent({
     },
   },
   beforeMount() {
+    if ((this.isServerOwnerInitialized || this.isServerCodeInitialized) && !this.currentSecurityServer) {
+      this.fetchCurrentSecurityServer()
+        .then(() => {
+          this.setFieldValue('memberClass', this.currentSecurityServer?.member_class);
+          this.setFieldValue('memberCode', this.currentSecurityServer?.member_code);
+          this.setFieldValue('securityServerCode', this.currentSecurityServer?.server_code);
+        })
+        .catch((error) => {
+          this.addError(error);
+        });
+    }
+
     this.fetchMemberClassesForCurrentInstance().catch((error) => {
       if (error.response.status === 500) {
         // this can happen if anchor is not ready
@@ -188,6 +200,8 @@ export default defineComponent({
     ...mapActions(useInitializeServer, ['storeInitServerSSCode', 'storeInitServerMemberClass', 'storeInitServerMemberCode']),
 
     ...mapActions(useGeneral, ['fetchMemberClassesForCurrentInstance', 'fetchMemberName']),
+
+    ...mapActions(useUser, ['fetchCurrentSecurityServer']),
 
     done(): void {
       this.storeInitServerMemberClass(this.values.memberClass);

--- a/src/security-server/admin-service/ui/src/views/InitialConfiguration/OwnerMemberStep.vue
+++ b/src/security-server/admin-service/ui/src/views/InitialConfiguration/OwnerMemberStep.vue
@@ -157,10 +157,24 @@ export default defineComponent({
 
   watch: {
     memberClassesCurrentInstance(val: string[]) {
-      // Set first member class selected if there is only one
-      if (val?.length === 1) {
+      // Set first member class selected if there is only one, unless the owner
+      // is already fixed by an existing server — its data takes precedence.
+      if (!this.isServerOwnerInitialized && val?.length === 1) {
         this.setFieldValue('memberClass', val[0]);
       }
+    },
+    currentSecurityServer: {
+      immediate: true,
+      handler(server) {
+        // Reacts whenever the server data arrives, regardless of whether it was
+        // already loaded before this component mounted or fetched afterwards.
+        if (!server) {
+          return;
+        }
+        this.setFieldValue('memberClass', server.member_class);
+        this.setFieldValue('memberCode', server.member_code);
+        this.setFieldValue('securityServerCode', server.server_code);
+      },
     },
     'values.memberClass'(val) {
       if (val) {
@@ -174,18 +188,6 @@ export default defineComponent({
     },
   },
   beforeMount() {
-    if ((this.isServerOwnerInitialized || this.isServerCodeInitialized) && !this.currentSecurityServer) {
-      this.fetchCurrentSecurityServer()
-        .then(() => {
-          this.setFieldValue('memberClass', this.currentSecurityServer?.member_class);
-          this.setFieldValue('memberCode', this.currentSecurityServer?.member_code);
-          this.setFieldValue('securityServerCode', this.currentSecurityServer?.server_code);
-        })
-        .catch((error) => {
-          this.addError(error);
-        });
-    }
-
     this.fetchMemberClassesForCurrentInstance().catch((error) => {
       if (error.response.status === 500) {
         // this can happen if anchor is not ready
@@ -200,8 +202,6 @@ export default defineComponent({
     ...mapActions(useInitializeServer, ['storeInitServerSSCode', 'storeInitServerMemberClass', 'storeInitServerMemberCode']),
 
     ...mapActions(useGeneral, ['fetchMemberClassesForCurrentInstance', 'fetchMemberName']),
-
-    ...mapActions(useUser, ['fetchCurrentSecurityServer']),
 
     done(): void {
       this.storeInitServerMemberClass(this.values.memberClass);

--- a/src/security-server/admin-service/ui/tests/component/initialization.browser.spec.ts
+++ b/src/security-server/admin-service/ui/tests/component/initialization.browser.spec.ts
@@ -80,6 +80,14 @@ const anchorImportedStatusFixture: InitializationStatus = {
   enforce_token_pin_policy: false,
 };
 
+const ownerAndCodeAlreadyInitializedStatusFixture: InitializationStatus = {
+  is_anchor_imported: true,
+  is_server_code_initialized: true,
+  is_server_owner_initialized: true,
+  software_token_init_status: TokenInitStatus.NOT_INITIALIZED,
+  enforce_token_pin_policy: false,
+};
+
 const currentServerFixture: SecurityServer = {
   id: 'CS:COM:1234:SS0',
   member_class: 'COM',
@@ -89,6 +97,7 @@ const currentServerFixture: SecurityServer = {
 
 validateBody(initStatusSchema, uninitializedStatusFixture);
 validateBody(initStatusSchema, anchorImportedStatusFixture);
+validateBody(initStatusSchema, ownerAndCodeAlreadyInitializedStatusFixture);
 validateBody(securityServerSchema, currentServerFixture);
 
 // ── MSW handlers ──────────────────────────────────────────────────────────────
@@ -99,6 +108,10 @@ const uninitializedStatusHandler = specHttp.get('/initialization/status', ({ res
 
 const anchorImportedStatusHandler = specHttp.get('/initialization/status', ({ response }) =>
   response(200).json(anchorImportedStatusFixture),
+);
+
+const ownerAndCodeAlreadyInitializedStatusHandler = specHttp.get('/initialization/status', ({ response }) =>
+  response(200).json(ownerAndCodeAlreadyInitializedStatusFixture),
 );
 
 const memberClassesHandler = specHttp.get('/member-classes', ({ response }) =>
@@ -157,6 +170,50 @@ describe('0100 — Security Server initialisation wizard (Browser Mode)', () => 
     await page.getByTestId('member-class-input').click();
 
     await expect.element(page.getByTestId('owner-member-save-button')).not.toBeDisabled();
+  });
+
+  it('Owner-member fields are prefilled and disabled, and Continue is enabled on load, on an already-initialized server', async () => {
+    await renderRoute('/initial-configuration', {
+      permissions: initPermissions,
+      msw: [
+        ownerAndCodeAlreadyInitializedStatusHandler,
+        memberClassesHandler,
+        memberNamesHandler,
+        currentServerHandler,
+      ],
+    });
+
+    await expect.element(page.getByTestId('member-class-input')).toBeVisible();
+
+    await expect.element(page.getByTestId('member-class-input')).toHaveTextContent(currentServerFixture.member_class ?? '');
+    await expect.element(page.getByTestId('member-class-input').getByRole('combobox').nth(1)).toBeDisabled();
+
+    await expect
+      .element(page.getByTestId('member-code-input').getByRole('textbox'))
+      .toHaveValue(currentServerFixture.member_code);
+    await expect.element(page.getByTestId('member-code-input').getByRole('textbox')).toBeDisabled();
+
+    await expect
+      .element(page.getByTestId('security-server-code-input').getByRole('textbox'))
+      .toHaveValue(currentServerFixture.server_code);
+    await expect.element(page.getByTestId('security-server-code-input').getByRole('textbox')).toBeDisabled();
+
+    await expect.element(page.getByTestId('owner-member-save-button')).not.toBeDisabled();
+  });
+
+  it('Previous button is not shown on the Owner Member step when the anchor is already imported', async () => {
+    await renderRoute('/initial-configuration', {
+      permissions: initPermissions,
+      msw: [
+        ownerAndCodeAlreadyInitializedStatusHandler,
+        memberClassesHandler,
+        memberNamesHandler,
+        currentServerHandler,
+      ],
+    });
+
+    await expect.element(page.getByTestId('member-class-input')).toBeVisible();
+    await expect.element(page.getByTestId('previous-button')).not.toBeInTheDocument();
   });
 
   it('PIN step shows token-policy alert; matching PINs enable Submit and POST 201 navigates to Clients', async () => {

--- a/src/security-server/admin-service/ui/tests/component/initialization.browser.spec.ts
+++ b/src/security-server/admin-service/ui/tests/component/initialization.browser.spec.ts
@@ -27,6 +27,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { page } from 'vitest/browser';
+import { delay } from 'msw';
 import { renderRoute } from '../setup/render-route';
 import { specHttp, validateBody } from '../setup/spec-http';
 import { Permissions, RouteName } from '@/global';
@@ -118,6 +119,17 @@ const memberClassesHandler = specHttp.get('/member-classes', ({ response }) =>
   response(200).json(['COM', 'ORG']),
 );
 
+// A single available class, different from currentServerFixture.member_class, resolving
+// after the current-server fetch, so the "only one member class available" auto-select
+// would clobber the owner's already-populated real class if it were not guarded against
+// an already-initialized owner.
+const singleOtherMemberClassHandler = specHttp.get('/member-classes', async ({ response }) => {
+  await delay(50);
+  return response(200).json(['ORG']);
+});
+
+const emptyMemberClassesHandler = specHttp.get('/member-classes', ({ response }) => response(200).json([]));
+
 const memberNamesHandler = specHttp.get('/member-names', ({ response }) =>
   response(404).empty(),
 );
@@ -197,6 +209,45 @@ describe('0100 — Security Server initialisation wizard (Browser Mode)', () => 
       .element(page.getByTestId('security-server-code-input').getByRole('textbox'))
       .toHaveValue(currentServerFixture.server_code);
     await expect.element(page.getByTestId('security-server-code-input').getByRole('textbox')).toBeDisabled();
+
+    await expect.element(page.getByTestId('owner-member-save-button')).not.toBeDisabled();
+  });
+
+  it("Owner's real member class is not overwritten by the single-available-class auto-select, on an already-initialized server", async () => {
+    await renderRoute('/initial-configuration', {
+      permissions: initPermissions,
+      msw: [
+        ownerAndCodeAlreadyInitializedStatusHandler,
+        singleOtherMemberClassHandler,
+        memberNamesHandler,
+        currentServerHandler,
+      ],
+    });
+
+    await expect.element(page.getByTestId('member-class-input')).toBeVisible();
+    await expect.element(page.getByTestId('member-class-input')).toHaveTextContent(currentServerFixture.member_class ?? '');
+  });
+
+  it('Owner-member fields stay prefilled and Continue stays enabled when the current instance has no member classes, on an already-initialized server', async () => {
+    await renderRoute('/initial-configuration', {
+      permissions: initPermissions,
+      msw: [
+        ownerAndCodeAlreadyInitializedStatusHandler,
+        emptyMemberClassesHandler,
+        memberNamesHandler,
+        currentServerHandler,
+      ],
+    });
+
+    await expect.element(page.getByTestId('member-class-input')).toBeVisible();
+    await expect.element(page.getByTestId('member-class-input')).toHaveTextContent(currentServerFixture.member_class ?? '');
+
+    await expect
+      .element(page.getByTestId('member-code-input').getByRole('textbox'))
+      .toHaveValue(currentServerFixture.member_code);
+    await expect
+      .element(page.getByTestId('security-server-code-input').getByRole('textbox'))
+      .toHaveValue(currentServerFixture.server_code);
 
     await expect.element(page.getByTestId('owner-member-save-button')).not.toBeDisabled();
   });


### PR DESCRIPTION
On a Security Server whose owner member, server code, and anchor are already set (e.g. right after a 7.8 -> 8 upgrade, before the software token is logged back in), the wizard's Owner Member step read its prefill data from a store field that was never populated before the step mounted, so the fields rendered blank and Continue never enabled. InitialConfigurationView now fetches the current security server before the step needs it, and OwnerMemberStep falls back to fetching it itself if the fields are still empty on mount.

Separately, the same already-initialized case left the Owner Member step effectively first in the wizard (the anchor step is hidden once imported), but its Previous button still rendered unconditionally. Clicking it navigated to the anchor step's stepper pane, which has no content in that state, blanking the page. Previous is now only shown when an anchor step actually precedes Owner Member.

Refs: XRDDEV-3344

<img width="1851" height="949" alt="Screenshot from 2026-09-02 19-17-01" src="https://github.com/user-attachments/assets/33248a96-06bb-4d73-9954-981ce8b4236b" />

Previous btn bug:
<img width="1176" height="283" alt="Screenshot from 2026-09-02 19-38-22" src="https://github.com/user-attachments/assets/e29da36d-f026-439c-97cd-58065edd2512" />


