### PR TITLE
ort: choose EPL-2.0 for Jersey dual-licensed packages

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -195,6 +195,23 @@ resolutions:
       comment: "Error is caused by the Scanner not being able to scan the JavaScript source map for Apache ECharts’ ES module bundle."
 
 license_choices:
+  package_license_choices:
+    - package_id: "Maven:org.glassfish.jersey.containers:jersey-container-servlet:4.0.2"
+      license_choices:
+        - given: "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+          choice: "EPL-2.0"
+    - package_id: "Maven:org.glassfish.jersey.inject:jersey-hk2:4.0.2"
+      license_choices:
+        - given: "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+          choice: "EPL-2.0"
+    - package_id: "Maven:org.glassfish.jersey.media:jersey-media-json-jackson:4.0.2"
+      license_choices:
+        - given: "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+          choice: "EPL-2.0"
+    - package_id: "Maven:org.glassfish.jersey.media:jersey-media-json-processing:4.0.2"
+      license_choices:
+        - given: "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
+          choice: "EPL-2.0"
   repository_license_choices:
     - given: "GPL-2.0-only OR Apache-2.0"
       choice: "Apache-2.0"


### PR DESCRIPTION
Records X-Road's licence choice for the four dual-licensed Jersey packages, surfaced by `/resolve-rule-violations` on ORT run 1829.

## Licence choices applied

| Package | Given | Choice |
|---|---|---|
| `Maven:org.glassfish.jersey.containers:jersey-container-servlet:4.0.2` | `EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0` | `EPL-2.0` |
| `Maven:org.glassfish.jersey.inject:jersey-hk2:4.0.2` | same | `EPL-2.0` |
| `Maven:org.glassfish.jersey.media:jersey-media-json-jackson:4.0.2` | same | `EPL-2.0` |
| `Maven:org.glassfish.jersey.media:jersey-media-json-processing:4.0.2` | same | `EPL-2.0` |

Every source file in these packages carries an `SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0` header. The GPL arm is a genuine option the files offer, not a scanner misdetection — so this is a **licence choice**, not a `rule_violation_resolution`. The project declines the GPL arm; it is not excepting a GPL obligation. Recording it the other way would misstate the position in the compliance record.

Together these cover 12 of the 22 open rule violations in run 1829 (`Strong copyleft license in direct dependency`, on `GPL-1.0-or-later`, `GPL-2.0-only` and `GPL-2.0-or-later`).

## Version scoping

**These choices are pinned to version 4.0.2 exactly.** `package_id` matching is exact, so any Jersey upgrade — patch, minor or major — will re-raise the violations until the version here is bumped. This is deliberate: it is narrower than the repository-wide entries below it, and forces a re-look on upgrade. New Jersey modules entering the dependency tree will also need adding.

## Caveat — this may not clear the violations on its own

`jaxb-runtime`'s dual expression already has a byte-exact `repository_license_choices` entry in this file, and its `GPL-1.0-or-later` violation still fired in run 1829. Two possible explanations, not distinguishable without the evaluator rules:

1. The copyleft rules evaluate **detected** licences without applying choices — every violation here is `licenseSource: DETECTED`. If so, these violations will need `rule_violation_resolutions` as well.
2. ORT compares the parsed expression and DOS's concluded string differs from the `given` in some detail.

The next ORT run distinguishes them: if the Jersey violations clear but `jaxb-runtime` does not, it is (2); if neither clears, it is (1).

## Related work on run 1829

- **RV1 (false-positive curation)** — 74 file-level clearances written to DOS across 8 packages, including 64 on three of these four Jersey packages concluding the dual expression. `jersey-media-json-jackson` deliberately got none: its 15 files were judged true positives and routed here.
- **RV2 (unhandled licences)** — draft PR doubleopen-io/policy-configuration#106 classifies `FSL-1.1-ALv2` and the two OpenJDK exception identifiers.
- **Not addressed here:** 10 further violations, all either already fixed by the RV1 clearances (pending a fresh run) or waiting on #106. One needs a separate decision: `jaxb-runtime@4.0.9`, whose GPL arm sits *inside* its concluded expression and cannot be cleared by curation.

## Audit trail

`~/.config/ort-mcp-server/clearances/run-1829-resolve-2026-09-09-171457.yaml` — all 22 violations, what was decided for each, and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dsviczKbNGcNhGjSaF52L
