### PR TITLE
revert: RHEL9 upgrade runs DS Liquibase migrations before Java 25 is active

### DIFF
--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
@@ -81,11 +81,11 @@ if systemctl is-active %{name} &> /dev/null; then
   touch "%{_localstatedir}/lib/rpm-state/%{name}/active"
 fi
 
-%define init_xroad_ds_control_plane_db()                       \
-    /usr/share/xroad/scripts/setup_ds_controlplane_db.sh ""
-
 %post -p /bin/bash
 umask 027
+
+# Run database setup script
+/usr/share/xroad/scripts/setup_ds_controlplane_db.sh "" || true
 
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
@@ -126,8 +126,5 @@ fi
 
 %postun
 %systemd_postun_with_restart xroad-ds-control-plane.service
-
-%posttrans
-%init_xroad_ds_control_plane_db
 
 %changelog

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
@@ -81,11 +81,11 @@ if systemctl is-active %{name} &> /dev/null; then
   touch "%{_localstatedir}/lib/rpm-state/%{name}/active"
 fi
 
-%define init_xroad_ds_identity_hub_db()                       \
-    /usr/share/xroad/scripts/setup_ds_identityhub_db.sh ""
-
 %post -p /bin/bash
 umask 027
+
+# Run database setup script
+/usr/share/xroad/scripts/setup_ds_identityhub_db.sh "" || true
 
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
@@ -126,8 +126,5 @@ fi
 
 %postun
 %systemd_postun_with_restart xroad-ds-identity-hub.service
-
-%posttrans
-%init_xroad_ds_identity_hub_db
 
 %changelog

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-proxy.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-proxy.spec
@@ -127,15 +127,13 @@ fi
 
 %define execute_init_or_update_resources()                                            \
     echo "Update resources: DB";                                                      \
-    rc=0;                                                                             \
-    for db_script in setup_serverconf_db.sh setup_messagelog_db.sh; do                \
-        "/usr/share/xroad/scripts/$db_script" || rc=$?;                               \
-    done;                                                                             \
+    /usr/share/xroad/scripts/setup_serverconf_db.sh;                                  \
+    /usr/share/xroad/scripts/setup_messagelog_db.sh;                                  \
                                                                                       \
-    if [ -x %{_bindir}/systemctl ]; then                                              \
+    if [ $1 -eq 1 ] && [ -x %{_bindir}/systemctl ]; then                              \
+        `# initial installation`;                                                     \
         %{_bindir}/systemctl try-restart rsyslog.service                              \
-    fi;                                                                               \
-    exit $rc
+    fi
 
 %post -p /bin/bash
 %systemd_post xroad-proxy.service


### PR DESCRIPTION
Reverts #3795.
Symptom: e2e (lxd) fails deterministically at the hurl bootstrap step "Register TestClient to SS1" (setup.hurl:1031) with a sanitized `core.server.clientproxy.io_error` after exhausting retries.
Actual cause (from lxd-provision-logs artifacts): on xrd-ss0, both `xroad-ds-control-plane` and `xroad-ds-identity-hub` crash-loop from install onward:
```
SEVERE Error booting runtime: Failed to bootstrap SQL schema,
error 'ERROR: permission denied for schema public'
```
With ss0's control plane down, ss1's client-registration management request (a DSP exchange targeting ss0) can never complete. It's ss0 only in every run — ss1's identical install is fine — suggesting an ordering/race in the RPM transaction rather than a plain scripting error.
Evidence:
- Branch XRDDEV-3314 at a commit without this change: lxd green, 0 occurrences of the error (run 34468260321).
- Same branch immediately after merging develop (which added only #3795 + two unrelated commits touching ACME scheduling / no packaging): lxd failed 4/4 consecutive runs — 34477555740 (×3 attempts) and 34499468293 — with 68/72/118 crash-loop occurrences on ss0 respectively.
- Other branches on current develop also fail only the lxd variant (e.g. XRDDEV-3315, XRDDEV-3190 runs today).
- k8s/compose/sidecar are unaffected (container images, not RPM).
This unblocks the lxd e2e pipeline while a Java-version-aware fix (run DB setup in `%post` when Java ≥25 is already active, defer to `%posttrans` only when it isn't yet — the actual 7.8→8.0 upgrade case #3795 was trying to fix) is finished separately.
Refs: XRDDEV-3346