### PR TITLE
fix: isolate ACME renewal schedulers from the shared task scheduler

### DIFF
--- a/src/central-server/admin-service/application/src/main/java/org/niis/xroad/cs/admin/application/dstls/DsTlsAcmeCertificateRenewalSchedulingConfig.java
+++ b/src/central-server/admin-service/application/src/main/java/org/niis/xroad/cs/admin/application/dstls/DsTlsAcmeCertificateRenewalSchedulingConfig.java
@@ -41,7 +41,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.scheduling.TaskScheduler;
 
 /**
  * Wires the co-located Issuer Service's own DS TLS certificate {@link CertificateRenewalScheduler} instance.
@@ -69,8 +68,9 @@ public class DsTlsAcmeCertificateRenewalSchedulingConfig {
     @Order(Ordered.LOWEST_PRECEDENCE - 98)
     @Conditional(IsDsTlsAcmeSchedulingActive.class)
     CertificateRenewalScheduler dsTlsAcmeCertificateRenewalScheduler(DsTlsAcmeCertificateRenewalWorker dsTlsAcmeCertificateRenewalWorker,
-                                                                     TaskScheduler taskScheduler, AcmeSchedulingProperties acmeConfig) {
-        var scheduler = new CertificateRenewalScheduler(dsTlsAcmeCertificateRenewalWorker, acmeConfig, taskScheduler);
+                                                                     AcmeSchedulingProperties acmeConfig) {
+        var scheduler = CertificateRenewalScheduler.withDedicatedScheduler(dsTlsAcmeCertificateRenewalWorker, acmeConfig,
+                "acme-renewal-ds-tls-");
         scheduler.init();
         return scheduler;
     }

--- a/src/lib/acme-spring/src/main/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalScheduler.java
+++ b/src/lib/acme-spring/src/main/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalScheduler.java
@@ -25,10 +25,11 @@
  */
 package org.niis.xroad.common.acme.spring.scheduling;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.niis.xroad.common.acme.config.AcmeSchedulingProperties;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
@@ -36,12 +37,12 @@ import java.util.concurrent.ScheduledFuture;
 import static java.time.temporal.ChronoUnit.SECONDS;
 
 @Slf4j
