### PR TITLE
fix: seed CS TLS certificate-provisioning identity into the DB, not dead conf.d YAML

### DIFF
--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
@@ -11,12 +11,25 @@ abort() {
 }
 log() { echo "xroad-center: $*" >&2; }
 get_prop() { crudini --get "$1" '' "$2" 2>/dev/null || echo -n "$3"; }
-get_yaml_prop() {
-  /usr/share/xroad/scripts/yaml_helper.sh get "$1" "$2" 2>/dev/null
-}
 
 gen_pw() {
   head -c 24 /dev/urandom | base64 | tr "/+" "_-"
+}
+
+# Checks whether a configuration_properties row exists for $1 (via db_property.sh, the only
+# channel the XRoadConfig DSL reads instance overrides from). Returns 0 when present, 1 when
+# absent, and aborts on a database error rather than treating it as absent — treating a query
+# failure as "absent" would let an unrelated DB outage clobber an instance-wide row on this
+# node's next configure run.
+db_row_present() {
+  local -r key="$1"
+  local rc=0
+  /usr/share/xroad/scripts/db_property.sh get "$key" >/dev/null || rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) abort "Unable to read ${key} from the database. ABORTING." ;;
+  esac
 }
 
 # setup database and run migrations
@@ -198,15 +211,7 @@ configure_dataspace_issuer_host() {
     reconfiguring=1
   fi
 
-  local row_present=0 rc=0
-  /usr/share/xroad/scripts/db_property.sh get "$key" >/dev/null || rc=$?
-  case "$rc" in
-    0) row_present=1 ;;
-    1) row_present=0 ;;
-    *) abort "Unable to read ${key} from the database. ABORTING." ;;
-  esac
-
-  if [[ "$row_present" -eq 1 && "$reconfiguring" != "1" ]]; then
+  if db_row_present "$key" && [[ "$reconfiguring" != "1" ]]; then
     log "Dataspace issuer host is already configured, skipping"
     return
   fi
@@ -226,8 +231,36 @@ extract_dns_list() {
   echo "$1" | tr ',' '\n' | grep '^DNS:' | sed 's/^DNS://' | paste -sd,
 }
 
