### PR TITLE
fix(packaging): copy DS admin credentials after RHEL9 DB setup

### DIFF
--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-control-plane.spec
@@ -87,6 +87,19 @@ fi
 %post -p /bin/bash
 umask 027
 
+%systemd_post xroad-ds-control-plane.service
+
+%preun
+%systemd_preun xroad-ds-control-plane.service
+
+%postun
+%systemd_postun_with_restart xroad-ds-control-plane.service
+
+%posttrans -p /bin/bash
+umask 027
+
+%init_xroad_ds_control_plane_db
+
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
 # Also updates JDBC URL with currentSchema for EDC compatibility
@@ -118,16 +131,5 @@ if [ -f "$root_properties" ] && [ -f "$db_properties" ]; then
     fi
   fi
 fi
-
-%systemd_post xroad-ds-control-plane.service
-
-%preun
-%systemd_preun xroad-ds-control-plane.service
-
-%postun
-%systemd_postun_with_restart xroad-ds-control-plane.service
-
-%posttrans
-%init_xroad_ds_control_plane_db
 
 %changelog

--- a/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
+++ b/deployment/native-packages/src/xroad/redhat/SPECS/xroad-ds-identity-hub.spec
@@ -87,6 +87,19 @@ fi
 %post -p /bin/bash
 umask 027
 
+%systemd_post xroad-ds-identity-hub.service
+
+%preun
+%systemd_preun xroad-ds-identity-hub.service
+
+%postun
+%systemd_postun_with_restart xroad-ds-identity-hub.service
+
+%posttrans -p /bin/bash
+umask 027
+
+%init_xroad_ds_identity_hub_db
+
 # Temporary dev flow - copy admin credentials from xroad.properties to db.properties
 # This allows the application to use admin credentials for database access
 # Also updates JDBC URL with currentSchema for EDC compatibility
@@ -118,16 +131,5 @@ if [ -f "$root_properties" ] && [ -f "$db_properties" ]; then
     fi
   fi
 fi
-
-%systemd_post xroad-ds-identity-hub.service
-
-%preun
-%systemd_preun xroad-ds-identity-hub.service
-
-%postun
-%systemd_postun_with_restart xroad-ds-identity-hub.service
-
-%posttrans
-%init_xroad_ds_identity_hub_db
 
 %changelog


### PR DESCRIPTION
Fixes the RHEL9 e2e (lxd) failures on develop introduced by #3795 (XRDDEV-3346).

#3795 moved DS DB setup from `%post` to `%posttrans`, but the temporary admin-credential/currentSchema override block stayed in `%post`. On RPM installs it now ran before `setup_ds_*_db.sh` wrote the admin keys, so it was a no-op: `xroad-ds-identity-hub` and `xroad-ds-control-plane` booted with the plain app user (USAGE-only on schema public), EDC schema bootstrap failed with `permission denied for schema public`, and both services crash-looped — pinning ss0 and timing out ss1's client-registration request (hurl entry 83).

Fix: move the override block into `%posttrans`, after `%init_xroad_ds_*_db`, in both spec files. This keeps #3795's Java-25 ordering fix and restores the setup → credential-copy ordering that the Ubuntu postinst already follows.

Evidence: across 13 develop/PR e2e runs, schema-permission errors on ss0 appear in every run containing #3795 (60–118 occurrences) and in none without it; zero lxd passes with #3795 present.

Refs: XRDDEV-3346