-@RequiredArgsConstructor
-public class CertificateRenewalScheduler {
+public class CertificateRenewalScheduler implements DisposableBean {
 
     private final AcmeRenewalWorker acmeRenewalWorker;
     private final AcmeSchedulingProperties acmeConfig;
     private final TaskScheduler taskScheduler;
+    private final boolean ownsTaskScheduler;
     private ScheduledFuture<?> scheduledFuture;
 
     private static final Duration RECOVER_FROM_INVALID_GLOBAL_CONF_DELAY = Duration.of(60, SECONDS);
@@ -49,8 +50,46 @@ public class CertificateRenewalScheduler {
     private boolean retryMode;
     private boolean rescheduledDuringCycle;
 
+    public CertificateRenewalScheduler(AcmeRenewalWorker acmeRenewalWorker, AcmeSchedulingProperties acmeConfig,
+                                       TaskScheduler taskScheduler) {
+        this(acmeRenewalWorker, acmeConfig, taskScheduler, false);
+    }
+
+    private CertificateRenewalScheduler(AcmeRenewalWorker acmeRenewalWorker, AcmeSchedulingProperties acmeConfig,
+                                        TaskScheduler taskScheduler, boolean ownsTaskScheduler) {
+        this.acmeRenewalWorker = acmeRenewalWorker;
+        this.acmeConfig = acmeConfig;
+        this.taskScheduler = taskScheduler;
+        this.ownsTaskScheduler = ownsTaskScheduler;
+    }
+
+    /**
+     * Creates a {@link CertificateRenewalScheduler} backed by its own single-thread {@link ThreadPoolTaskScheduler},
+     * isolated from any shared {@code TaskScheduler} used elsewhere in the application. The dedicated scheduler is
+     * started immediately and is shut down when this instance is {@linkplain #destroy() destroyed}.
+     */
+    public static CertificateRenewalScheduler withDedicatedScheduler(AcmeRenewalWorker acmeRenewalWorker,
+                                                                     AcmeSchedulingProperties acmeConfig,
+                                                                     String threadNamePrefix) {
+        var scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix(threadNamePrefix);
+        scheduler.initialize();
+        log.info("Started dedicated ACME renewal scheduler thread '{}'", threadNamePrefix);
+        return new CertificateRenewalScheduler(acmeRenewalWorker, acmeConfig, scheduler, true);
+    }
+
     public void init() {
         reschedule(INITIAL_DELAY);
+    }
+
+    @Override
+    public void destroy() {
+        cancelNext();
+        if (ownsTaskScheduler) {
+            log.info("Shutting down dedicated ACME renewal scheduler thread");
+            ((ThreadPoolTaskScheduler) taskScheduler).shutdown();
+        }
     }
 
     private Duration getNextDelay() {

--- a/src/lib/acme-spring/src/main/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalScheduler.java
+++ b/src/lib/acme-spring/src/main/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalScheduler.java
@@ -49,6 +49,7 @@ public class CertificateRenewalScheduler implements DisposableBean {
     private static final Duration INITIAL_DELAY = Duration.of(5, SECONDS);
     private boolean retryMode;
     private boolean rescheduledDuringCycle;
+    private volatile boolean shuttingDown;
 
     public CertificateRenewalScheduler(AcmeRenewalWorker acmeRenewalWorker, AcmeSchedulingProperties acmeConfig,
                                        TaskScheduler taskScheduler) {
@@ -85,6 +86,7 @@ public class CertificateRenewalScheduler implements DisposableBean {
 
     @Override
     public void destroy() {
+        shuttingDown = true;
         cancelNext();
         if (ownsTaskScheduler) {
             log.info("Shutting down dedicated ACME renewal scheduler thread");
@@ -144,6 +146,9 @@ public class CertificateRenewalScheduler implements DisposableBean {
     }
 
     private void reschedule(Duration delay) {
+        if (shuttingDown) {
+            return;
+        }
         cancelNext();
         log.trace("Rescheduling job after {}", delay);
         this.scheduledFuture = taskScheduler.schedule(this::runJob, taskScheduler.getClock().instant().plus(delay));

--- a/src/lib/acme-spring/src/test/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalSchedulerTest.java
+++ b/src/lib/acme-spring/src/test/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalSchedulerTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ * Copyright (c) 2019- Nordic Institute for Interoperability Solutions (NIIS)
+ * Copyright (c) 2018 Estonian Information System Authority (RIA),
+ * Nordic Institute for Interoperability Solutions (NIIS), Population Register Centre (VRK)
+ * Copyright (c) 2015-2017 Estonian Information System Authority (RIA), Population Register Centre (VRK)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xroad.common.acme.spring.scheduling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.niis.xroad.common.acme.config.AcmeSchedulingProperties;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateRenewalSchedulerTest {
+
+    @Mock
+    private AcmeRenewalWorker acmeRenewalWorker;
+    @Mock
+    private AcmeSchedulingProperties acmeConfig;
+    @Mock
+    private TaskScheduler injectedTaskScheduler;
+
+    @Test
+    void withDedicatedSchedulerShutsDownItsOwnSchedulerOnDestroy() throws Exception {
+        var scheduler = CertificateRenewalScheduler.withDedicatedScheduler(acmeRenewalWorker, acmeConfig, "test-owned-");
+        var dedicatedScheduler = dedicatedScheduler(scheduler);
+        assertThat(dedicatedScheduler.getScheduledExecutor().isShutdown()).isFalse();
+
+        scheduler.destroy();
+
+        assertThat(dedicatedScheduler.getScheduledExecutor().isShutdown()).isTrue();
+    }
+
+    @Test
+    void publicConstructorNeverTouchesAnInjectedScheduler() {
+        var scheduler = new CertificateRenewalScheduler(acmeRenewalWorker, acmeConfig, injectedTaskScheduler);
+
+        scheduler.destroy();
+
+        verifyNoInteractions(injectedTaskScheduler);
+    }
+
+    private static ThreadPoolTaskScheduler dedicatedScheduler(CertificateRenewalScheduler scheduler) throws Exception {
+        Field field = CertificateRenewalScheduler.class.getDeclaredField("taskScheduler");
+        field.setAccessible(true);
+        return (ThreadPoolTaskScheduler) field.get(scheduler);
+    }
+}

--- a/src/lib/acme-spring/src/test/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalSchedulerTest.java
+++ b/src/lib/acme-spring/src/test/java/org/niis/xroad/common/acme/spring/scheduling/CertificateRenewalSchedulerTest.java
@@ -36,6 +36,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,6 +58,14 @@ class CertificateRenewalSchedulerTest {
         scheduler.destroy();
 
         assertThat(dedicatedScheduler.getScheduledExecutor().isShutdown()).isTrue();
+    }
+
+    @Test
+    void rescheduleAfterDestroyIsANoOp() {
+        var scheduler = CertificateRenewalScheduler.withDedicatedScheduler(acmeRenewalWorker, acmeConfig, "test-shutdown-race-");
+        scheduler.destroy();
+
+        assertThatCode(scheduler::init).doesNotThrowAnyException();
     }
 
     @Test

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeCertificateRenewalSchedulingConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/config/AcmeCertificateRenewalSchedulingConfig.java
@@ -41,7 +41,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.scheduling.TaskScheduler;
 
 @Slf4j
 @Configuration
@@ -52,8 +51,9 @@ public class AcmeCertificateRenewalSchedulingConfig {
     @Order(Ordered.LOWEST_PRECEDENCE - 99)
     @Conditional(IsAcmeCertRenewalJobsActive.class)
     CertificateRenewalScheduler acmeCertificateRenewalScheduler(AcmeCertificateRenewalWorker acmeCertificateRenewalWorker,
-                                                                TaskScheduler taskScheduler, AcmeConfig acmeConfig) {
-        var scheduler = new CertificateRenewalScheduler(acmeCertificateRenewalWorker, acmeConfig, taskScheduler);
+                                                                AcmeConfig acmeConfig) {
+        var scheduler = CertificateRenewalScheduler.withDedicatedScheduler(acmeCertificateRenewalWorker, acmeConfig,
+                "acme-renewal-auth-sign-");
         scheduler.init();
         return scheduler;
     }

--- a/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dstls/DsTlsAcmeCertificateRenewalSchedulingConfig.java
+++ b/src/security-server/admin-service/application/src/main/java/org/niis/xroad/securityserver/restapi/dstls/DsTlsAcmeCertificateRenewalSchedulingConfig.java
@@ -41,7 +41,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.scheduling.TaskScheduler;
 
 /**
  * Wires the DS TLS certificate's own {@link CertificateRenewalScheduler} instance, entirely separate from the
@@ -71,8 +70,9 @@ public class DsTlsAcmeCertificateRenewalSchedulingConfig {
     @Order(Ordered.LOWEST_PRECEDENCE - 98)
     @Conditional(IsDsTlsAcmeSchedulingActive.class)
     CertificateRenewalScheduler dsTlsAcmeCertificateRenewalScheduler(DsTlsAcmeCertificateRenewalWorker dsTlsAcmeCertificateRenewalWorker,
-                                                                     TaskScheduler taskScheduler, AcmeSchedulingProperties acmeConfig) {
-        var scheduler = new CertificateRenewalScheduler(dsTlsAcmeCertificateRenewalWorker, acmeConfig, taskScheduler);
+                                                                     AcmeSchedulingProperties acmeConfig) {
+        var scheduler = CertificateRenewalScheduler.withDedicatedScheduler(dsTlsAcmeCertificateRenewalWorker, acmeConfig,
+                "acme-renewal-ds-tls-");
         scheduler.init();
         return scheduler;
     }


### PR DESCRIPTION
DS TLS and auth/sign ACME certificate renewal schedulers (`CertificateRenewalScheduler`, 3 instances: CS DS
TLS, SS DS TLS, SS auth/sign) shared Spring's default `TaskScheduler` with unrelated best-effort background
jobs (data space issuer/participant provisioning). Those jobs make gRPC calls with a bounded-but-generous
60s deadline and can make several per tick; a stuck one can occupy the shared thread well over a minute.
Because the ACME renewal schedulers queued behind them on that same thread, renewal cycles were
intermittently delayed by ~100s+ — enough to time out `DsTlsAcmeEnrollmentTest` on both products, and a
real risk in production for a job whose job is keeping a certificate from expiring.
Traced from a real CI failure: [run 34389031154, job 102604024104](https://github.com/nordic-institute/X-Road/actions/runs/34389031154/job/102604024104) — attempt 1 failed on the 100s `await()`
timeout, attempt 2 of the same run passed with no code change, confirming the delay rather than a real
enrollment regression.
Give each of the 3 `CertificateRenewalScheduler` instances its own dedicated single-thread
`ThreadPoolTaskScheduler`, fully isolated from the shared `@Scheduled` pool and from each other:
- `CertificateRenewalScheduler` gains a `withDedicatedScheduler(...)` static factory and implements
  `DisposableBean` to shut its own scheduler down on context close (ownership tracked via a `boolean`, never
  by inspecting the injected `TaskScheduler`'s type — an externally-shared scheduler is never at risk of
  being shut down by this).
- The existing public constructor is unchanged — no impact on existing callers/tests.
- No changes to the dataspace provisioning workers, their gRPC deadlines, or any config keys — scheduling
  isolation only.
- New `CertificateRenewalSchedulerTest` covers both `destroy()` branches (owns vs. does not own the
  scheduler).
- Existing `AcmeCertificateRenewalWorkerTest`, `DsTlsAcmeCertificateRenewalWorkerTest`, and both products'
  `DsTlsAcmeCertificateRenewalSchedulingConfigTest` pass unchanged.
- Checkstyle clean on all touched modules.
- `DsTlsAcmeEnrollmentTest` (both products) needs the containerized stack to verify directly — left for CI.
Refs: XRDDEV-3291
