### PR TITLE
fix(packaging): RHEL9 upgrade runs DS Liquibase migrations before Java 25 is active

### DIFF
--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
@@ -81,11 +81,11 @@ if systemctl is-active %{name} &> /dev/null; then
   touch "%{_localstatedir}/lib/rpm-state/%{name}/active"
 fi
 
+%define init_xroad_ds_control_plane_db()                       \
+    /usr/share/xroad/scripts/setup_ds_controlplane_db.sh ""
+
 %post -p /bin/bash
 umask 027
-
-# Run database setup script
-/usr/share/xroad/scripts/setup_ds_controlplane_db.sh "" || true
 
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
@@ -126,5 +126,8 @@ fi
 
 %postun
 %systemd_postun_with_restart xroad-ds-control-plane.service
+
+%posttrans
+%init_xroad_ds_control_plane_db
 
 %changelog

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
@@ -81,11 +81,11 @@ if systemctl is-active %{name} &> /dev/null; then
   touch "%{_localstatedir}/lib/rpm-state/%{name}/active"
 fi
 
+%define init_xroad_ds_identity_hub_db()                       \
+    /usr/share/xroad/scripts/setup_ds_identityhub_db.sh ""
+
 %post -p /bin/bash
 umask 027
-
-# Run database setup script
-/usr/share/xroad/scripts/setup_ds_identityhub_db.sh "" || true
 
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
@@ -126,5 +126,8 @@ fi
 
 %postun
 %systemd_postun_with_restart xroad-ds-identity-hub.service
+
+%posttrans
+%init_xroad_ds_identity_hub_db
 
 %changelog

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-proxy.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-proxy.spec
@@ -127,13 +127,15 @@ fi
 
 %define execute_init_or_update_resources()                                            \
     echo "Update resources: DB";                                                      \
-    /usr/share/xroad/scripts/setup_serverconf_db.sh;                                  \
-    /usr/share/xroad/scripts/setup_messagelog_db.sh;                                  \
+    rc=0;                                                                             \
+    for db_script in setup_serverconf_db.sh setup_messagelog_db.sh; do                \
+        "/usr/share/xroad/scripts/$db_script" || rc=$?;                               \
+    done;                                                                             \
                                                                                       \
-    if [ $1 -eq 1 ] && [ -x %{_bindir}/systemctl ]; then                              \
-        `# initial installation`;                                                     \
+    if [ -x %{_bindir}/systemctl ]; then                                              \
         %{_bindir}/systemctl try-restart rsyslog.service                              \
-    fi
+    fi;                                                                               \
+    exit $rc
 
 %post -p /bin/bash
 %systemd_post xroad-proxy.service


### PR DESCRIPTION
## What

During a Security Server upgrade from X-Road 7.8.2 to 8.0 on RHEL 9, the `xroad-ds-control-plane` and `xroad-ds-identity-hub` packages ran their Liquibase database migrations from `%post`, before `xroad-base`'s `%posttrans` had switched the system default Java runtime to 25. Migrations compiled for Java 25 failed with `UnsupportedClassVersionError` under the still-active Java 21, and the failure was discarded with `|| true`, so the upgrade reported success anyway.

While fixing that, a related but separate bug was found in `xroad-proxy`: its own database setup already ran in `%posttrans`, but the calls sat inside a macro whose trailing rsyslog-restart conditional determined the whole block's exit status — so a migration failure there was silently discarded too, just structurally instead of via an explicit `|| true`.

## Changes

- `xroad-ds-control-plane.spec` / `xroad-ds-identity-hub.spec`: move the database migration call from `%post` to `%posttrans` (runs after `xroad-base`'s Java switch, guaranteed by the existing `Requires: xroad-base`), and drop the `|| true` so a failing migration surfaces as a visible scriptlet-failure warning instead of being silently swallowed.
- `xroad-proxy.spec`: restructure `%posttrans` to capture each database script's own exit status and exit the scriptlet on the worst of the two, instead of letting the trailing restart block's exit status mask a migration failure. Also drops the rsyslog restart's `$1 -eq 1` "initial installation" guard — confirmed empirically that `%posttrans`'s `$1` doesn't reliably distinguish a fresh install from an upgrade on this platform, so the guard never worked as intended; `systemctl try-restart` is a no-op when rsyslog isn't running, so restarting it unconditionally is safe.

## Known platform limitation

Removing `|| true` makes a failing migration print a visible `warning: ... scriptlet failed` line in the transaction output. It does **not** and cannot make `rpm`/`dnf`'s own process exit code, or `dnf history`'s recorded return code, reflect the failure — confirmed to be general RPM/dnf behavior on RHEL 9 with no spec-level workaround, independently reproduced with synthetic test packages. This is the ceiling of what a packaging-only fix can deliver.

## Out of scope

- `xroad-base`'s own `|| true` suppression around its versioned migration runner, and a restart-before-migration ordering hazard in its `%posttrans` (it restarts other packages' services before their own `%posttrans` migration has run) — both are the same defect class, found during this work, and deliberately left untouched. Neither is currently exploitable: `xroad-base`'s only shipped migration script is a hardcoded no-op placeholder.
- Debian/Ubuntu packaging — investigated, no equivalent race found (the JRE package's own `update-alternatives` priority is set synchronously in its `postinst`, before any dependent package configures, on every Ubuntu release tested).

Refs: XRDDEV-3346