+# Writes the debconf-collected TLS certificate identity for the admin-service and
+# management-service vault-provisioned certificates to the CS configuration_properties DB —
+# the only place the XRoadConfig DSL resolves these keys from (see configure_dataspace_issuer_host
+# above for the same channel). Must run after setup_database() so the table exists.
+#
+# registration-service no longer provisions its own certificate (commit c64700480a): it reuses
+# the management-service certificate from Vault, so no xroad.registration-service.tls.* keys
+# are written here.
+#
+# Each service's three keys (common-name, alt-names, ip-subject-alt-names) are treated as one
+# group, keyed off common-name: existing rows are left untouched except under dpkg-reconfigure
+# (DEBCONF_RECONFIGURE=1, or "reconfigure" as $1 per debconf-devel(7) forward-compat guidance —
+# postinst itself always receives "configure").
+#
+# Skipped entirely when database migrations were skipped (operator-managed/legacy migration
+# installs): the schema may predate the configuration_properties table, and the debconf
+# questions can be (re-)asked later via dpkg-reconfigure once the schema is migrated.
 prepare_certificates_settings() {
-  CONFIG_FILE="/etc/xroad/conf.d/local-tls.yaml"
+  RET=""
+  db_get xroad-common/skip-cs-db-migrations || true
+  if [[ "$RET" == "true" ]]; then
+    log "Database migrations were skipped — not storing TLS certificate identity; run 'dpkg-reconfigure xroad-center' after migrating"
+    return
+  fi
+
+  local reconfiguring=""
+  if [[ "${DEBCONF_RECONFIGURE:-}" == "1" || "${1:-}" == "reconfigure" ]]; then
+    reconfiguring=1
+  fi
+
   HOST=$(hostname -f)
   if (( ${#HOST} > 64 )); then
     HOST="$(hostname -s)"
@@ -236,10 +269,9 @@ prepare_certificates_settings() {
   for i in $(ip addr | grep 'scope global' | tr '/' ' ' | awk '{print $2}'); do LIST+="IP:$i,"; done;
   ALT="${LIST}DNS:$(hostname -f),DNS:$(hostname -s)"
 
-  if [[ -z $(get_yaml_prop "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.common-name") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.alt-names") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.ip-subject-alt-names") ]]; then
-
+  if db_row_present "xroad.admin-service.tls.certificate-provisioning.common-name" && [[ "$reconfiguring" != "1" ]]; then
+    log "Center-admin-service certificate properties are set, skipping"
+  else
     log "Preparing center-admin-service certificate properties"
     db_subst xroad-common/admin-subject HOST "$HOST"
     db_subst xroad-common/admin-altsubject ALT "$ALT"
@@ -264,21 +296,18 @@ prepare_certificates_settings() {
     ip_list=$(extract_ip_list "$altn")
     dns_list=$(extract_dns_list "$altn")
 
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.common-name" "$subj"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.alt-names" "$dns_list"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.admin-service.tls.certificate-provisioning.ip-subject-alt-names" "$ip_list"
-  else
-    log "Center-admin-service certificate properties are set, skipping"
+    /usr/share/xroad/scripts/db_property.sh set "xroad.admin-service.tls.certificate-provisioning.common-name" "$subj" --yes \
+      || abort "Failed to store admin-service TLS certificate-provisioning common-name in the database. ABORTING."
+    /usr/share/xroad/scripts/db_property.sh set "xroad.admin-service.tls.certificate-provisioning.alt-names" "$dns_list" --yes \
+      || abort "Failed to store admin-service TLS certificate-provisioning alt-names in the database. ABORTING."
+    /usr/share/xroad/scripts/db_property.sh set "xroad.admin-service.tls.certificate-provisioning.ip-subject-alt-names" "$ip_list" --yes \
+      || abort "Failed to store admin-service TLS certificate-provisioning ip-subject-alt-names in the database. ABORTING."
   fi
 
-  if [[ -z $(get_yaml_prop "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.common-name") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.alt-names") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.ip-subject-alt-names") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.common-name") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.alt-names") && \
-        -z $(get_yaml_prop "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.ip-subject-alt-names") ]]; then
-
-    log "Preparing management and registration service certificate properties"
+  if db_row_present "xroad.management-service.tls.certificate-provisioning.common-name" && [[ "$reconfiguring" != "1" ]]; then
+    log "Management service certificate properties are set, skipping"
+  else
+    log "Preparing management service certificate properties"
     db_subst xroad-common/service-subject HOST "$HOST"
     db_subst xroad-common/service-altsubject ALT "$ALT"
 
@@ -302,23 +331,20 @@ prepare_certificates_settings() {
     ip_list=$(extract_ip_list "$altn")
     dns_list=$(extract_dns_list "$altn")
 
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.common-name" "$subj"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.alt-names" "$dns_list"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.registration-service.tls.certificate-provisioning.ip-subject-alt-names" "$ip_list"
-
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.common-name" "$subj"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.alt-names" "$dns_list"
-    /usr/share/xroad/scripts/yaml_helper.sh set "$CONFIG_FILE" "xroad.management-service.tls.certificate-provisioning.ip-subject-alt-names" "$ip_list"
-  else
-    log "Management and registration service certificate properties are set, skipping"
+    /usr/share/xroad/scripts/db_property.sh set "xroad.management-service.tls.certificate-provisioning.common-name" "$subj" --yes \
+      || abort "Failed to store management-service TLS certificate-provisioning common-name in the database. ABORTING."
+    /usr/share/xroad/scripts/db_property.sh set "xroad.management-service.tls.certificate-provisioning.alt-names" "$dns_list" --yes \
+      || abort "Failed to store management-service TLS certificate-provisioning alt-names in the database. ABORTING."
+    /usr/share/xroad/scripts/db_property.sh set "xroad.management-service.tls.certificate-provisioning.ip-subject-alt-names" "$ip_list" --yes \
+      || abort "Failed to store management-service TLS certificate-provisioning ip-subject-alt-names in the database. ABORTING."
   fi
 }
 
 
 case "$1" in
 configure | reconfigure)
-    prepare_certificates_settings
     setup_database
+    prepare_certificates_settings "$1"
     configure_dataspace_issuer_host "$1"
 
     RET=""

--- a/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
+++ b/deployment/native-packages/src/xroad/ubuntu/generic/xroad-center.postinst
@@ -249,6 +249,18 @@ extract_dns_list() {
 # installs): the schema may predate the configuration_properties table, and the debconf
 # questions can be (re-)asked later via dpkg-reconfigure once the schema is migrated.
 prepare_certificates_settings() {
+  # Identity can only be captured on the final host. Without a running systemd
+  # (the same check debhelper-generated code uses to skip service starts) this
+  # is a container image build or chroot, where `hostname -f` is an ephemeral
+  # build name — persisting it as a DB row would outrank the XROAD_HOST-based
+  # runtime default that containerized deployments configure their identity
+  # with. Containers keep the env channel; a chroot-provisioned native host
+  # can seed later via 'dpkg-reconfigure xroad-center'.
+  if [[ ! -d /run/systemd/system ]]; then
+    log "No running systemd — not storing TLS certificate identity (containerized deployments configure it via XROAD_HOST)"
+    return
+  fi
+
   RET=""
   db_get xroad-common/skip-cs-db-migrations || true
   if [[ "$RET" == "true" ]]; then

--- a/development/ansible/roles/xroad-cs/tasks/post-cs-install.yml
+++ b/development/ansible/roles/xroad-cs/tasks/post-cs-install.yml
@@ -1,17 +1,10 @@
 ---
-# TEMPORARY (dataspaces dev): remove stale systemd drop-in that set jwks.url
-# via Environment= (superseded by local-ds-issuer-service.yaml placed by
-# pre-cs-install.yml). The drop-in dir is created by the package, so this
-# must run after install. Remove once the packages never shipped this drop-in.
-- name: drop legacy ds-issuer-service systemd override (now in YAML)
-  file:
-    path: /etc/systemd/system/xroad-ds-issuer-service.service.d/jwks.conf
-    state: absent
-
-# The XRoadConfig DSL resolves DB overrides and packaged defaults only — env vars
-# and conf.d yaml are ignored — so these are seeded straight into the centerui
-# configuration_properties table. Deterministic upsert; restart xroad-center
-# because it resolved the DSL config before the rows existed.
+# Dev-only tuning, applied as post-install reconfiguration (not install
+# convergence — a fresh install is healthy without it). The XRoadConfig DSL
+# resolves DB overrides and packaged defaults only — env vars and conf.d yaml
+# are ignored — so these are seeded straight into the centerui
+# configuration_properties table. Deterministic upsert; the consumers are
+# restarted because the DSL resolves once at process start.
 - name: seed dev-cadence configuration into centerui configuration_properties
   become: true
   command:
@@ -41,38 +34,4 @@
 - name: restart xroad-ds-issuer-service to resolve the seeded configuration
   systemd:
     name: xroad-ds-issuer-service
-    state: restarted
-
-# TEMPORARY FIX — race in ManagementServiceSslBundleRegistrar
-# (core/src/common/common-management-service/.../ManagementServiceSslBundleRegistrar.java).
-# Both xroad-center-management-service and xroad-center-registration-service share
-# the vault path `tls/management-service` and each calls `ensureTlsKeyPresent()`
-# at startup. On a clean install the path is empty, so BOTH services provision a
-# fresh keypair via `vaultKeyClient.provisionNewCerts()` and `createManagementServiceTlsCredentials`
-# overwrites whichever wrote first. The losing service stays in memory with cert A
-# while vault (and the second service) hold cert B; admin-service's globalconf-generator
-# (PrivateParametersLoader.java:73) then publishes cert B as authCertRegServiceCert
-# while port 4001 (registration-service) actually presents cert A → SS auth-cert
-# registration fails with "Central server TLS certificate does not match in global conf".
-#
-# The proper fix is to make ensureTlsKeyPresent idempotent across services
-# (one writer, others read-only) — see ManagementServiceSslBundleRegistrar.
-# Until then: restart registration-service AFTER both have settled. The restarted
-# instance will read the now-populated vault entry and serve whichever cert
-# management-service wrote (also what globalconf advertises). One sync point is
-# enough — vault state is then stable.
-- name: wait for management & registration services to be active (race resolution prerequisite)
-  systemd:
-    name: "{{ item }}"
-  register: cs_mgmt_reg_state
-  until: cs_mgmt_reg_state.status.ActiveState == "active"
-  retries: 30
-  delay: 2
-  loop:
-    - xroad-center-management-service
-    - xroad-center-registration-service
-
-- name: restart xroad-center-registration-service so its TLS bundle reloads from vault
-  systemd:
-    name: xroad-center-registration-service
     state: restarted

--- a/development/ansible/roles/xroad-cs/tasks/pre-cs-install.yml
+++ b/development/ansible/roles/xroad-cs/tasks/pre-cs-install.yml
@@ -1,16 +1,19 @@
 ---
 # TEMPORARY (dataspaces dev): this file pre-seeds values that xroad-centralserver's
 # packages need on disk before their own postinst starts a unit for the first time,
-# where provisioning is only-if-absent so a value arriving late never lands
-# (systemd drop-ins for the admin-service TLS certificate hostname and the Issuer
-# Service's vault CA trust). The statuslist-callback/hostname gap this file used to
-# paper over for xroad-ds-issuer-service is closed: the package's own postinst now
-# writes edc.hostname and edc.statuslist.callback.address from the debconf-sourced
+# where provisioning is only-if-absent so a value arriving late never lands. The
+# statuslist-callback/hostname gap this file used to paper over for
+# xroad-ds-issuer-service is closed: the package's own postinst now writes
+# edc.hostname and edc.statuslist.callback.address from the debconf-sourced
 # dataspace issuer host answer before the unit's first start.
 #
+# The admin-service/management-service TLS certificate common-name gap is closed the
+# same way: xroad-center.postinst now seeds those into the DB from the debconf
+# answers that ubuntu.yml already pre-answers via Ansible's debconf module
+# (debconf-set-selections) with the .lxd FQDN before the package installs — no
+# drop-in needed.
+#
 # What remains here, and why:
-# - the systemd drop-ins (XROAD_HOST, QUARKUS_VAULT_TLS_CA_CERT) have no packaged
-#   equivalent yet — remove each once its underlying package ships one;
 # - xroad.edc.web.https.trust.reload-interval-seconds is genuine dev-only tuning
 #   (shortens a reload cycle for faster local iteration, not a correctness fix), so
 #   it stays regardless of packaging maturity.
@@ -32,45 +35,6 @@
     owner: root
     group: root
     mode: "0755"
-
-# ---------------------------------------------------------------------------
-# 2b. TLS certificate host for the vault-provisioned service certs. The cert
-#     common-name resolves from the XROAD_HOST env var (default localhost);
-#     management/registration-service run Jetty with SNI validation, so the SS
-#     connecting to https://<cs>.lxd:4001 gets "400 Invalid SNI" when the cert
-#     says localhost. Provisioning is only-if-absent, so the env var must be in
-#     place before the package postinst starts the services the first time —
-#     hence systemd drop-ins created pre-install (they apply once the units
-#     appear).
-# ---------------------------------------------------------------------------
-- name: create systemd drop-in dirs for XROAD_HOST
-  file:
-    path: "/etc/systemd/system/{{ item }}.service.d"
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
-  loop: &cs_xroad_host_units
-    - xroad-center
-    - xroad-center-management-service
-    - xroad-center-registration-service
-
-- name: set XROAD_HOST for CS services (TLS cert common-name)
-  copy:
-    dest: "/etc/systemd/system/{{ item }}.service.d/xroad-host.conf"
-    owner: root
-    group: root
-    mode: "0644"
-    content: |
-      [Service]
-      Environment=XROAD_HOST={{ inventory_hostname }}.lxd
-  loop: *cs_xroad_host_units
-  register: cs_xroad_host_dropins
-
-- name: reload systemd after drop-in changes
-  systemd:
-    daemon_reload: true
-  when: cs_xroad_host_dropins is changed
 
 # ---------------------------------------------------------------------------
 # 2. DS issuer-service dev-only runtime tuning.

--- a/src/central-server/admin-service/application/src/main/resources/application.yml
+++ b/src/central-server/admin-service/application/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
   config:
     import:
       - classpath:/xroad-common.yaml
-      - optional:file:/etc/xroad/conf.d/local-tls.yaml
       - optional:file:/etc/xroad/conf.d/local.yaml
       - optional:file:/etc/xroad/db.properties
   jackson:

--- a/src/central-server/management-service/application/src/main/resources/application.yml
+++ b/src/central-server/management-service/application/src/main/resources/application.yml
@@ -6,7 +6,6 @@ spring:
   config:
     import:
       - classpath:/xroad-common.yaml
-      - optional:file:/etc/xroad/conf.d/local-tls.yaml
       - optional:file:/etc/xroad/conf.d/local.yaml
   servlet:
     multipart:

--- a/src/central-server/registration-service/src/main/resources/application.yml
+++ b/src/central-server/registration-service/src/main/resources/application.yml
@@ -4,7 +4,6 @@ spring:
   config:
     import:
       - classpath:/xroad-common.yaml
-      - optional:file:/etc/xroad/conf.d/local-tls.yaml
       - optional:file:/etc/xroad/conf.d/local.yaml
   servlet:
     multipart:

--- a/src/service/ds-issuer-service/ds-issuer-service-application/src/main/resources/application.yaml
+++ b/src/service/ds-issuer-service/ds-issuer-service-application/src/main/resources/application.yaml
@@ -20,7 +20,6 @@ quarkus:
       locations:
         - xroad-common.yaml
         - xroad-logging.yaml
-        - /etc/xroad/conf.d/local-tls.yaml
         - /etc/xroad/conf.d/local.yaml
         - /etc/xroad/conf.d/local-ds-issuer-service.yaml
         - /etc/xroad/db.properties


### PR DESCRIPTION


xroad-center.postinst's prepare_certificates_settings() wrote the debconf-collected admin/management TLS certificate subject into /etc/xroad/conf.d/local-tls.yaml, but the XRoadConfig DSL that AdminServiceTlsProperties/ManagementServiceTlsProperties read these keys through resolves only DB overrides and packaged defaults, never conf.d YAML. The write was a no-op, so vault-provisioned admin-service and management/registration-service certificates always defaulted their CN to XROAD_HOST (localhost), breaking SNI validation on SS-to-CS TLS.

Write the identity to configuration_properties via db_property.sh instead, the same DB channel configure_dataspace_issuer_host() already uses, with the same only-if-absent / dpkg-reconfigure semantics (factored into a shared db_row_present helper). Must run after setup_database() so the table exists; the call order in the postinst's configure/reconfigure case is updated accordingly.

xroad.registration-service.tls.certificate-provisioning.* is no longer written: registration-service stopped provisioning its own certificate in c64700480a and now reuses the management-service certificate from Vault, so that ConfigKey provider was removed along with it.

With the write path gone, nothing on the CS reads /etc/xroad/conf.d/local-tls.yaml any more: drop its spring.config.import / Quarkus config-location entry from the three CS Spring apps (admin-service, management-service, registration-service) and ds-issuer-service. configure_management_api_key.sh's legacy api-token migration read of the same file is untouched — it goes through yaml_helper.sh directly, independent of these imports.

Ansible's xroad-cs role already pre-answers the admin/service-subject debconf questions with the .lxd FQDN via its debconf task (the first-class preseed channel) before package install, so the XROAD_HOST systemd drop-in workaround in pre-cs-install.yml is now redundant and removed.